### PR TITLE
Add Claude Code to container image

### DIFF
--- a/src/runtime/Dockerfile
+++ b/src/runtime/Dockerfile
@@ -20,7 +20,15 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     apt-get update && apt-get install -y gh && \
     rm -rf /var/lib/apt/lists/*
 
-# Bun
+# Node.js (required for Claude Code)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Claude Code
+RUN npm install -g @anthropic-ai/claude-code
+
+# Bun (runs the supervisor)
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 


### PR DESCRIPTION
## Summary
- Adds Node.js 22 and `@anthropic-ai/claude-code` to the session container image
- The supervisor defaults to `AGENT_CMD=claude` which now resolves inside the container
- Claude Code 2.1.76 verified working inside both Docker and apple/container

## Test plan
- [x] `docker build` succeeds
- [x] `claude --version` returns `2.1.76` inside the container via supervisor exec
- [x] Image loaded into apple/container successfully