### PR TITLE
Fix AppleContainerRuntime to match container CLI

### DIFF
--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -56,14 +56,19 @@ impl ContainerConfig {
 /// Implementations can use different container runtimes (apple/container, Docker, etc.)
 #[trait_variant::make(Send)]
 pub trait ContainerRuntime {
+    /// Create a container from the given config. Returns the container ID.
     async fn create(&self, config: &ContainerConfig) -> Result<String, ContainerError>;
-    async fn start(&self, container_id: &str) -> Result<(), ContainerError>;
+    /// Start a container and attach to its stdio. Returns the transport.
+    async fn start(&self, container_id: &str) -> Result<StdioTransport, ContainerError>;
+    /// Stop a running container.
     async fn stop(&self, container_id: &str) -> Result<(), ContainerError>;
+    /// Destroy a container and clean up.
     async fn destroy(&self, container_id: &str) -> Result<(), ContainerError>;
-    fn attach(&self, container_id: &str) -> Result<StdioTransport, ContainerError>;
 }
 
 /// Container runtime using the apple/container CLI.
+///
+/// See https://github.com/apple/container
 #[derive(Clone)]
 pub struct AppleContainerRuntime;
 
@@ -82,19 +87,22 @@ impl Default for AppleContainerRuntime {
 impl ContainerRuntime for AppleContainerRuntime {
     async fn create(&self, config: &ContainerConfig) -> Result<String, ContainerError> {
         let mut cmd = Command::new("container");
-        cmd.arg("create").arg("--image").arg(&config.image);
+        cmd.arg("create");
 
         for (key, value) in &config.env {
-            cmd.arg("--env").arg(format!("{}={}", key, value));
+            cmd.arg("-e").arg(format!("{}={}", key, value));
         }
 
         if let Some(cpus) = config.cpus {
-            cmd.arg("--cpus").arg(cpus.to_string());
+            cmd.arg("-c").arg(cpus.to_string());
         }
 
         if let Some(ref memory) = config.memory {
-            cmd.arg("--memory").arg(memory);
+            cmd.arg("-m").arg(memory);
         }
+
+        // Image is a positional argument (must come last, before any container arguments).
+        cmd.arg(&config.image);
 
         let output = cmd.output().await?;
 
@@ -107,19 +115,22 @@ impl ContainerRuntime for AppleContainerRuntime {
         Ok(container_id)
     }
 
-    async fn start(&self, container_id: &str) -> Result<(), ContainerError> {
-        let output = Command::new("container")
+    /// Start the container with attached stdio.
+    ///
+    /// Uses `container start --attach --interactive <id>` which starts the
+    /// container and connects stdin/stdout to the supervisor process.
+    async fn start(&self, container_id: &str) -> Result<StdioTransport, ContainerError> {
+        let child = std::process::Command::new("container")
             .arg("start")
+            .arg("--attach")
+            .arg("--interactive")
             .arg(container_id)
-            .output()
-            .await?;
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(ContainerError::CommandFailed(stderr.to_string()));
-        }
-
-        Ok(())
+        Ok(StdioTransport::new(child))
     }
 
     async fn stop(&self, container_id: &str) -> Result<(), ContainerError> {
@@ -138,11 +149,11 @@ impl ContainerRuntime for AppleContainerRuntime {
     }
 
     async fn destroy(&self, container_id: &str) -> Result<(), ContainerError> {
-        // Stop first (ignore errors)
+        // Stop first (ignore errors — may already be stopped)
         let _ = self.stop(container_id).await;
 
         let output = Command::new("container")
-            .arg("delete")
+            .arg("rm")
             .arg(container_id)
             .output()
             .await?;
@@ -153,17 +164,5 @@ impl ContainerRuntime for AppleContainerRuntime {
         }
 
         Ok(())
-    }
-
-    fn attach(&self, container_id: &str) -> Result<StdioTransport, ContainerError> {
-        let child = std::process::Command::new("container")
-            .arg("attach")
-            .arg(container_id)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
-
-        Ok(StdioTransport::new(child))
     }
 }

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -75,13 +75,10 @@ impl<R: ContainerRuntime> Session<R> {
         let container_id = self.runtime.create(&self.config).await?;
         self.container_id = Some(container_id.clone());
 
-        // Start container
-        self.runtime.start(&container_id).await?;
-        self.state = SessionState::Starting;
-
-        // Attach transport
-        let transport = self.runtime.attach(&container_id)?;
+        // Start container and attach stdio
+        let transport = self.runtime.start(&container_id).await?;
         self.transport = Some(transport);
+        self.state = SessionState::Starting;
 
         // Wait for system:ready
         self.wait_ready(ready_timeout)?;


### PR DESCRIPTION
## Summary
- Fixes `AppleContainerRuntime` to match the actual `apple/container` CLI (v0.10.0)
- `create`: image is a positional arg, env uses `-e` flag
- `start`: now returns `StdioTransport` directly (uses `start -ai` which combines start + stdio attach)
- `destroy`: uses `rm` subcommand (not `delete`)
- `ContainerRuntime` trait simplified: `start()` returns `StdioTransport`, removed separate `attach()` method

## Test plan
- [x] All 140 workspace tests pass
- [x] Tested end-to-end with `container create` → `container start -ai` → supervisor responds with `system:ready` and handles `exec` commands