### PR TITLE
Ignore agentic-workflows label, skip permissions

### DIFF
--- a/crates/server/src/workflow.rs
+++ b/crates/server/src/workflow.rs
@@ -85,7 +85,7 @@ impl Default for DispatchConfig {
 impl Default for LabelConfig {
     fn default() -> Self {
         Self {
-            ignore: Vec::new(),
+            ignore: vec!["agentic-workflows".to_string()],
             blocked: Vec::new(),
         }
     }
@@ -119,7 +119,7 @@ mod tests {
         assert_eq!(cfg.dispatch.max_retries, 3);
         assert_eq!(cfg.dispatch.retry_base_delay, 5);
         assert_eq!(cfg.dispatch.progress_threshold, 60);
-        assert!(cfg.labels.ignore.is_empty());
+        assert_eq!(cfg.labels.ignore, vec!["agentic-workflows"]);
         assert!(cfg.labels.blocked.is_empty());
         assert!(cfg.prompt.system_prompt.is_none());
     }

--- a/crates/supervisor/src/main.rs
+++ b/crates/supervisor/src/main.rs
@@ -158,6 +158,7 @@ async fn start_agent(
             "--verbose".to_string(),
             "--output-format".to_string(),
             "stream-json".to_string(),
+            "--dangerously-skip-permissions".to_string(),
         ]);
 
     let mut cmd = Command::new(&agent_cmd);


### PR DESCRIPTION
## Summary

- Issues/PRs labeled `agentic-workflows` are now ignored by default (never imported as tasks)
- Claude Code agent runs with `--dangerously-skip-permissions` since no human is present to approve tool calls

## Test plan

- [x] `cargo test -p server --lib -- workflow` passes
- [x] `cargo check` passes