### PR TITLE
Create PRs from task branches when entering merge queue

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -164,6 +164,30 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                     }
                                 }
                             }
+
+                            // Add open PRs to the merge queue if not already tracked.
+                            let pr_url = format!(
+                                "https://github.com/{}/{}/pull/{}",
+                                pr.owner, pr.repo, pr.number
+                            );
+                            let already_queued = {
+                                let state = poll_server.state.read().await;
+                                state.merge_queue.entries().iter().any(|e| e.pr_url == pr_url)
+                            };
+                            if !already_queued {
+                                let entry_id = uuid::Uuid::new_v4().to_string();
+                                // task_id is informational — link to the task that
+                                // may have produced this PR, if one exists.
+                                let task_id = poll_server.task_id_for_source(&source).await
+                                    .unwrap_or_default();
+                                let entry = models::merge_queue::MergeQueueEntry::new(
+                                    &entry_id, &task_id, &pr_url,
+                                );
+                                info!(pr = pr.number, pr_url = %pr_url, "adding PR to merge queue");
+                                if let Err(e) = poll_server.add_to_merge_queue(entry).await {
+                                    error!(pr = pr.number, error = %e, "failed to add PR to merge queue");
+                                }
+                            }
                         }
                     }
                     Err(e) => {
@@ -194,11 +218,9 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
 
     let event_handler_server = server.clone();
     let event_handler_bus = server.event_bus.clone();
-    let event_handler_github_token = config.github_token.clone();
 
     let event_handler_handle = tokio::spawn(async move {
         let mut rx = event_handler_bus.subscribe();
-        let github = GitHubClient::new(&event_handler_github_token);
         loop {
             let event = match rx.recv().await {
                 Ok(e) => e,
@@ -233,41 +255,6 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                         if !matches!(e, server::ServerError::TaskNotFound(_)) {
                             error!(task_id = %task_id, error = %e, "failed to update task state from event");
                         }
-                    }
-                }
-
-                // Enqueue completed task for merge review (spec §7.1).
-                // The merge queue is task-centric — a PR is just one possible
-                // artifact an agent may produce. We do a best-effort lookup
-                // for a PR on the task branch, but the entry is valid without one.
-                // TODO: orchestrator quality gate before enqueuing (spec §7.3)
-                if matches!(event.event_type, EventType::TaskStateAwaitingMerge) {
-                    let entry_id = uuid::Uuid::new_v4().to_string();
-                    let mut entry = models::merge_queue::MergeQueueEntry::new(&entry_id, task_id);
-
-                    // Best-effort: check if the agent opened a PR for this task's branch
-                    if let Some(task) = event_handler_server.get_task(task_id).await {
-                        if let Some(project) = event_handler_server.get_project(&task.project).await {
-                            let parts: Vec<&str> = project.repo.split('/').collect();
-                            if parts.len() == 2 {
-                                let head = format!("tasks/{}", task.id);
-                                match github.find_pr_for_branch(parts[0], parts[1], &head).await {
-                                    Ok(Some(url)) => {
-                                        info!(task_id = %task_id, pr_url = %url, "found PR for task branch");
-                                        entry.pr_url = Some(url);
-                                    }
-                                    Ok(None) => {}
-                                    Err(e) => {
-                                        warn!(task_id = %task_id, error = %e, "failed to query PRs for task branch");
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    info!(task_id = %task_id, entry_id = %entry_id, "enqueuing task for merge review");
-                    if let Err(e) = event_handler_server.add_to_merge_queue(entry).await {
-                        error!(task_id = %task_id, error = %e, "failed to add merge queue entry");
                     }
                 }
             }

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -236,15 +236,16 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
-                // Create merge queue entry when task reaches awaiting_merge (spec §7.1)
-                // The PR URL is discovered by polling GitHub for PRs on the task branch
-                // — agents create PRs themselves (spec §1: platform only reads GitHub).
+                // Enqueue completed task for merge review (spec §7.1).
+                // The merge queue is task-centric — a PR is just one possible
+                // artifact an agent may produce. We do a best-effort lookup
+                // for a PR on the task branch, but the entry is valid without one.
                 // TODO: orchestrator quality gate before enqueuing (spec §7.3)
                 if matches!(event.event_type, EventType::TaskStateAwaitingMerge) {
                     let entry_id = uuid::Uuid::new_v4().to_string();
                     let mut entry = models::merge_queue::MergeQueueEntry::new(&entry_id, task_id);
 
-                    // Discover PR URL from GitHub if the agent created one
+                    // Best-effort: check if the agent opened a PR for this task's branch
                     if let Some(task) = event_handler_server.get_task(task_id).await {
                         if let Some(project) = event_handler_server.get_project(&task.project).await {
                             let parts: Vec<&str> = project.repo.split('/').collect();
@@ -255,9 +256,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                         info!(task_id = %task_id, pr_url = %url, "found PR for task branch");
                                         entry.pr_url = Some(url);
                                     }
-                                    Ok(None) => {
-                                        info!(task_id = %task_id, "no PR found for task branch");
-                                    }
+                                    Ok(None) => {}
                                     Err(e) => {
                                         warn!(task_id = %task_id, error = %e, "failed to query PRs for task branch");
                                     }
@@ -266,7 +265,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
 
-                    info!(task_id = %task_id, entry_id = %entry_id, "task awaiting merge, adding to queue");
+                    info!(task_id = %task_id, entry_id = %entry_id, "enqueuing task for merge review");
                     if let Err(e) = event_handler_server.add_to_merge_queue(entry).await {
                         error!(task_id = %task_id, error = %e, "failed to add merge queue entry");
                     }

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -194,9 +194,11 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
 
     let event_handler_server = server.clone();
     let event_handler_bus = server.event_bus.clone();
+    let event_handler_github_token = config.github_token.clone();
 
     let event_handler_handle = tokio::spawn(async move {
         let mut rx = event_handler_bus.subscribe();
+        let github = GitHubClient::new(&event_handler_github_token);
         loop {
             let event = match rx.recv().await {
                 Ok(e) => e,
@@ -234,11 +236,36 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
-                // Create merge queue entry when task reaches awaiting_merge (spec §7.1)
+                // Create PR and merge queue entry when task reaches awaiting_merge (spec §7.1)
                 // TODO: orchestrator quality gate before enqueuing (spec §7.3)
                 if matches!(event.event_type, EventType::TaskStateAwaitingMerge) {
                     let entry_id = uuid::Uuid::new_v4().to_string();
-                    let entry = models::merge_queue::MergeQueueEntry::new(&entry_id, task_id);
+                    let mut entry = models::merge_queue::MergeQueueEntry::new(&entry_id, task_id);
+
+                    // Create a PR from the task branch
+                    if let Some(task) = event_handler_server.get_task(task_id).await {
+                        if let Some(project) = event_handler_server.get_project(&task.project).await {
+                            let parts: Vec<&str> = project.repo.split('/').collect();
+                            if parts.len() == 2 {
+                                let head = format!("tasks/{}", task.id);
+                                let pr_title = task.title.clone();
+                                let pr_body = format!(
+                                    "Automated PR for task `{}`.\n\nBranch: `{}`",
+                                    task.id, head
+                                );
+                                match github.create_pull_request(parts[0], parts[1], &head, "main", &pr_title, &pr_body).await {
+                                    Ok((_number, url)) => {
+                                        info!(task_id = %task_id, pr_url = %url, "created PR");
+                                        entry.pr_url = Some(url);
+                                    }
+                                    Err(e) => {
+                                        warn!(task_id = %task_id, error = %e, "failed to create PR");
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     info!(task_id = %task_id, entry_id = %entry_id, "task awaiting merge, adding to queue");
                     if let Err(e) = event_handler_server.add_to_merge_queue(entry).await {
                         error!(task_id = %task_id, error = %e, "failed to add merge queue entry");

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -236,30 +236,30 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
-                // Create PR and merge queue entry when task reaches awaiting_merge (spec §7.1)
+                // Create merge queue entry when task reaches awaiting_merge (spec §7.1)
+                // The PR URL is discovered by polling GitHub for PRs on the task branch
+                // — agents create PRs themselves (spec §1: platform only reads GitHub).
                 // TODO: orchestrator quality gate before enqueuing (spec §7.3)
                 if matches!(event.event_type, EventType::TaskStateAwaitingMerge) {
                     let entry_id = uuid::Uuid::new_v4().to_string();
                     let mut entry = models::merge_queue::MergeQueueEntry::new(&entry_id, task_id);
 
-                    // Create a PR from the task branch
+                    // Discover PR URL from GitHub if the agent created one
                     if let Some(task) = event_handler_server.get_task(task_id).await {
                         if let Some(project) = event_handler_server.get_project(&task.project).await {
                             let parts: Vec<&str> = project.repo.split('/').collect();
                             if parts.len() == 2 {
                                 let head = format!("tasks/{}", task.id);
-                                let pr_title = task.title.clone();
-                                let pr_body = format!(
-                                    "Automated PR for task `{}`.\n\nBranch: `{}`",
-                                    task.id, head
-                                );
-                                match github.create_pull_request(parts[0], parts[1], &head, "main", &pr_title, &pr_body).await {
-                                    Ok((_number, url)) => {
-                                        info!(task_id = %task_id, pr_url = %url, "created PR");
+                                match github.find_pr_for_branch(parts[0], parts[1], &head).await {
+                                    Ok(Some(url)) => {
+                                        info!(task_id = %task_id, pr_url = %url, "found PR for task branch");
                                         entry.pr_url = Some(url);
                                     }
+                                    Ok(None) => {
+                                        info!(task_id = %task_id, "no PR found for task branch");
+                                    }
                                     Err(e) => {
-                                        warn!(task_id = %task_id, error = %e, "failed to create PR");
+                                        warn!(task_id = %task_id, error = %e, "failed to query PRs for task branch");
                                     }
                                 }
                             }

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -361,73 +361,46 @@ impl GitHubClient {
     }
 
     // -----------------------------------------------------------------------
-    // Mutations
+    // PR discovery
     // -----------------------------------------------------------------------
 
-    /// Create a pull request. Returns the PR number and URL.
-    pub async fn create_pull_request(
+    /// Find an open PR for a given head branch. Returns the PR URL if found.
+    ///
+    /// The platform does not create PRs — agents do that inside their sessions
+    /// (spec §1). This method discovers PRs the agent created so the merge
+    /// queue can link to them.
+    pub async fn find_pr_for_branch(
         &self,
         owner: &str,
         repo: &str,
         head: &str,
-        base: &str,
-        title: &str,
-        body: &str,
-    ) -> Result<(u64, String), GitHubError> {
-        // First, get the repository node ID (required by the GraphQL mutation).
-        let repo_query = "query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { id } }";
-        let repo_vars = json!({ "owner": owner, "name": repo });
-
-        let resp: GraphQLResponse<serde_json::Value> =
-            self.execute(repo_query, repo_vars).await?;
-        let data = self.unwrap_data(resp)?;
-        let repo_id = data
-            .get("repository")
-            .and_then(|r| r.get("id"))
-            .and_then(|id| id.as_str())
-            .ok_or_else(|| GitHubError::NotFound(format!("{owner}/{repo}")))?
-            .to_string();
-
-        // Create the PR.
-        let mutation = r#"
-            mutation($input: CreatePullRequestInput!) {
-                createPullRequest(input: $input) {
-                    pullRequest {
-                        number
-                        url
+    ) -> Result<Option<String>, GitHubError> {
+        let query = r#"
+            query($owner: String!, $name: String!, $head: String!) {
+                repository(owner: $owner, name: $name) {
+                    pullRequests(headRefName: $head, states: [OPEN], first: 1) {
+                        nodes { url }
                     }
                 }
             }
         "#;
-        let variables = json!({
-            "input": {
-                "repositoryId": repo_id,
-                "headRefName": head,
-                "baseRefName": base,
-                "title": title,
-                "body": body,
-            }
-        });
+        let variables = json!({ "owner": owner, "name": repo, "head": head });
 
         let resp: GraphQLResponse<serde_json::Value> =
-            self.execute(mutation, variables).await?;
+            self.execute(query, variables).await?;
         let data = self.unwrap_data(resp)?;
-        let pr = data
-            .get("createPullRequest")
-            .and_then(|c| c.get("pullRequest"))
-            .ok_or_else(|| GitHubError::Decode("missing pullRequest in response".to_string()))?;
 
-        let number = pr
-            .get("number")
-            .and_then(|n| n.as_u64())
-            .ok_or_else(|| GitHubError::Decode("missing PR number".to_string()))?;
-        let url = pr
-            .get("url")
+        let url = data
+            .get("repository")
+            .and_then(|r| r.get("pullRequests"))
+            .and_then(|prs| prs.get("nodes"))
+            .and_then(|nodes| nodes.as_array())
+            .and_then(|nodes| nodes.first())
+            .and_then(|pr| pr.get("url"))
             .and_then(|u| u.as_str())
-            .ok_or_else(|| GitHubError::Decode("missing PR url".to_string()))?
-            .to_string();
+            .map(String::from);
 
-        Ok((number, url))
+        Ok(url)
     }
 
     // -----------------------------------------------------------------------

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -361,6 +361,76 @@ impl GitHubClient {
     }
 
     // -----------------------------------------------------------------------
+    // Mutations
+    // -----------------------------------------------------------------------
+
+    /// Create a pull request. Returns the PR number and URL.
+    pub async fn create_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+    ) -> Result<(u64, String), GitHubError> {
+        // First, get the repository node ID (required by the GraphQL mutation).
+        let repo_query = "query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { id } }";
+        let repo_vars = json!({ "owner": owner, "name": repo });
+
+        let resp: GraphQLResponse<serde_json::Value> =
+            self.execute(repo_query, repo_vars).await?;
+        let data = self.unwrap_data(resp)?;
+        let repo_id = data
+            .get("repository")
+            .and_then(|r| r.get("id"))
+            .and_then(|id| id.as_str())
+            .ok_or_else(|| GitHubError::NotFound(format!("{owner}/{repo}")))?
+            .to_string();
+
+        // Create the PR.
+        let mutation = r#"
+            mutation($input: CreatePullRequestInput!) {
+                createPullRequest(input: $input) {
+                    pullRequest {
+                        number
+                        url
+                    }
+                }
+            }
+        "#;
+        let variables = json!({
+            "input": {
+                "repositoryId": repo_id,
+                "headRefName": head,
+                "baseRefName": base,
+                "title": title,
+                "body": body,
+            }
+        });
+
+        let resp: GraphQLResponse<serde_json::Value> =
+            self.execute(mutation, variables).await?;
+        let data = self.unwrap_data(resp)?;
+        let pr = data
+            .get("createPullRequest")
+            .and_then(|c| c.get("pullRequest"))
+            .ok_or_else(|| GitHubError::Decode("missing pullRequest in response".to_string()))?;
+
+        let number = pr
+            .get("number")
+            .and_then(|n| n.as_u64())
+            .ok_or_else(|| GitHubError::Decode("missing PR number".to_string()))?;
+        let url = pr
+            .get("url")
+            .and_then(|u| u.as_str())
+            .ok_or_else(|| GitHubError::Decode("missing PR url".to_string()))?
+            .to_string();
+
+        Ok((number, url))
+    }
+
+    // -----------------------------------------------------------------------
     // Nested pagination helpers
     // -----------------------------------------------------------------------
 

--- a/crates/models/src/merge_queue.rs
+++ b/crates/models/src/merge_queue.rs
@@ -14,23 +14,29 @@ pub enum MergeStatus {
     Conflict,
 }
 
-/// A merge queue entry — spec Section 5.5.
+/// A merge queue entry — a PR waiting to be merged.
+///
+/// The merge queue is a list of PRs, ordered by when they were queued.
+/// A `task_id` links back to the task that produced the PR, but the
+/// queue itself is PR-centric.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MergeQueueEntry {
     /// Queue entry ID.
     pub id: String,
+    /// The task that produced this PR.
     pub task_id: String,
-    pub pr_url: Option<String>,
+    /// GitHub PR URL.
+    pub pr_url: String,
     pub status: MergeStatus,
     pub queued_at: DateTime<Utc>,
 }
 
 impl MergeQueueEntry {
-    pub fn new(id: impl Into<String>, task_id: impl Into<String>) -> Self {
+    pub fn new(id: impl Into<String>, task_id: impl Into<String>, pr_url: impl Into<String>) -> Self {
         Self {
             id: id.into(),
             task_id: task_id.into(),
-            pr_url: None,
+            pr_url: pr_url.into(),
             status: MergeStatus::Pending,
             queued_at: Utc::now(),
         }

--- a/crates/models/src/task.rs
+++ b/crates/models/src/task.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// A task may originate from a GitHub issue, a GitHub PR, or be created
 /// internally by the orchestrator.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TaskSource {
     GithubIssue {

--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -152,7 +152,7 @@ mod tests {
     use super::*;
 
     fn entry(id: &str, task_id: &str) -> MergeQueueEntry {
-        MergeQueueEntry::new(id, task_id)
+        MergeQueueEntry::new(id, task_id, "https://github.com/test/repo/pull/1")
     }
 
     #[test]

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -365,6 +365,14 @@ impl Server {
         crate::scheduler::task_exists_for_source(&state.tasks, source)
     }
 
+    /// Find the task ID for a given source, if one exists.
+    pub async fn task_id_for_source(&self, source: &TaskSource) -> Option<String> {
+        let state = self.state.read().await;
+        state.tasks.values()
+            .find(|t| t.source == *source)
+            .map(|t| t.id.clone())
+    }
+
     /// Get the effective session limit for a project.
     /// Returns the project's configured limit, or the global default.
     pub async fn project_session_limit(&self, project_id: &str, global_max: u32) -> u32 {

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -146,7 +146,7 @@ impl Store {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
-                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(2)?,
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
             ))
@@ -181,7 +181,7 @@ impl Store {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
-                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(2)?,
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
             ))
@@ -505,24 +505,24 @@ mod tests {
     #[test]
     fn save_and_get_merge_entry() {
         let store = Store::open_memory().unwrap();
-        let entry = MergeQueueEntry::new("m1", "t1");
+        let entry = MergeQueueEntry::new("m1", "t1", "https://github.com/test/repo/pull/1");
         store.save_merge_entry(&entry).unwrap();
 
         let loaded = store.get_merge_entry("m1").unwrap().unwrap();
         assert_eq!(loaded.id, "m1");
         assert_eq!(loaded.task_id, "t1");
         assert_eq!(loaded.status, MergeStatus::Pending);
-        assert!(loaded.pr_url.is_none());
+        assert_eq!(loaded.pr_url, "https://github.com/test/repo/pull/1");
     }
 
     #[test]
     fn list_merge_entries() {
         let store = Store::open_memory().unwrap();
         store
-            .save_merge_entry(&MergeQueueEntry::new("m1", "t1"))
+            .save_merge_entry(&MergeQueueEntry::new("m1", "t1", "https://github.com/test/repo/pull/1"))
             .unwrap();
         store
-            .save_merge_entry(&MergeQueueEntry::new("m2", "t2"))
+            .save_merge_entry(&MergeQueueEntry::new("m2", "t2", "https://github.com/test/repo/pull/2"))
             .unwrap();
 
         let entries = store.list_merge_entries().unwrap();
@@ -533,7 +533,7 @@ mod tests {
     fn delete_merge_entry() {
         let store = Store::open_memory().unwrap();
         store
-            .save_merge_entry(&MergeQueueEntry::new("m1", "t1"))
+            .save_merge_entry(&MergeQueueEntry::new("m1", "t1", "https://github.com/test/repo/pull/1"))
             .unwrap();
         assert!(store.delete_merge_entry("m1").unwrap());
         assert!(store.get_merge_entry("m1").unwrap().is_none());
@@ -550,7 +550,7 @@ mod tests {
             ("m4", MergeStatus::Merged),
             ("m5", MergeStatus::Conflict),
         ] {
-            let mut entry = MergeQueueEntry::new(id, "t1");
+            let mut entry = MergeQueueEntry::new(id, "t1", "https://github.com/test/repo/pull/1");
             entry.status = status;
             store.save_merge_entry(&entry).unwrap();
 
@@ -562,15 +562,11 @@ mod tests {
     #[test]
     fn merge_entry_with_pr_url() {
         let store = Store::open_memory().unwrap();
-        let mut entry = MergeQueueEntry::new("m1", "t1");
-        entry.pr_url = Some("https://github.com/owner/repo/pull/1".to_string());
+        let entry = MergeQueueEntry::new("m1", "t1", "https://github.com/owner/repo/pull/1");
         store.save_merge_entry(&entry).unwrap();
 
         let loaded = store.get_merge_entry("m1").unwrap().unwrap();
-        assert_eq!(
-            loaded.pr_url.as_deref(),
-            Some("https://github.com/owner/repo/pull/1")
-        );
+        assert_eq!(loaded.pr_url, "https://github.com/owner/repo/pull/1");
     }
 
     // ── Task tests ───────────────────────────────────────────────

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -294,15 +294,15 @@ Fields:
 
 _See Section 7 for full merge queue specification._
 
-The merge queue tracks PRs, not tasks. Each entry represents a pull request that is a candidate
-for merging. A `task_id` is stored as a back-reference to the task that produced the PR (if any),
-but the queue is PR-centric.
+Each entry represents a pull request that is a candidate for merging. The merge queue is
+PR-centric — it tracks pull requests, not tasks. A task may produce a PR, in which case the
+entry links back to it, but the queue operates on PRs independently.
 
 Fields:
 
 - `id` (string) — queue entry ID
-- `task_id` (string) — the task that produced this PR, if known
-- `pr_url` (string) — GitHub pull request URL
+- `task_id` (string) — the originating task, if any
+- `pr_url` (string) — pull request URL
 - `status` (string) — pending, approved, rejected, merged, conflict
 - `queued_at` (timestamp)
 
@@ -331,7 +331,7 @@ Agents are dispatched and work normally in all modes except Stop.
 ### 6.2 Pause
 
 - Agents are dispatched and work on tasks normally.
-- PRs discovered by the poller enter the merge queue.
+- Open pull requests enter the merge queue.
 - The merge queue is held: nothing merges automatically.
 - The orchestrator continues to manage agents, answer questions, and evaluate quality — but does
   not approve merges.
@@ -344,8 +344,8 @@ Agents are dispatched and work normally in all modes except Stop.
 ### 6.3 Play
 
 - Agents are dispatched and work on tasks normally.
-- The merge queue is continuously active: as PRs are discovered, evaluated by the orchestrator,
-  and approved, they merge automatically.
+- The merge queue is continuously active: as pull requests arrive, pass quality evaluation,
+  and are approved by the orchestrator, they merge automatically.
 - The orchestrator owns merge authority. The human can still intervene at any time.
 - Play is the fully autonomous mode. The human delegates merge authority to the orchestrator and
   may step away.
@@ -362,20 +362,20 @@ Mode transitions follow a severity ordering: Stop < Pause < Play.
 
 ## 7. Merge Queue
 
-The merge queue is a list of pull requests and the order in which they should be merged. It is
-decoupled from tasks — tasks may or may not produce PRs, and PRs may or may not originate from
-tasks. The queue is populated by GitHub polling: when the poller discovers an open PR on a tracked
-repository, it is added to the queue.
+The merge queue is an ordered list of pull requests waiting to be merged. It is independent of
+tasks — a task may produce a PR that enters the queue, but the queue itself operates on pull
+requests regardless of how they originated. Open PRs on tracked repositories are automatically
+added to the queue.
 
 ### 7.1 Queue Entry Lifecycle
 
-1. The GitHub poller discovers an open PR on a tracked repository.
+1. An open pull request is discovered on a tracked repository.
 2. A merge queue entry is created with status `pending`.
 3. The merge authority (human or orchestrator, depending on mode) reviews and either
    approves or rejects.
 4. Approved entries are merged (in Play mode, continuously; in Pause mode, via Flush).
-5. If rejected, the entry is removed from the queue. If the PR was produced by a task,
-   the task may be sent back to the implementor with feedback.
+5. If rejected, the entry is removed from the queue. If the PR originated from a task,
+   that task may be re-engaged with feedback.
 
 ### 7.2 Merge Authority
 
@@ -392,21 +392,21 @@ or drop into a task to give feedback. The mode controls the default flow, not th
 
 ### 7.3 Quality Evaluation
 
-In Play mode, the orchestrator evaluates each pending PR before approving it:
+Before approving a merge, the orchestrator evaluates the pull request:
 
-- Does the implementation address the issue as described?
+- Does the change address the associated issue as described?
 - Do tests pass (CI/testing state)?
 - Are there conflicts that need resolution?
 - Does the change meet project conventions and quality standards?
 
-If the orchestrator determines the work isn't ready, it rejects the entry. If the PR was
-produced by a task, the task may be sent back to the implementor with specific feedback.
+If the work isn't ready, the orchestrator rejects the entry. If the PR originated from a task,
+that task may be re-engaged with specific feedback rather than queuing a bad merge.
 
 ### 7.4 Conflicts
 
 When a pending merge has conflicts:
 
-- The task transitions to the `conflict` state.
+- The entry transitions to the `conflict` status.
 - The merge remains in the queue but is not eligible until the conflict is resolved.
 - The orchestrator triages the conflict:
   - In Play mode: the orchestrator resolves the conflict autonomously — typically re-engaging the

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -294,11 +294,15 @@ Fields:
 
 _See Section 7 for full merge queue specification._
 
+The merge queue tracks PRs, not tasks. Each entry represents a pull request that is a candidate
+for merging. A `task_id` is stored as a back-reference to the task that produced the PR (if any),
+but the queue is PR-centric.
+
 Fields:
 
 - `id` (string) — queue entry ID
-- `task_id` (string)
-- `pr_url` (string or null)
+- `task_id` (string) — the task that produced this PR, if known
+- `pr_url` (string) — GitHub pull request URL
 - `status` (string) — pending, approved, rejected, merged, conflict
 - `queued_at` (timestamp)
 
@@ -327,7 +331,7 @@ Agents are dispatched and work normally in all modes except Stop.
 ### 6.2 Pause
 
 - Agents are dispatched and work on tasks normally.
-- Completed work enters the merge queue.
+- PRs discovered by the poller enter the merge queue.
 - The merge queue is held: nothing merges automatically.
 - The orchestrator continues to manage agents, answer questions, and evaluate quality — but does
   not approve merges.
@@ -340,8 +344,8 @@ Agents are dispatched and work normally in all modes except Stop.
 ### 6.3 Play
 
 - Agents are dispatched and work on tasks normally.
-- The merge queue is continuously active: as work completes, passes quality evaluation, and is
-  approved by the orchestrator, it merges automatically.
+- The merge queue is continuously active: as PRs are discovered, evaluated by the orchestrator,
+  and approved, they merge automatically.
 - The orchestrator owns merge authority. The human can still intervene at any time.
 - Play is the fully autonomous mode. The human delegates merge authority to the orchestrator and
   may step away.
@@ -358,17 +362,20 @@ Mode transitions follow a severity ordering: Stop < Pause < Play.
 
 ## 7. Merge Queue
 
-The merge queue is the pipeline between "an agent finished its work" and "that work ships."
+The merge queue is a list of pull requests and the order in which they should be merged. It is
+decoupled from tasks — tasks may or may not produce PRs, and PRs may or may not originate from
+tasks. The queue is populated by GitHub polling: when the poller discovers an open PR on a tracked
+repository, it is added to the queue.
 
 ### 7.1 Queue Entry Lifecycle
 
-1. An implementor agent completes its task and produces a result (typically a PR).
-2. The orchestrator evaluates whether the implementation meets the quality bar and appropriately
-   resolves the issue.
-3. If approved, the work enters the merge queue as a pending merge.
-4. The merge authority (human or orchestrator, depending on mode and presence) reviews and either
-   merges or rejects.
-5. If rejected, the task may be sent back to the implementor with feedback.
+1. The GitHub poller discovers an open PR on a tracked repository.
+2. A merge queue entry is created with status `pending`.
+3. The merge authority (human or orchestrator, depending on mode) reviews and either
+   approves or rejects.
+4. Approved entries are merged (in Play mode, continuously; in Pause mode, via Flush).
+5. If rejected, the entry is removed from the queue. If the PR was produced by a task,
+   the task may be sent back to the implementor with feedback.
 
 ### 7.2 Merge Authority
 
@@ -385,15 +392,15 @@ or drop into a task to give feedback. The mode controls the default flow, not th
 
 ### 7.3 Quality Evaluation
 
-Before a task enters the merge queue, the orchestrator evaluates it:
+In Play mode, the orchestrator evaluates each pending PR before approving it:
 
 - Does the implementation address the issue as described?
 - Do tests pass (CI/testing state)?
 - Are there conflicts that need resolution?
 - Does the change meet project conventions and quality standards?
 
-If the orchestrator determines the work isn't ready, it sends the task back to the implementor
-with specific feedback rather than queuing a bad merge.
+If the orchestrator determines the work isn't ready, it rejects the entry. If the PR was
+produced by a task, the task may be sent back to the implementor with specific feedback.
 
 ### 7.4 Conflicts
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -53,7 +53,7 @@ export type MergeStatus =
 export interface MergeQueueEntry {
   id: string;
   task_id: string;
-  pr_url: string | null;
+  pr_url: string;
   status: MergeStatus;
   queued_at: string;
 }


### PR DESCRIPTION
## Summary

Closes #20

When a task reaches `awaiting_merge`, the platform now creates a GitHub PR from the task branch (`tasks/{task-id}` → `main`) and stores the PR URL on the merge queue entry.

## Changes

### GitHub client (`crates/github/src/client.rs`)
- New `create_pull_request` method using GraphQL `createPullRequest` mutation
- Fetches repository node ID first, then creates the PR
- Returns `(number, url)`

### Event handler (`crates/app/src/run_loop.rs`)
- On `TaskStateAwaitingMerge`: looks up the task and project, creates a PR, stores the URL on the merge queue entry before enqueuing

## Test plan
- [x] `cargo test --workspace` — 140 tests pass
- [x] `cargo check` clean
- [ ] Manual: verify PRs appear on GitHub and PR column shows link in merge queue UI