### PR TITLE
Fix cargo not found in containers, add 8G memory default

### DIFF
--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -16,6 +16,8 @@ pub struct AppConfig {
     pub dispatch_interval: Duration,
     /// Container image for sessions.
     pub container_image: String,
+    /// Container memory limit (default: 8G).
+    pub container_memory: String,
     /// Session soft time limit (default: 1h).
     pub session_soft_limit: Duration,
     /// Session hard time limit (default: 1h15m).
@@ -44,6 +46,9 @@ impl AppConfig {
         let container_image = std::env::var("TASKS_CONTAINER_IMAGE")
             .unwrap_or_else(|_| "tasks-agent:latest".to_string());
 
+        let container_memory = std::env::var("TASKS_CONTAINER_MEMORY")
+            .unwrap_or_else(|_| "8G".to_string());
+
         let max_sessions = std::env::var("TASKS_MAX_SESSIONS")
             .ok()
             .and_then(|s| s.parse().ok())
@@ -66,6 +71,7 @@ impl AppConfig {
             poll_interval: Duration::from_secs(poll_interval_secs),
             dispatch_interval: Duration::from_secs(dispatch_interval_secs),
             container_image,
+            container_memory,
             session_soft_limit: Duration::from_secs(3600),
             session_hard_limit: Duration::from_secs(4500),
             tui: false, // set by CLI flag

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -27,6 +27,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         poll_interval = ?config.poll_interval,
         dispatch_interval = ?config.dispatch_interval,
         container_image = %config.container_image,
+        container_memory = %config.container_memory,
         "starting tasks platform"
     );
 
@@ -53,8 +54,9 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // --- 3. Create session manager ---
 
     let container_runtime = AppleContainerRuntime::new();
-    let mut default_container_config =
-        ContainerConfig::new(&config.container_image).env("GITHUB_TOKEN", &config.github_token);
+    let mut default_container_config = ContainerConfig::new(&config.container_image)
+        .env("GITHUB_TOKEN", &config.github_token)
+        .memory(&config.container_memory);
     if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
         default_container_config = default_container_config.env("ANTHROPIC_API_KEY", key);
     }

--- a/src/runtime/Dockerfile
+++ b/src/runtime/Dockerfile
@@ -69,7 +69,8 @@ RUN npm install -g @anthropic-ai/claude-code
 # Create non-root user (Claude Code refuses --dangerously-skip-permissions as root)
 RUN useradd -m -s /bin/bash agent && \
     echo 'agent ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-    echo 'Defaults env_keep += "ANTHROPIC_API_KEY GITHUB_TOKEN AGENT_CMD AGENT_ARGS"' >> /etc/sudoers
+    echo 'Defaults env_keep += "ANTHROPIC_API_KEY GITHUB_TOKEN AGENT_CMD AGENT_ARGS"' >> /etc/sudoers && \
+    echo 'Defaults secure_path="/home/agent/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' >> /etc/sudoers
 
 # Rust (minimal profile — for Rust-based projects the agent works on)
 RUN su agent -c 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal'


### PR DESCRIPTION
## Summary

- **cargo: command not found** — Rust is installed under `/home/agent/.cargo/bin` but `sudo`'s `secure_path` didn't include it. When the supervisor runs the agent via `sudo --preserve-env -u agent`, PATH gets reset. Added cargo's bin dir to `secure_path` in sudoers.
- **OOM during cargo build** — No memory limit was configured, so containers got the `apple/container` default. Rust compilation needs more headroom. Now defaults to 8G, configurable via `TASKS_CONTAINER_MEMORY` env var.

These two issues explain why most Rust-related tasks were either failing with `cargo: command not found` (exit 127) or crashing mid-compilation.

## Test plan

- [ ] Rebuild container image: `container build --dns 8.8.8.8 -f src/runtime/Dockerfile -t tasks-agent:latest .`
- [ ] Run a task that requires `cargo build` — should find cargo and have enough memory to compile
- [ ] Verify startup log shows `container_memory=8G`