### PR TITLE
Sort tasks table by state by default

### DIFF
--- a/web/src/pages/tasks/columns.tsx
+++ b/web/src/pages/tasks/columns.tsx
@@ -42,6 +42,21 @@ export interface TaskStateMeta {
   className: string;
 }
 
+// State priority for sorting (lower number = higher priority, appears first)
+// Active/actionable states at top, terminal states at bottom
+export const taskStatePriority: Record<TaskState, number> = {
+  awaiting_merge: 0,
+  running: 1,
+  question: 2,
+  conflict: 3,
+  testing: 4,
+  waiting: 5,
+  blocked: 6,
+  completed: 7,
+  failed: 8,
+  cancelled: 9,
+};
+
 export const taskStateMeta: Record<TaskState, TaskStateMeta> = {
   waiting: {
     label: "Waiting",
@@ -209,6 +224,11 @@ export const columns: ColumnDef<Task>[] = [
     },
     filterFn: (row, id, value: string[]) => {
       return value.includes(row.getValue(id));
+    },
+    sortingFn: (rowA, rowB) => {
+      const stateA = rowA.getValue<TaskState>("state");
+      const stateB = rowB.getValue<TaskState>("state");
+      return taskStatePriority[stateA] - taskStatePriority[stateB];
     },
   },
 

--- a/web/src/pages/tasks/data-table.tsx
+++ b/web/src/pages/tasks/data-table.tsx
@@ -35,7 +35,9 @@ export function DataTable<TData extends Task, TValue>({
   columns,
   data,
 }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "state", desc: false },
+  ]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [rowSelection, setRowSelection] = useState({});
 


### PR DESCRIPTION
## Summary
- Add default sorting to the tasks table by state, showing highest priority states first
- State priority order: awaiting_merge > running > question > conflict > testing > waiting > blocked > completed > failed > cancelled
- Active/actionable states appear at the top, terminal states at the bottom

## Changes
- Added `taskStatePriority` mapping in `columns.tsx` defining sort order for each state
- Added `sortingFn` to the state column to use custom priority-based sorting
- Set default sorting state in `data-table.tsx` to sort by state ascending

## Test plan
- [ ] Open the tasks page and verify tasks are sorted by state by default
- [ ] Verify awaiting_merge, running, and question tasks appear before waiting/blocked tasks
- [ ] Verify clicking the state column header still allows manual sort toggling

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)