### PR TITLE
Add task cancel button to session UI

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -43,6 +43,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/tasks/{id}", get(get_task))
         .route("/tasks/{id}/events", get(get_task_events))
         .route("/tasks/{id}/chat", post(send_chat))
+        .route("/tasks/{id}/cancel", post(cancel_task))
         .route("/projects", get(list_projects))
         .route("/projects", post(add_project))
         .route("/projects/{id}", axum::routing::delete(delete_project))
@@ -287,6 +288,21 @@ async fn send_chat(
         .as_ref()
         .ok_or_else(|| ApiError::SessionManager("session manager not available".into()))?;
     sm.send_chat(&id, req.message)
+        .await
+        .map_err(|e| ApiError::SessionManager(e.to_string()))?;
+    Ok(StatusCode::OK)
+}
+
+/// POST /api/tasks/:id/cancel — Stop a running session (spec §9.5).
+async fn cancel_task(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let sm = state
+        .session_manager
+        .as_ref()
+        .ok_or_else(|| ApiError::SessionManager("session manager not available".into()))?;
+    sm.stop_session(&id)
         .await
         .map_err(|e| ApiError::SessionManager(e.to_string()))?;
     Ok(StatusCode::OK)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -90,6 +90,10 @@ export function sendChat(taskId: string, message: string): Promise<void> {
   });
 }
 
+export function cancelTask(taskId: string): Promise<void> {
+  return requestVoid(`/api/tasks/${taskId}/cancel`, { method: "POST" });
+}
+
 export function subscribeEvents(opts?: {
   pattern?: string;
   task_id?: string;

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -8,11 +8,12 @@ import {
   ChevronRight,
   FileText,
   Terminal,
+  StopCircle,
 } from "lucide-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useAppState } from "@/hooks/use-app-state";
-import { fetchTaskEvents, sendChat, subscribeEvents } from "@/lib/api";
+import { cancelTask, fetchTaskEvents, sendChat, subscribeEvents } from "@/lib/api";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -415,6 +416,7 @@ export function TaskDetailPage() {
   const [events, setEvents] = useState<Event[]>([]);
   const [eventsLoading, setEventsLoading] = useState(true);
   const [showDetails, setShowDetails] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
 
   const task = snapshot?.tasks.find((t) => t.id === id);
 
@@ -422,6 +424,18 @@ export function TaskDetailPage() {
     task?.state === "running" ||
     task?.state === "question" ||
     task?.state === "testing";
+
+  const handleCancel = useCallback(async () => {
+    if (!id || cancelling) return;
+    setCancelling(true);
+    try {
+      await cancelTask(id);
+    } catch {
+      // Error will be reflected in task state change via SSE
+    } finally {
+      setCancelling(false);
+    }
+  }, [id, cancelling]);
 
   useEffect(() => {
     if (!id) return;
@@ -473,6 +487,18 @@ export function TaskDetailPage() {
           <div className="flex items-center gap-2">
             <h1 className="text-xl font-bold truncate">{task.title}</h1>
             {stateBadge(task.state)}
+            {isSessionActive && (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleCancel}
+                disabled={cancelling}
+                className="ml-2 gap-1"
+              >
+                <StopCircle className="h-4 w-4" />
+                {cancelling ? "Cancelling..." : "Cancel"}
+              </Button>
+            )}
           </div>
           <div className="flex items-center gap-3 mt-1 text-sm text-muted-foreground">
             <span className="font-mono text-xs">{task.id.slice(0, 8)}</span>


### PR DESCRIPTION
## Summary

- Adds `POST /api/tasks/{id}/cancel` endpoint that calls `SessionManager::stop_session()` to gracefully stop a running agent session
- Adds `cancelTask()` function to the frontend API client
- Adds a "Cancel" button in the task detail header that appears when a session is active (running, question, or testing states)

The infrastructure for stopping sessions was already in place (`SessionManager::stop_session()`, `SessionCommand::Stop`, etc.), this PR exposes it via the HTTP API and adds the UI button.

## Test plan

- [ ] Start a task and verify the Cancel button appears in the task detail view
- [ ] Click Cancel and verify the session stops gracefully
- [ ] Verify the button disappears after cancellation
- [ ] Verify the button shows "Cancelling..." state while the request is in progress

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)