### PR TITLE
Wire task state updates and merge queue from session events

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -223,25 +223,25 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
             };
 
             if let Some(state) = new_state {
-                // Skip if this event was already published by set_task_state (actor = System from scheduler)
-                // Only handle events from agents/sessions (actor = Agent or System from session monitor)
-                // Apply state from session monitor events (agent-originated).
-                // Uses apply_task_state (no re-publish) to avoid infinite loops.
-                if let Err(e) = event_handler_server.apply_task_state(task_id, state).await {
-                    // TaskNotFound can happen for events on tasks not yet in state
-                    if !matches!(e, server::ServerError::TaskNotFound(_)) {
-                        error!(task_id = %task_id, error = %e, "failed to update task state from event");
+                // Only process events from agents/sessions — skip events
+                // already published by set_task_state (from scheduler/dispatch)
+                // to avoid double-applying state and bumping updated_at twice.
+                if event.actor != events::Actor::Scheduler {
+                    if let Err(e) = event_handler_server.apply_task_state(task_id, state).await {
+                        if !matches!(e, server::ServerError::TaskNotFound(_)) {
+                            error!(task_id = %task_id, error = %e, "failed to update task state from event");
+                        }
                     }
                 }
 
-                // Create merge queue entry when task reaches awaiting_merge
+                // Create merge queue entry when task reaches awaiting_merge (spec §7.1)
+                // TODO: orchestrator quality gate before enqueuing (spec §7.3)
                 if matches!(event.event_type, EventType::TaskStateAwaitingMerge) {
                     let entry_id = uuid::Uuid::new_v4().to_string();
                     let entry = models::merge_queue::MergeQueueEntry::new(&entry_id, task_id);
-                    let mut server_state = event_handler_server.state.write().await;
-                    if server_state.merge_queue.get_by_task(task_id).is_none() {
-                        info!(task_id = %task_id, entry_id = %entry_id, "task awaiting merge, adding to queue");
-                        server_state.merge_queue.enqueue(entry);
+                    info!(task_id = %task_id, entry_id = %entry_id, "task awaiting merge, adding to queue");
+                    if let Err(e) = event_handler_server.add_to_merge_queue(entry).await {
+                        error!(task_id = %task_id, error = %e, "failed to add merge queue entry");
                     }
                 }
             }

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -185,6 +185,69 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
+    // --- 6b. Spawn event handler loop ---
+    //
+    // Listens for session lifecycle events and feeds state changes back
+    // into the server. The session monitor publishes events (e.g.
+    // TaskStateAwaitingMerge) but doesn't update server state directly.
+    // This loop bridges events → state updates + merge queue entries.
+
+    let event_handler_server = server.clone();
+    let event_handler_bus = server.event_bus.clone();
+
+    let event_handler_handle = tokio::spawn(async move {
+        let mut rx = event_handler_bus.subscribe();
+        loop {
+            let event = match rx.recv().await {
+                Ok(e) => e,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(skipped = n, "event handler lagged, some events may not update state");
+                    continue;
+                }
+                Err(_) => break,
+            };
+
+            let task_id = &event.task;
+            let new_state = match event.event_type {
+                EventType::TaskStateRunning => Some(models::task::TaskState::Running),
+                EventType::TaskStateQuestion => Some(models::task::TaskState::Question),
+                EventType::TaskStateWaiting => Some(models::task::TaskState::Waiting),
+                EventType::TaskStateBlocked => Some(models::task::TaskState::Blocked),
+                EventType::TaskStateTesting => Some(models::task::TaskState::Testing),
+                EventType::TaskStateAwaitingMerge => Some(models::task::TaskState::AwaitingMerge),
+                EventType::TaskStateConflict => Some(models::task::TaskState::Conflict),
+                EventType::TaskStateCompleted => Some(models::task::TaskState::Completed),
+                EventType::TaskStateFailed => Some(models::task::TaskState::Failed),
+                EventType::TaskStateCancelled => Some(models::task::TaskState::Cancelled),
+                _ => None,
+            };
+
+            if let Some(state) = new_state {
+                // Skip if this event was already published by set_task_state (actor = System from scheduler)
+                // Only handle events from agents/sessions (actor = Agent or System from session monitor)
+                // Apply state from session monitor events (agent-originated).
+                // Uses apply_task_state (no re-publish) to avoid infinite loops.
+                if let Err(e) = event_handler_server.apply_task_state(task_id, state).await {
+                    // TaskNotFound can happen for events on tasks not yet in state
+                    if !matches!(e, server::ServerError::TaskNotFound(_)) {
+                        error!(task_id = %task_id, error = %e, "failed to update task state from event");
+                    }
+                }
+
+                // Create merge queue entry when task reaches awaiting_merge
+                if matches!(event.event_type, EventType::TaskStateAwaitingMerge) {
+                    let entry_id = uuid::Uuid::new_v4().to_string();
+                    let entry = models::merge_queue::MergeQueueEntry::new(&entry_id, task_id);
+                    let mut server_state = event_handler_server.state.write().await;
+                    if server_state.merge_queue.get_by_task(task_id).is_none() {
+                        info!(task_id = %task_id, entry_id = %entry_id, "task awaiting merge, adding to queue");
+                        server_state.merge_queue.enqueue(entry);
+                    }
+                }
+            }
+        }
+    });
+
     // --- 7. Spawn dispatch tick loop ---
 
     let dispatch_server = server.clone();
@@ -336,6 +399,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // Cancel the loops
     poll_handle.abort();
     dispatch_handle.abort();
+    event_handler_handle.abort();
     if let Some(h) = web_handle {
         h.abort();
     }

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -2,9 +2,9 @@
 //!
 //! This is intentionally thin — the logic lives in the library crates.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
 use events::{Actor, Event, EventBus, EventStore, EventType};
@@ -69,41 +69,51 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         .with_hard_time_limit(config.session_hard_limit),
     );
 
-    // --- 4. Load projects from store and create pollers ---
+    // --- 4. Emit system:started ---
 
-    let mut pollers: Vec<(String, RepoPoller)> = Vec::new();
-    {
-        let state = server.state.read().await;
-        for (project_id, project) in &state.projects {
-            let parts: Vec<&str> = project.repo.split('/').collect();
-            if parts.len() == 2 {
-                let client = GitHubClient::new(&config.github_token);
-                let poller = RepoPoller::new(client, parts[0], parts[1]);
-                pollers.push((project_id.clone(), poller));
-            }
-        }
-    }
-
-    // --- 5. Emit system:started ---
-
+    let project_count = server.state.read().await.projects.len();
     server.emit_started().await?;
-    info!(projects = pollers.len(), "tasks platform started");
+    info!(projects = project_count, "tasks platform started");
 
-    // --- 6. Spawn GitHub poll loop ---
+    // --- 5. Spawn GitHub poll loop ---
+    //
+    // Pollers are rebuilt from the live project list each tick so that
+    // projects added/removed via the web UI take effect immediately.
 
     let poll_server = server.clone();
     let poll_interval = config.poll_interval;
-    let pollers = Arc::new(RwLock::new(pollers));
-    let poll_pollers = pollers.clone();
+    let github_token = config.github_token.clone();
 
     let poll_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(poll_interval);
         let label_config = server::workflow::LabelConfig::default();
+        let mut pollers: HashMap<String, RepoPoller> = HashMap::new();
 
         loop {
             interval.tick().await;
 
-            let mut pollers = poll_pollers.write().await;
+            // Sync pollers with live project list
+            let projects: Vec<(String, String)> = {
+                let state = poll_server.state.read().await;
+                state.projects.iter().map(|(id, p)| (id.clone(), p.repo.clone())).collect()
+            };
+
+            // Remove pollers for deleted projects
+            let active_ids: std::collections::HashSet<&str> = projects.iter().map(|(id, _)| id.as_str()).collect();
+            pollers.retain(|id, _| active_ids.contains(id.as_str()));
+
+            // Add pollers for new projects
+            for (project_id, repo) in &projects {
+                if !pollers.contains_key(project_id) {
+                    let parts: Vec<&str> = repo.split('/').collect();
+                    if parts.len() == 2 {
+                        let client = GitHubClient::new(&github_token);
+                        let poller = RepoPoller::new(client, parts[0], parts[1]);
+                        pollers.insert(project_id.clone(), poller);
+                    }
+                }
+            }
+
             for (project_id, poller) in pollers.iter_mut() {
                 match poller.poll().await {
                     Ok(result) => {

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -293,10 +293,12 @@ impl Server {
         Ok(())
     }
 
-    /// Update task state and persist to store, without publishing an event.
+    /// Update task state and persist to store, **without publishing an event**.
     ///
-    /// Used by the event handler loop to apply state changes from events
-    /// that were already published by the session monitor, avoiding infinite loops.
+    /// Only call this from the event-handler loop in `app`, where the
+    /// state-change event was already published by the session monitor.
+    /// All other callers should use [`set_task_state`], which publishes
+    /// the corresponding event.
     pub async fn apply_task_state(
         &self,
         task_id: &str,
@@ -317,6 +319,41 @@ impl Server {
                 }
             }
         }
+        Ok(())
+    }
+
+    // --- Merge queue (spec §7) ---
+
+    /// Add an entry to the merge queue, persisting to store and publishing
+    /// a `merge:queued` event (spec §7.1 step 3).
+    pub async fn add_to_merge_queue(
+        &self,
+        entry: crate::model::merge_queue::MergeQueueEntry,
+    ) -> Result<(), ServerError> {
+        let task_id = entry.task_id.clone();
+        let entry_id = entry.id.clone();
+        {
+            let mut state = self.state.write().await;
+            if state.merge_queue.get_by_task(&task_id).is_some() {
+                return Ok(()); // Already queued
+            }
+            if let Some(ref store) = self.store {
+                if let Ok(store) = store.lock() {
+                    if let Err(e) = store.save_merge_entry(&entry) {
+                        tracing::error!(entry_id = %entry_id, error = %e, "failed to persist merge queue entry");
+                    }
+                }
+            }
+            state.merge_queue.enqueue(entry);
+        }
+
+        let event = Event::new(
+            EventType::MergeQueued,
+            &task_id,
+            Actor::System,
+            serde_json::json!({ "entry_id": entry_id }),
+        );
+        self.event_bus.publish(event).await?;
         Ok(())
     }
 

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -266,29 +266,14 @@ impl Server {
     }
 
     /// Transition a task's state and emit the corresponding event.
+    /// Update task state, persist to store, and publish an event.
     pub async fn set_task_state(
         &self,
         task_id: &str,
         new_state: TaskState,
         actor: Actor,
     ) -> Result<(), ServerError> {
-        {
-            let mut state = self.state.write().await;
-            let task = state
-                .tasks
-                .get_mut(task_id)
-                .ok_or_else(|| ServerError::TaskNotFound(task_id.to_string()))?;
-            task.set_state(new_state);
-
-            // Write-through to store
-            if let Some(ref store) = self.store {
-                if let Ok(store) = store.lock() {
-                    if let Err(e) = store.save_task(task) {
-                        tracing::error!(task_id = %task_id, error = %e, "failed to persist task state to store");
-                    }
-                }
-            }
-        }
+        self.apply_task_state(task_id, new_state).await?;
 
         let event_type = match new_state {
             TaskState::Waiting => EventType::TaskStateWaiting,
@@ -305,6 +290,33 @@ impl Server {
 
         let event = Event::new(event_type, task_id, actor, serde_json::json!({}));
         self.event_bus.publish(event).await?;
+        Ok(())
+    }
+
+    /// Update task state and persist to store, without publishing an event.
+    ///
+    /// Used by the event handler loop to apply state changes from events
+    /// that were already published by the session monitor, avoiding infinite loops.
+    pub async fn apply_task_state(
+        &self,
+        task_id: &str,
+        new_state: TaskState,
+    ) -> Result<(), ServerError> {
+        let mut state = self.state.write().await;
+        let task = state
+            .tasks
+            .get_mut(task_id)
+            .ok_or_else(|| ServerError::TaskNotFound(task_id.to_string()))?;
+        task.set_state(new_state);
+
+        // Write-through to store
+        if let Some(ref store) = self.store {
+            if let Ok(store) = store.lock() {
+                if let Err(e) = store.save_task(task) {
+                    tracing::error!(task_id = %task_id, error = %e, "failed to persist task state to store");
+                }
+            }
+        }
         Ok(())
     }
 

--- a/crates/supervisor/src/main.rs
+++ b/crates/supervisor/src/main.rs
@@ -171,6 +171,8 @@ async fn start_agent(
         .unwrap_or_else(|_| vec![
             "--print".to_string(),
             "--verbose".to_string(),
+            "--model".to_string(),
+            "claude-opus-4-5".to_string(),
             "--output-format".to_string(),
             "stream-json".to_string(),
             "--dangerously-skip-permissions".to_string(),

--- a/web/src/components/ui/toggle-group.tsx
+++ b/web/src/components/ui/toggle-group.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import * as React from "react"
+import { type VariantProps } from "class-variance-authority"
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        "w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10",
+        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/web/src/components/ui/toggle.tsx
+++ b/web/src/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Toggle as TogglePrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 min-w-9 px-2",
+        sm: "h-8 min-w-8 px-1.5",
+        lg: "h-10 min-w-10 px-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }

--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatRelativeTime } from "@/lib/utils";
 import { approveMerge, rejectMerge } from "@/lib/api";
-import type { MergeQueueEntry, MergeStatus } from "@/lib/types";
+import type { MergeQueueEntry, MergeStatus, Task } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // Status badge
@@ -43,14 +43,23 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
   {
     accessorKey: "task_id",
     header: "Task",
-    cell: ({ row }) => (
-      <Link
-        to={`/tasks/${row.original.task_id}`}
-        className="font-mono text-xs text-blue-400 hover:underline"
-      >
-        {row.original.task_id.slice(0, 8)}...
-      </Link>
-    ),
+    cell: ({ row, table }) => {
+      const tasks = (table.options.meta as { tasks?: Task[] })?.tasks ?? [];
+      const task = tasks.find((t) => t.id === row.original.task_id);
+      const source = task?.source;
+      const label =
+        source && (source.type === "github_issue" || source.type === "github_pr")
+          ? `#${source.number}`
+          : row.original.task_id.slice(0, 8);
+      return (
+        <Link
+          to={`/tasks/${row.original.task_id}`}
+          className="font-mono text-sm text-blue-400 hover:underline"
+        >
+          {label}
+        </Link>
+      );
+    },
   },
   {
     accessorKey: "pr_url",

--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -46,7 +46,7 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
     cell: ({ row }) => (
       <Link
         to={`/tasks/${row.original.task_id}`}
-        className="font-mono text-xs text-blue-600 hover:underline"
+        className="font-mono text-xs text-blue-400 hover:underline"
       >
         {row.original.task_id.slice(0, 8)}...
       </Link>
@@ -65,7 +65,7 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-blue-600 hover:underline text-xs"
+          className="inline-flex items-center gap-1 text-blue-400 hover:underline text-xs"
         >
           PR
           <ExternalLink className="h-3 w-3" />
@@ -108,11 +108,11 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
       }
 
       return (
-        <div className="flex items-center gap-1">
+        <div className="inline-flex items-center rounded-md border border-border">
           <Button
             variant="ghost"
             size="sm"
-            className="h-7 gap-1 text-green-600 hover:text-green-700 hover:bg-green-50"
+            className="h-7 gap-1 rounded-r-none border-r border-border"
             onClick={handleApprove}
           >
             <Check className="h-3.5 w-3.5" />
@@ -121,7 +121,7 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
           <Button
             variant="ghost"
             size="sm"
-            className="h-7 gap-1 text-red-600 hover:text-red-700 hover:bg-red-50"
+            className="h-7 gap-1 rounded-l-none"
             onClick={handleReject}
           >
             <X className="h-3.5 w-3.5" />

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -66,6 +66,7 @@ export function MergeQueuePage() {
     getPaginationRowModel: getPaginationRowModel(),
     meta: {
       refreshSnapshot,
+      tasks: snapshot?.tasks ?? [],
     },
   });
 


### PR DESCRIPTION
## Summary

Closes the gap between session lifecycle events and server state. Previously, when an agent completed a task, the session monitor published a `task:state:awaiting_merge` event but nothing updated the actual task state or populated the merge queue. Tasks showed as "running" forever and the merge queue stayed empty.

## Changes

### Event handler loop (`run_loop.rs`)
- New spawned task subscribes to the event bus and applies state changes from session events back into the server
- Uses `apply_task_state` (no re-publish) to avoid infinite event loops
- Creates merge queue entries when tasks reach `awaiting_merge`
- Handles broadcast lag gracefully with a warning

### Server (`server.rs`)
- Extract `apply_task_state` from `set_task_state` — updates state + persists to store without publishing an event
- `set_task_state` now delegates to `apply_task_state` then publishes

### Poll loop sync (`run_loop.rs`)
- Pollers rebuilt from live project list each tick — projects added via web UI work without restart

### Agent model (`supervisor/main.rs`)
- Default model set to `claude-opus-4-5`

## Spec alignment

Per spec Section 7.1, work enters the merge queue after quality evaluation. The orchestrator quality gate is not yet implemented, so for now tasks go directly to the queue on `awaiting_merge`. This is noted as a TODO for the orchestrator integration.

## Test plan
- [x] `cargo test --workspace` — 140 tests pass
- [x] `cargo check` clean