### PR TITLE
Fix GraphQL Actor type and add session logging

### DIFF
--- a/crates/github/src/queries.rs
+++ b/crates/github/src/queries.rs
@@ -8,7 +8,7 @@ const ISSUE_FIELDS: &str = r#"
     body
     state
     stateReason
-    author { login ... on User { id } ... on Bot { id } }
+    author { login ... on User { id } ... on Bot { id } ... on Mannequin { id } }
     labels(first: 100) {
         nodes { name color }
     }
@@ -24,7 +24,7 @@ const ISSUE_FIELDS: &str = r#"
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login ... on User { id } ... on Bot { id } }
+            author { login ... on User { id } ... on Bot { id } ... on Mannequin { id } }
             body
             createdAt
             updatedAt
@@ -69,7 +69,7 @@ const PR_FIELDS: &str = r#"
     baseRefName
     isDraft
     mergeable
-    author { login ... on User { id } ... on Bot { id } }
+    author { login ... on User { id } ... on Bot { id } ... on Mannequin { id } }
     labels(first: 100) {
         nodes { name color }
     }
@@ -81,7 +81,7 @@ const PR_FIELDS: &str = r#"
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login ... on User { id } ... on Bot { id } }
+            author { login ... on User { id } ... on Bot { id } ... on Mannequin { id } }
             state
             body
             submittedAt
@@ -91,7 +91,7 @@ const PR_FIELDS: &str = r#"
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login ... on User { id } ... on Bot { id } }
+            author { login ... on User { id } ... on Bot { id } ... on Mannequin { id } }
             body
             createdAt
             updatedAt
@@ -156,7 +156,7 @@ pub fn issue_comments_query() -> &'static str {
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login ... on User { id } ... on Bot { id } }
+            author { login ... on User { id } ... on Bot { id } ... on Mannequin { id } }
             body
             createdAt
             updatedAt
@@ -210,7 +210,7 @@ pub fn pr_comments_query() -> &'static str {
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login ... on User { id } ... on Bot { id } }
+            author { login ... on User { id } ... on Bot { id } ... on Mannequin { id } }
             body
             createdAt
             updatedAt
@@ -230,7 +230,7 @@ pub fn pr_reviews_query() -> &'static str {
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login ... on User { id } ... on Bot { id } }
+            author { login ... on User { id } ... on Bot { id } ... on Mannequin { id } }
             state
             body
             submittedAt

--- a/crates/github/src/queries.rs
+++ b/crates/github/src/queries.rs
@@ -8,7 +8,7 @@ const ISSUE_FIELDS: &str = r#"
     body
     state
     stateReason
-    author { login id }
+    author { login ... on User { id } ... on Bot { id } }
     labels(first: 100) {
         nodes { name color }
     }
@@ -24,7 +24,7 @@ const ISSUE_FIELDS: &str = r#"
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login id }
+            author { login ... on User { id } ... on Bot { id } }
             body
             createdAt
             updatedAt
@@ -69,7 +69,7 @@ const PR_FIELDS: &str = r#"
     baseRefName
     isDraft
     mergeable
-    author { login id }
+    author { login ... on User { id } ... on Bot { id } }
     labels(first: 100) {
         nodes { name color }
     }
@@ -81,7 +81,7 @@ const PR_FIELDS: &str = r#"
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login id }
+            author { login ... on User { id } ... on Bot { id } }
             state
             body
             submittedAt
@@ -91,7 +91,7 @@ const PR_FIELDS: &str = r#"
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login id }
+            author { login ... on User { id } ... on Bot { id } }
             body
             createdAt
             updatedAt
@@ -156,7 +156,7 @@ pub fn issue_comments_query() -> &'static str {
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login id }
+            author { login ... on User { id } ... on Bot { id } }
             body
             createdAt
             updatedAt
@@ -210,7 +210,7 @@ pub fn pr_comments_query() -> &'static str {
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login id }
+            author { login ... on User { id } ... on Bot { id } }
             body
             createdAt
             updatedAt
@@ -230,7 +230,7 @@ pub fn pr_reviews_query() -> &'static str {
         pageInfo { hasNextPage endCursor }
         nodes {
             id
-            author { login id }
+            author { login ... on User { id } ... on Bot { id } }
             state
             body
             submittedAt

--- a/crates/github/src/response.rs
+++ b/crates/github/src/response.rs
@@ -55,14 +55,16 @@ pub(crate) struct Nodes<T> {
 #[derive(Debug, Default, Deserialize)]
 pub(crate) struct GqlUser {
     pub login: String,
-    pub id: String,
+    /// Node ID — comes from inline fragment (... on User { id }), so may be absent.
+    #[serde(default)]
+    pub id: Option<String>,
 }
 
 impl GqlUser {
     pub fn into_model(self) -> model::User {
         model::User {
             login: self.login,
-            node_id: self.id,
+            node_id: self.id.unwrap_or_default(),
         }
     }
 }

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -179,8 +179,10 @@ impl<R: ContainerRuntime + Clone + Send + Sync + 'static> SessionManager<R> {
 
         session.start(self.ready_timeout).await?;
         let container_id = session.container_id().unwrap().to_string();
+        eprintln!("[session] {task_id}: container {container_id} ready");
 
         session.start_agent(&repo_url, &branch, &prompt)?;
+        eprintln!("[session] {task_id}: agent started");
 
         // Create command channel
         let (command_tx, command_rx) = tokio::sync::mpsc::channel::<SessionCommand>(32);


### PR DESCRIPTION
## Summary
- Fixes GraphQL query to use inline fragments for Actor.id (`... on User { id } ... on Bot { id }`)
- Makes `GqlUser.id` optional since some Actor types don't have node IDs
- Adds minimal session lifecycle logging (container ready, agent started)

## Context
Discovered during first real e2e test against iamnbutler/multibuffer. The GitHub GraphQL API
returns `Field 'id' doesn't exist on type 'Actor'` because `Actor` is an interface — only
concrete types like `User` and `Bot` have the `id` field.

## Test plan
- [x] All 27 github crate tests pass (JSON fixtures already use valid `id` values)
- [x] All 140 workspace tests pass
- [x] Tested e2e: poll → task creation → dispatch → session start against live repo