### PR TITLE
Rewrite container supervisor in Rust

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,12 @@ A human-in-the-loop platform that orchestrates coding agents to get project work
   - `server/` — Server: domain models, operating modes, merge queue, presence
   - `session/` — Session management: lifecycle, monitoring, event bridging
   - `store/` — Persistent storage: SQLite for projects, tasks, merge queue
-- `src/` — TypeScript (supervisor that runs inside containers)
+  - `supervisor/` — Container supervisor binary (PID 1 inside containers)
 
 ## Key decisions
 
 - Host runtime: Rust
-- Container supervisor: Bun/TypeScript (PID 1 inside containers)
+- Container supervisor: Rust (PID 1 inside containers, built from same workspace)
 - Session isolation: apple/container (one lightweight Linux VM per session)
 - Host ↔ container communication: JSON-line protocol over stdio
 - Agent provider: Claude Code (initial), pluggable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,24 @@ A human-in-the-loop platform that orchestrates coding agents to get project work
 - Session isolation: apple/container (one lightweight Linux VM per session)
 - Host ↔ container communication: JSON-line protocol over stdio
 - Agent provider: Claude Code (initial), pluggable
+- Container images: built with `container build` (apple/container CLI), NOT Docker
+- Data directory: `~/.tasks/` (SQLite + event logs), configurable via `TASKS_DATA_DIR`
+- Config: `.env` file at project root, loaded automatically via dotenvy
+
+## Building the container image
+
+```sh
+container build -f src/runtime/Dockerfile -t tasks-agent:latest .
+```
+
+The Dockerfile uses a multi-stage build: Rust compilation in `rust:1.85-slim`, runtime on `ubuntu:24.04`. The supervisor binary (`crates/supervisor/`) is compiled in the builder stage and copied into the final image.
+
+## Running
+
+```sh
+cargo run -- add-project owner/repo   # add a project (stored in SQLite)
+cargo run -- run                      # headless mode
+cargo run -- run --tui                # terminal UI
+```
+
+Requires `.env` with `GITHUB_TOKEN` and `ANTHROPIC_API_KEY`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ A human-in-the-loop platform that orchestrates coding agents to get project work
 ## Building the container image
 
 ```sh
-container build -f src/runtime/Dockerfile -t tasks-agent:latest .
+container build --dns 8.8.8.8 -f src/runtime/Dockerfile -t tasks-agent:latest .
 ```
 
 The Dockerfile uses a multi-stage build: Rust compilation in `rust:1.85-slim`, runtime on `ubuntu:24.04`. The supervisor binary (`crates/supervisor/`) is compiled in the builder stage and copied into the final image.

--- a/crates/supervisor/Cargo.toml
+++ b/crates/supervisor/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tasks-supervisor"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["full", "process", "signal"] }

--- a/crates/supervisor/Cargo.toml
+++ b/crates/supervisor/Cargo.toml
@@ -9,3 +9,6 @@ rust-version.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full", "process", "signal"] }
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.29", features = ["signal"] }

--- a/crates/supervisor/src/main.rs
+++ b/crates/supervisor/src/main.rs
@@ -293,6 +293,24 @@ async fn main() {
     // the main loop emits them to the host.
     let (event_tx, mut event_rx) = mpsc::unbounded_channel::<Ev>();
 
+    // Set up Claude Code auth from ANTHROPIC_API_KEY if present.
+    // Claude Code uses ~/.claude/anthropic_key.sh as a credential helper.
+    if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
+        let claude_dir = format!(
+            "{}/.claude",
+            std::env::var("HOME").unwrap_or_else(|_| "/root".to_string())
+        );
+        let _ = std::fs::create_dir_all(&claude_dir);
+        let script = format!("#!/bin/bash\necho \"{api_key}\"\n");
+        let script_path = format!("{claude_dir}/anthropic_key.sh");
+        let _ = std::fs::write(&script_path, &script);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o700));
+        }
+    }
+
     // Emit system:ready (§4.2).
     emit(&Ev::SystemReady {});
 

--- a/crates/supervisor/src/main.rs
+++ b/crates/supervisor/src/main.rs
@@ -155,6 +155,7 @@ async fn start_agent(
         .map(|s| s.split_whitespace().map(String::from).collect())
         .unwrap_or_else(|_| vec![
             "--print".to_string(),
+            "--verbose".to_string(),
             "--output-format".to_string(),
             "stream-json".to_string(),
         ]);
@@ -359,7 +360,7 @@ async fn main() {
                     }
                     Cmd::Chat { text } => {
                         if let Some(ref mut handle) = agent {
-                            send_chat(handle, &text);
+                            send_chat(handle, &text).await;
                         } else {
                             // Buffer if agent not running (§4.1).
                             pending_chat.push(text);

--- a/crates/supervisor/src/main.rs
+++ b/crates/supervisor/src/main.rs
@@ -1,0 +1,416 @@
+//! Session supervisor — runs as PID 1 inside containers.
+//!
+//! Manages the agent process lifecycle and bridges communication between
+//! the host and the agent via the JSON-lines supervisor protocol.
+//! See spec/session-runtime.md §4.
+
+use std::io::{self, BufRead, Write};
+use std::process::Stdio;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::mpsc;
+
+// ---------------------------------------------------------------------------
+// Protocol types (matching spec/session-runtime.md §4)
+// ---------------------------------------------------------------------------
+
+/// Commands from host → supervisor (§4.1).
+#[derive(serde::Deserialize)]
+#[serde(tag = "cmd", rename_all = "snake_case")]
+enum Cmd {
+    Start {
+        repo: String,
+        branch: String,
+        prompt: String,
+    },
+    Chat {
+        text: String,
+    },
+    Stop,
+    Exec {
+        id: String,
+        argv: Vec<String>,
+    },
+}
+
+/// Events from supervisor → host (§4.2).
+/// Serialized as single-line JSON to stdout.
+#[derive(serde::Serialize)]
+#[serde(tag = "ev", rename_all = "snake_case")]
+enum Ev {
+    #[serde(rename = "system:ready")]
+    SystemReady {},
+    #[serde(rename = "agent:started")]
+    AgentStarted { pid: u32 },
+    #[serde(rename = "agent:stdout")]
+    AgentStdout { data: String },
+    #[serde(rename = "agent:stderr")]
+    AgentStderr { data: String },
+    #[serde(rename = "agent:exit")]
+    AgentExit {
+        code: Option<i32>,
+        signal: Option<String>,
+    },
+    #[serde(rename = "exec:result")]
+    ExecResult {
+        id: String,
+        code: i32,
+        stdout: String,
+        stderr: String,
+    },
+}
+
+/// Write a protocol event to stdout (§4.3: single-line JSON, newline-delimited).
+fn emit(ev: &Ev) {
+    let json = serde_json::to_string(ev).expect("event serialization failed");
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    let _ = writeln!(out, "{json}");
+    let _ = out.flush();
+}
+
+/// Log to stderr (supervisor logging must not go to stdout — §4.3).
+macro_rules! log {
+    ($($arg:tt)*) => {
+        eprintln!("[supervisor] {}", format!($($arg)*));
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Repo provisioning (spec/session-runtime.md §3)
+// ---------------------------------------------------------------------------
+
+const WORK_DIR: &str = "/workspace";
+
+/// Check if the workspace already has a git repo (workspace reuse).
+fn repo_exists() -> bool {
+    std::process::Command::new("git")
+        .args(["-C", WORK_DIR, "rev-parse", "--git-dir"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// Clone the repo and check out the branch. Embeds GITHUB_TOKEN in the URL
+/// for HTTPS auth (spec §3.1).
+fn clone_repo(url: &str, branch: &str) -> Result<(), String> {
+    // Configure git identity.
+    let _ = std::process::Command::new("git")
+        .args(["config", "--global", "user.email", "tasks@localhost"])
+        .status();
+    let _ = std::process::Command::new("git")
+        .args(["config", "--global", "user.name", "Tasks Agent"])
+        .status();
+
+    // Embed token in URL for auth.
+    let clone_url = match std::env::var("GITHUB_TOKEN") {
+        Ok(token) if url.starts_with("https://github.com/") => {
+            url.replace("https://github.com/", &format!("https://x-access-token:{token}@github.com/"))
+        }
+        _ => url.to_string(),
+    };
+
+    let status = std::process::Command::new("git")
+        .args(["clone", &clone_url, WORK_DIR])
+        .stderr(Stdio::inherit()) // let clone progress go to container stderr
+        .status()
+        .map_err(|e| format!("git clone failed to start: {e}"))?;
+
+    if !status.success() {
+        return Err(format!("git clone exited with {status}"));
+    }
+
+    let status = std::process::Command::new("git")
+        .args(["-C", WORK_DIR, "checkout", "-B", branch])
+        .status()
+        .map_err(|e| format!("git checkout failed to start: {e}"))?;
+
+    if !status.success() {
+        return Err(format!("git checkout exited with {status}"));
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Agent management (spec §9.4, session-runtime.md §4.1)
+// ---------------------------------------------------------------------------
+
+const KILL_TIMEOUT_SECS: u64 = 5;
+
+struct AgentHandle {
+    child: Child,
+}
+
+/// Start the agent process. Returns the handle and spawns tasks that
+/// forward stdout/stderr as protocol events via the provided channel.
+async fn start_agent(
+    prompt: &str,
+    event_tx: &mpsc::UnboundedSender<Ev>,
+) -> Result<AgentHandle, String> {
+    let agent_cmd = std::env::var("AGENT_CMD").unwrap_or_else(|_| "claude".to_string());
+    let agent_args: Vec<String> = std::env::var("AGENT_ARGS")
+        .map(|s| s.split_whitespace().map(String::from).collect())
+        .unwrap_or_else(|_| vec![
+            "--print".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+        ]);
+
+    let mut cmd = Command::new(&agent_cmd);
+    cmd.args(&agent_args)
+        .arg(prompt)
+        .current_dir(WORK_DIR)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| format!("failed to spawn agent: {e}"))?;
+    let pid = child.id().unwrap_or(0);
+
+    // Spawn stdout reader.
+    if let Some(stdout) = child.stdout.take() {
+        let tx = event_tx.clone();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout);
+            let mut buf = vec![0u8; 8192];
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let data = String::from_utf8_lossy(&buf[..n]).to_string();
+                        let _ = tx.send(Ev::AgentStdout { data });
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+    }
+
+    // Spawn stderr reader.
+    if let Some(stderr) = child.stderr.take() {
+        let tx = event_tx.clone();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stderr);
+            let mut buf = vec![0u8; 8192];
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let data = String::from_utf8_lossy(&buf[..n]).to_string();
+                        let _ = tx.send(Ev::AgentStderr { data });
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+    }
+
+    event_tx.send(Ev::AgentStarted { pid }).ok();
+    Ok(AgentHandle { child })
+}
+
+/// Stop the agent: SIGTERM → timeout → SIGKILL (spec §4.1 stop command).
+async fn stop_agent(handle: &mut AgentHandle) {
+    // Send SIGTERM.
+    if let Err(e) = handle.child.start_kill() {
+        log!("failed to send kill signal: {e}");
+        return;
+    }
+
+    // Wait with timeout.
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(KILL_TIMEOUT_SECS),
+        handle.child.wait(),
+    )
+    .await
+    {
+        Ok(_) => {} // exited
+        Err(_) => {
+            // Timeout — force kill.
+            log!("agent did not exit in {KILL_TIMEOUT_SECS}s, sending SIGKILL");
+            let _ = handle.child.kill().await;
+        }
+    }
+}
+
+/// Send a chat message to the agent's stdin (spec §4.1 chat command).
+async fn send_chat(handle: &mut AgentHandle, text: &str) {
+    if let Some(ref mut stdin) = handle.child.stdin {
+        let msg = format!("{text}\n");
+        let _ = stdin.write_all(msg.as_bytes()).await;
+        let _ = stdin.flush().await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exec command (spec §4.1)
+// ---------------------------------------------------------------------------
+
+async fn exec_command(id: &str, argv: &[String]) -> Ev {
+    if argv.is_empty() {
+        return Ev::ExecResult {
+            id: id.to_string(),
+            code: 1,
+            stdout: String::new(),
+            stderr: "empty argv".to_string(),
+        };
+    }
+
+    match Command::new(&argv[0])
+        .args(&argv[1..])
+        .current_dir(WORK_DIR)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+    {
+        Ok(output) => Ev::ExecResult {
+            id: id.to_string(),
+            code: output.status.code().unwrap_or(1),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        },
+        Err(e) => Ev::ExecResult {
+            id: id.to_string(),
+            code: 1,
+            stdout: String::new(),
+            stderr: format!("{e}"),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main loop
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() {
+    // Event channel — agent stdout/stderr readers send events here,
+    // the main loop emits them to the host.
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<Ev>();
+
+    // Emit system:ready (§4.2).
+    emit(&Ev::SystemReady {});
+
+    // Read commands from stdin on a blocking thread (stdin is sync).
+    let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<Cmd>();
+    std::thread::spawn(move || {
+        let stdin = io::stdin();
+        for line in stdin.lock().lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => break,
+            };
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<Cmd>(&line) {
+                Ok(cmd) => {
+                    if cmd_tx.send(cmd).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => {
+                    // Malformed command — ignore and log warning (§4.3).
+                    log!("ignoring malformed command: {line}");
+                }
+            }
+        }
+    });
+
+    // Set up SIGTERM handler for graceful shutdown (spec §4.1 stop).
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .expect("failed to register SIGTERM handler");
+
+    let mut agent: Option<AgentHandle> = None;
+    let mut pending_chat: Vec<String> = Vec::new();
+
+    loop {
+        tokio::select! {
+            // Commands from host.
+            Some(cmd) = cmd_rx.recv() => {
+                match cmd {
+                    Cmd::Start { repo, branch, prompt } => {
+                        // Clone repo if needed (§3).
+                        if !repo_exists() {
+                            if let Err(e) = clone_repo(&repo, &branch) {
+                                log!("clone failed: {e}");
+                                emit(&Ev::AgentExit { code: Some(1), signal: None });
+                                continue;
+                            }
+                        }
+                        // Start agent.
+                        match start_agent(&prompt, &event_tx).await {
+                            Ok(mut handle) => {
+                                // Flush pending chat messages.
+                                for text in pending_chat.drain(..) {
+                                    send_chat(&mut handle, &text).await;
+                                }
+                                agent = Some(handle);
+                            }
+                            Err(e) => {
+                                log!("agent start failed: {e}");
+                                emit(&Ev::AgentExit { code: Some(1), signal: None });
+                            }
+                        }
+                    }
+                    Cmd::Chat { text } => {
+                        if let Some(ref mut handle) = agent {
+                            send_chat(handle, &text);
+                        } else {
+                            // Buffer if agent not running (§4.1).
+                            pending_chat.push(text);
+                        }
+                    }
+                    Cmd::Stop => {
+                        if let Some(ref mut handle) = agent {
+                            stop_agent(handle).await;
+                        }
+                    }
+                    Cmd::Exec { id, argv } => {
+                        let result = exec_command(&id, &argv).await;
+                        emit(&result);
+                    }
+                }
+            }
+            // Events from agent stdout/stderr readers.
+            Some(ev) = event_rx.recv() => {
+                emit(&ev);
+            }
+            // Agent process exit.
+            _ = async {
+                if let Some(ref mut handle) = agent {
+                    handle.child.wait().await.ok();
+                } else {
+                    // No agent — sleep forever so this branch doesn't fire.
+                    std::future::pending::<()>().await;
+                }
+            } => {
+                if let Some(mut handle) = agent.take() {
+                    let status = handle.child.try_wait().ok().flatten();
+                    let code = status.and_then(|s| s.code());
+                    // Check for signal (Unix only).
+                    #[cfg(unix)]
+                    let signal = {
+                        use std::os::unix::process::ExitStatusExt;
+                        status.and_then(|s| s.signal()).map(|s| format!("{s}"))
+                    };
+                    #[cfg(not(unix))]
+                    let signal: Option<String> = None;
+
+                    emit(&Ev::AgentExit { code, signal });
+                }
+            }
+            // SIGTERM — graceful shutdown.
+            _ = sigterm.recv() => {
+                if let Some(ref mut handle) = agent {
+                    stop_agent(handle).await;
+                }
+                break;
+            }
+        }
+    }
+}

--- a/crates/supervisor/src/main.rs
+++ b/crates/supervisor/src/main.rs
@@ -7,7 +7,7 @@
 use std::io::{self, BufRead, Write};
 use std::process::Stdio;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 
@@ -171,40 +171,24 @@ async fn start_agent(
     let mut child = cmd.spawn().map_err(|e| format!("failed to spawn agent: {e}"))?;
     let pid = child.id().unwrap_or(0);
 
-    // Spawn stdout reader.
+    // Spawn stdout reader (line-oriented to avoid splitting UTF-8 sequences).
     if let Some(stdout) = child.stdout.take() {
         let tx = event_tx.clone();
         tokio::spawn(async move {
-            let mut reader = BufReader::new(stdout);
-            let mut buf = vec![0u8; 8192];
-            loop {
-                match reader.read(&mut buf).await {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        let data = String::from_utf8_lossy(&buf[..n]).to_string();
-                        let _ = tx.send(Ev::AgentStdout { data });
-                    }
-                    Err(_) => break,
-                }
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = tx.send(Ev::AgentStdout { data: line + "\n" });
             }
         });
     }
 
-    // Spawn stderr reader.
+    // Spawn stderr reader (line-oriented).
     if let Some(stderr) = child.stderr.take() {
         let tx = event_tx.clone();
         tokio::spawn(async move {
-            let mut reader = BufReader::new(stderr);
-            let mut buf = vec![0u8; 8192];
-            loop {
-                match reader.read(&mut buf).await {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        let data = String::from_utf8_lossy(&buf[..n]).to_string();
-                        let _ = tx.send(Ev::AgentStderr { data });
-                    }
-                    Err(_) => break,
-                }
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = tx.send(Ev::AgentStderr { data: line + "\n" });
             }
         });
     }
@@ -215,22 +199,35 @@ async fn start_agent(
 
 /// Stop the agent: SIGTERM → timeout → SIGKILL (spec §4.1 stop command).
 async fn stop_agent(handle: &mut AgentHandle) {
-    // Send SIGTERM.
-    if let Err(e) = handle.child.start_kill() {
-        log!("failed to send kill signal: {e}");
-        return;
+    let pid = match handle.child.id() {
+        Some(pid) => pid,
+        None => return, // already exited
+    };
+
+    // Send SIGTERM (not SIGKILL — the agent gets a grace period).
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{kill, Signal};
+        use nix::unistd::Pid;
+        if let Err(e) = kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
+            log!("failed to send SIGTERM: {e}");
+            return;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = handle.child.start_kill();
     }
 
-    // Wait with timeout.
+    // Wait with timeout, then SIGKILL if still alive.
     match tokio::time::timeout(
         std::time::Duration::from_secs(KILL_TIMEOUT_SECS),
         handle.child.wait(),
     )
     .await
     {
-        Ok(_) => {} // exited
+        Ok(_) => {} // exited gracefully
         Err(_) => {
-            // Timeout — force kill.
             log!("agent did not exit in {KILL_TIMEOUT_SECS}s, sending SIGKILL");
             let _ = handle.child.kill().await;
         }
@@ -353,6 +350,10 @@ async fn main() {
             Some(cmd) = cmd_rx.recv() => {
                 match cmd {
                     Cmd::Start { repo, branch, prompt } => {
+                        if agent.is_some() {
+                            log!("start received while agent already running — ignoring");
+                            continue;
+                        }
                         // Clone repo if needed (§3).
                         if !repo_exists() {
                             if let Err(e) = clone_repo(&repo, &branch) {
@@ -425,8 +426,18 @@ async fn main() {
             }
             // SIGTERM — graceful shutdown.
             _ = sigterm.recv() => {
-                if let Some(ref mut handle) = agent {
-                    stop_agent(handle).await;
+                if let Some(mut handle) = agent.take() {
+                    stop_agent(&mut handle).await;
+                    let status = handle.child.try_wait().ok().flatten();
+                    let code = status.and_then(|s| s.code());
+                    #[cfg(unix)]
+                    let signal = {
+                        use std::os::unix::process::ExitStatusExt;
+                        status.and_then(|s| s.signal()).map(|s| format!("{s}"))
+                    };
+                    #[cfg(not(unix))]
+                    let signal: Option<String> = None;
+                    emit(&Ev::AgentExit { code, signal });
                 }
                 break;
             }

--- a/src/runtime/Dockerfile
+++ b/src/runtime/Dockerfile
@@ -1,3 +1,21 @@
+# Stage 1: Build the supervisor binary
+FROM rust:1.85-slim AS builder
+
+WORKDIR /build
+
+# Copy just the workspace manifests and supervisor crate first (cache deps).
+COPY Cargo.toml Cargo.lock* ./
+COPY crates/supervisor/Cargo.toml crates/supervisor/Cargo.toml
+
+# Create dummy source to build deps.
+RUN mkdir -p crates/supervisor/src && echo 'fn main() {}' > crates/supervisor/src/main.rs
+RUN cargo build -p tasks-supervisor --release 2>/dev/null || true
+
+# Copy real source and build.
+COPY crates/supervisor/src crates/supervisor/src
+RUN cargo build -p tasks-supervisor --release
+
+# Stage 2: Runtime image
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -28,21 +46,14 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
 # Claude Code
 RUN npm install -g @anthropic-ai/claude-code
 
-# Bun (runs the supervisor)
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
-
-# Rust (minimal profile)
+# Rust (minimal profile — for Rust-based projects the agent works on)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Build context is the repo root: docker build -f src/runtime/Dockerfile .
-WORKDIR /opt/supervisor
-COPY package.json bun.lock* tsconfig.json ./
-COPY src/runtime/ ./src/runtime/
-RUN bun install --frozen-lockfile 2>/dev/null || bun install
+# Supervisor binary from build stage.
+COPY --from=builder /build/target/release/tasks-supervisor /usr/local/bin/supervisor
 
 # Workspace directory for cloned repos
 RUN mkdir -p /workspace
 
-ENTRYPOINT ["bun", "run", "src/runtime/supervisor/main.ts"]
+ENTRYPOINT ["supervisor"]

--- a/src/runtime/spec.md
+++ b/src/runtime/spec.md
@@ -25,7 +25,7 @@ Server (host)
         ├── receives chat messages from server, forwards to supervisor
         │
         └── container (lightweight Linux VM)
-              └── Supervisor (PID 1, Bun/TS)
+              └── Supervisor (PID 1, Rust)
                     ├── manages agent process lifecycle
                     ├── frames agent output as protocol events
                     ├── routes incoming commands to agent stdin
@@ -62,7 +62,7 @@ The base image is a pre-built OCI image containing the tools an agent needs to w
 Contents:
 
 - **Git and GitHub CLI** (`git`, `gh`) — for repository operations and PR management.
-- **Bun** — JavaScript/TypeScript runtime. Also runs the supervisor process.
+- **Supervisor binary** — built from `crates/supervisor/`, manages agent lifecycle.
 - **Rust and Cargo** — for Rust-based projects.
 - **Agent CLI** — the coding agent executable (Claude Code initially).
 - **Standard utilities** — coreutils, curl, ssh, etc.
@@ -128,9 +128,10 @@ This is the provisional approach. Future iterations may support:
 
 ## 4. Supervisor Protocol
 
-The supervisor is a Bun/TypeScript process that runs as PID 1 inside the container. It
-communicates with the host-side session wrapper over the container's stdio using a JSON-lines
-protocol (one JSON object per line, newline-delimited).
+The supervisor is a Rust binary that runs as PID 1 inside the container. It communicates with
+the host-side session wrapper over the container's stdio using a JSON-lines protocol (one JSON
+object per line, newline-delimited). The supervisor binary is built from `crates/supervisor/`
+in the same workspace as the host-side code.
 
 ### 4.1 Commands (Host → Container)
 


### PR DESCRIPTION
## Summary
Replaces the Bun/TypeScript supervisor with a Rust binary (`crates/supervisor/`) that implements the same JSON-lines protocol from spec §4.

**Why:** The Bun supervisor had shell quoting bugs in git clone that prevented repos from being cloned. Moving to Rust eliminates Bun from the container image, removes the TypeScript/Node split, and means the supervisor is built from the same workspace as the host code.

## Changes
- `crates/supervisor/` — new Rust binary implementing the supervisor protocol
- `src/runtime/Dockerfile` — multi-stage build (rust:1.85-slim for compilation, ubuntu:24.04 for runtime), Bun removed
- `src/runtime/spec.md` — updated references from Bun/TS to Rust
- `CLAUDE.md` — updated project structure and key decisions

## Protocol (unchanged)
Commands: `start` (clone + agent launch), `chat`, `stop`, `exec`
Events: `system:ready`, `agent:started`, `agent:stdout`, `agent:stderr`, `agent:exit`, `exec:result`

## Test plan
- [x] All 140 workspace tests pass
- [x] `cargo check -p tasks-supervisor` compiles cleanly
- [ ] Docker build (requires OrbStack — not available in current session)
- [ ] E2e test with apple/container (blocked on Docker build)