### PR TITLE
Sort tasks list by state by default

### DIFF
--- a/web/src/pages/tasks/columns.tsx
+++ b/web/src/pages/tasks/columns.tsx
@@ -42,6 +42,20 @@ export interface TaskStateMeta {
   className: string;
 }
 
+// State priority for sorting (lower number = higher priority / shown first)
+export const stateSortOrder: Record<TaskState, number> = {
+  awaiting_merge: 0,
+  running: 1,
+  question: 2,
+  conflict: 3,
+  testing: 4,
+  waiting: 5,
+  blocked: 6,
+  completed: 7,
+  failed: 8,
+  cancelled: 9,
+};
+
 export const taskStateMeta: Record<TaskState, TaskStateMeta> = {
   waiting: {
     label: "Waiting",
@@ -209,6 +223,11 @@ export const columns: ColumnDef<Task>[] = [
     },
     filterFn: (row, id, value: string[]) => {
       return value.includes(row.getValue(id));
+    },
+    sortingFn: (rowA, rowB) => {
+      const a = stateSortOrder[rowA.getValue<TaskState>("state")] ?? 999;
+      const b = stateSortOrder[rowB.getValue<TaskState>("state")] ?? 999;
+      return a - b;
     },
   },
 

--- a/web/src/pages/tasks/data-table.tsx
+++ b/web/src/pages/tasks/data-table.tsx
@@ -35,7 +35,9 @@ export function DataTable<TData extends Task, TValue>({
   columns,
   data,
 }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "state", desc: false },
+  ]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [rowSelection, setRowSelection] = useState({});
 


### PR DESCRIPTION
## Summary
- Add default sorting to the tasks table by state, showing highest priority states first
- State priority order: awaiting_merge > running > question > conflict > testing > waiting > blocked > completed > failed > cancelled
- Active/actionable states appear at the top, terminal states at the bottom

## Test plan
- [ ] Open the tasks page and verify tasks are sorted by state by default
- [ ] Verify awaiting_merge, running, and question tasks appear before waiting/blocked tasks
- [ ] Verify clicking the state column header still allows manual sort toggling

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)