### PR TITLE
Replace eprintln with structured tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,6 @@ tokio = { version = "1.0", features = ["full"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 thiserror = "2.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 trait-variant = "0.1"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -16,4 +16,6 @@ tasks-store = { path = "../store" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 chrono.workspace = true

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -80,6 +80,14 @@ fn print_usage() {
 
 #[tokio::main]
 async fn main() {
+    // Initialize tracing subscriber (controlled by RUST_LOG env var, default: info)
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
     let args: Vec<String> = std::env::args().collect();
     let cmd = args.get(1).map(|s| s.as_str()).unwrap_or("run");
 

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
+use tracing::{error, info, warn};
 
 use events::{Actor, Event, EventBus, EventStore, EventType};
 use runtime::{AppleContainerRuntime, ContainerConfig};
@@ -20,12 +21,14 @@ use crate::config::AppConfig;
 /// Constructs all components and starts the GitHub poll loop,
 /// dispatch tick loop, and session management.
 pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
-    eprintln!("Tasks platform starting...");
-    eprintln!("  data_dir: {}", config.data_dir);
-    eprintln!("  max_sessions: {}", config.max_sessions);
-    eprintln!("  poll_interval: {:?}", config.poll_interval);
-    eprintln!("  dispatch_interval: {:?}", config.dispatch_interval);
-    eprintln!("  container_image: {}", config.container_image);
+    info!(
+        data_dir = %config.data_dir,
+        max_sessions = config.max_sessions,
+        poll_interval = ?config.poll_interval,
+        dispatch_interval = ?config.dispatch_interval,
+        container_image = %config.container_image,
+        "starting tasks platform"
+    );
 
     // --- 1. Create infrastructure ---
 
@@ -84,7 +87,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // --- 5. Emit system:started ---
 
     server.emit_started().await?;
-    eprintln!("Tasks platform started ({} projects)", pollers.len());
+    info!(projects = pollers.len(), "tasks platform started");
 
     // --- 6. Spawn GitHub poll loop ---
 
@@ -118,9 +121,11 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                     &label_config,
                                 ) {
                                     if let Err(e) = poll_server.add_task(task).await {
-                                        eprintln!(
-                                            "Failed to add task for issue #{}: {e}",
-                                            issue.number
+                                        warn!(
+                                            project = %project_id,
+                                            issue = issue.number,
+                                            error = %e,
+                                            "failed to add task for issue"
                                         );
                                     }
                                 }
@@ -140,9 +145,11 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                     &label_config,
                                 ) {
                                     if let Err(e) = poll_server.add_task(task).await {
-                                        eprintln!(
-                                            "Failed to add task for PR #{}: {e}",
-                                            pr.number
+                                        warn!(
+                                            project = %project_id,
+                                            pr = pr.number,
+                                            error = %e,
+                                            "failed to add task for PR"
                                         );
                                     }
                                 }
@@ -150,7 +157,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                     Err(e) => {
-                        eprintln!("Poll error for {project_id}: {e}");
+                        error!(project = %project_id, error = %e, "poll failed");
                     }
                 }
             }
@@ -232,7 +239,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 )
                                 .await
                             {
-                                eprintln!("Failed to start session for {task_id}: {e}");
+                                error!(task_id = %task_id, error = %e, "failed to start session");
                             }
                         }
                     }
@@ -244,12 +251,12 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                             .send_chat(task_id, "Resuming — please continue.".to_string())
                             .await
                         {
-                            eprintln!("Failed to resume session for {task_id}: {e}");
+                            error!(task_id = %task_id, error = %e, "failed to resume session");
                         }
                     }
                 }
                 Err(e) => {
-                    eprintln!("Dispatch error: {e}");
+                    error!(error = %e, "dispatch failed");
                 }
             }
         }
@@ -258,7 +265,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // --- 8. Wait for shutdown ---
 
     tokio::signal::ctrl_c().await?;
-    eprintln!("\nShutting down...");
+    info!("shutting down");
 
     // Stop all sessions
     session_manager.stop_all().await;
@@ -267,6 +274,6 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     poll_handle.abort();
     dispatch_handle.abort();
 
-    eprintln!("Shutdown complete.");
+    info!("shutdown complete");
     Ok(())
 }

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -14,6 +14,7 @@ serde_json.workspace = true
 tokio.workspace = true
 chrono.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -179,10 +179,10 @@ impl<R: ContainerRuntime + Clone + Send + Sync + 'static> SessionManager<R> {
 
         session.start(self.ready_timeout).await?;
         let container_id = session.container_id().unwrap().to_string();
-        eprintln!("[session] {task_id}: container {container_id} ready");
+        tracing::info!(task_id = %task_id, container_id = %container_id, "container ready");
 
         session.start_agent(&repo_url, &branch, &prompt)?;
-        eprintln!("[session] {task_id}: agent started");
+        tracing::info!(task_id = %task_id, "agent started");
 
         // Create command channel
         let (command_tx, command_rx) = tokio::sync::mpsc::channel::<SessionCommand>(32);


### PR DESCRIPTION
## Summary
- Adds `tracing` and `tracing-subscriber` (with env-filter) to workspace deps
- Initializes subscriber in main.rs — controlled by `RUST_LOG` env var (default: `info`)
- Replaces all `eprintln!` in run_loop.rs and session manager with `tracing::info!`, `tracing::warn!`, `tracing::error!` using structured fields
- CLI user-facing output (usage, project commands) remains as `eprintln!`

## Test plan
- [x] All 140 workspace tests pass
- [x] Verified structured output with `RUST_LOG=debug`