### PR TITLE
Implement retry logic for failed agent sessions (spec §18.2)

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -184,6 +184,9 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     let event_handler_server = server.clone();
     let event_handler_bus = server.event_bus.clone();
 
+    // Default max_retries from workflow config (spec §14.1).
+    const DEFAULT_MAX_RETRIES: u32 = 3;
+
     let event_handler_handle = tokio::spawn(async move {
         let mut rx = event_handler_bus.subscribe();
         loop {
@@ -197,6 +200,28 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
             };
 
             let task_id = &event.task;
+
+            // Handle agent:exit events — apply retry logic per spec §13.2, §18.2.
+            if event.event_type == EventType::AgentExit {
+                let exit_code = event.data.get("exit_code").and_then(|v| v.as_i64()).map(|v| v as i32);
+                let signal = event.data.get("signal").and_then(|v| v.as_i64()).map(|v| v as i32);
+                let made_progress = event.data.get("made_progress").and_then(|v| v.as_bool()).unwrap_or(false);
+
+                // TODO: Get max_retries from project's workflow config.
+                // For now, use the default value.
+                let max_retries = DEFAULT_MAX_RETRIES;
+
+                if let Err(e) = event_handler_server
+                    .handle_agent_failure(task_id, exit_code, signal, made_progress, max_retries)
+                    .await
+                {
+                    if !matches!(e, server::ServerError::TaskNotFound(_)) {
+                        error!(task_id = %task_id, error = %e, "failed to handle agent failure");
+                    }
+                }
+                continue;
+            }
+
             let new_state = match event.event_type {
                 EventType::TaskStateRunning => Some(models::task::TaskState::Running),
                 EventType::TaskStateQuestion => Some(models::task::TaskState::Question),

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -38,6 +38,7 @@ pub enum EventType {
     AgentMessage,
     AgentQuestion,
     AgentError,
+    AgentExit,
 
     // Merge events
     MergeQueued,
@@ -78,6 +79,7 @@ impl EventType {
             Self::AgentMessage => "agent:message",
             Self::AgentQuestion => "agent:question",
             Self::AgentError => "agent:error",
+            Self::AgentExit => "agent:exit",
             Self::MergeQueued => "merge:queued",
             Self::MergeApproved => "merge:approved",
             Self::MergeRejected => "merge:rejected",
@@ -141,6 +143,7 @@ impl TryFrom<String> for EventType {
             "agent:message" => Ok(Self::AgentMessage),
             "agent:question" => Ok(Self::AgentQuestion),
             "agent:error" => Ok(Self::AgentError),
+            "agent:exit" => Ok(Self::AgentExit),
             "merge:queued" => Ok(Self::MergeQueued),
             "merge:approved" => Ok(Self::MergeApproved),
             "merge:rejected" => Ok(Self::MergeRejected),

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -322,6 +322,94 @@ impl Server {
         Ok(())
     }
 
+    /// Handle an agent failure — apply retry logic per spec §13.2 and §18.2.
+    ///
+    /// Called when `agent:exit` event is received with non-zero exit code.
+    /// Updates retry_count and last_failure_at, then either:
+    /// - If retries exhausted: set state to Failed, emit `task:state:failed`
+    /// - Else: set state to Waiting, emit `task:state:waiting` (dispatcher
+    ///   will pick up after backoff)
+    pub async fn handle_agent_failure(
+        &self,
+        task_id: &str,
+        exit_code: Option<i32>,
+        signal: Option<i32>,
+        made_progress: bool,
+        max_retries: u32,
+    ) -> Result<(), ServerError> {
+        use chrono::Utc;
+
+        // Update retry_count and last_failure_at
+        let (new_state, retry_count) = {
+            let mut state = self.state.write().await;
+            let task = state
+                .tasks
+                .get_mut(task_id)
+                .ok_or_else(|| ServerError::TaskNotFound(task_id.to_string()))?;
+
+            task.retry_count += 1;
+            task.last_failure_at = Some(Utc::now());
+            task.updated_at = Utc::now();
+
+            let retry_count = task.retry_count;
+            let new_state = if retry_count >= max_retries {
+                TaskState::Failed
+            } else {
+                TaskState::Waiting
+            };
+            task.state = new_state;
+
+            // Write-through to store
+            if let Some(ref store) = self.store {
+                if let Ok(store) = store.lock() {
+                    if let Err(e) = store.save_task(task) {
+                        tracing::error!(task_id = %task_id, error = %e, "failed to persist task retry state");
+                    }
+                }
+            }
+
+            (new_state, retry_count)
+        };
+
+        // Emit the appropriate state event
+        let (event_type, data) = match new_state {
+            TaskState::Failed => (
+                EventType::TaskStateFailed,
+                serde_json::json!({
+                    "exit_code": exit_code,
+                    "signal": signal,
+                    "made_progress": made_progress,
+                    "retry_count": retry_count,
+                    "reason": "max_retries_exceeded",
+                }),
+            ),
+            TaskState::Waiting => (
+                EventType::TaskStateWaiting,
+                serde_json::json!({
+                    "exit_code": exit_code,
+                    "signal": signal,
+                    "made_progress": made_progress,
+                    "retry_count": retry_count,
+                    "reason": "retry_scheduled",
+                }),
+            ),
+            _ => unreachable!(),
+        };
+
+        let event = Event::new(event_type, task_id, Actor::System, data);
+        self.event_bus.publish(event).await?;
+
+        tracing::info!(
+            task_id = %task_id,
+            retry_count = retry_count,
+            max_retries = max_retries,
+            new_state = ?new_state,
+            "handled agent failure"
+        );
+
+        Ok(())
+    }
+
     // --- Merge queue (spec §7) ---
 
     /// Add an entry to the merge queue, persisting to store and publishing
@@ -807,5 +895,138 @@ mod tests {
         // Now state should be populated
         assert!(server.get_project("p1").await.is_some());
         assert!(server.get_task("t1").await.is_some());
+    }
+
+    // --- Retry logic tests (spec §13.2, §18.2) ---
+
+    #[tokio::test]
+    async fn agent_failure_increments_retry_count() {
+        let server = test_server().await;
+        let mut rx = server.event_bus.subscribe();
+
+        let project = Project::new("p1", "owner/repo");
+        server.add_project(project).await;
+
+        let mut task = Task::new("t1", TaskSource::Internal, "Test", "p1");
+        task.state = TaskState::Running;
+        server.add_task(task).await.unwrap();
+
+        // Handle first failure
+        server
+            .handle_agent_failure("t1", Some(1), None, false, 3)
+            .await
+            .unwrap();
+
+        // Retry count should be 1
+        let task = server.get_task("t1").await.unwrap();
+        assert_eq!(task.retry_count, 1);
+        assert!(task.last_failure_at.is_some());
+
+        // Drain initial events
+        while rx.try_recv().is_ok() {}
+
+        // Handle second failure
+        server
+            .handle_agent_failure("t1", Some(1), None, false, 3)
+            .await
+            .unwrap();
+
+        let task = server.get_task("t1").await.unwrap();
+        assert_eq!(task.retry_count, 2);
+    }
+
+    #[tokio::test]
+    async fn agent_failure_transitions_to_waiting_when_retries_available() {
+        let server = test_server().await;
+        let mut rx = server.event_bus.subscribe();
+
+        let project = Project::new("p1", "owner/repo");
+        server.add_project(project).await;
+
+        let mut task = Task::new("t1", TaskSource::Internal, "Test", "p1");
+        task.state = TaskState::Running;
+        server.add_task(task).await.unwrap();
+
+        // Drain initial events
+        while rx.try_recv().is_ok() {}
+
+        // Handle failure with max_retries=3 (retry_count will be 1 < 3)
+        server
+            .handle_agent_failure("t1", Some(1), None, true, 3)
+            .await
+            .unwrap();
+
+        // Task should be Waiting
+        let task = server.get_task("t1").await.unwrap();
+        assert_eq!(task.state, TaskState::Waiting);
+
+        // TaskStateWaiting event should have been emitted
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.event_type, EventType::TaskStateWaiting);
+        assert_eq!(event.data["retry_count"], 1);
+        assert_eq!(event.data["reason"], "retry_scheduled");
+    }
+
+    #[tokio::test]
+    async fn agent_failure_transitions_to_failed_when_retries_exhausted() {
+        let server = test_server().await;
+        let mut rx = server.event_bus.subscribe();
+
+        let project = Project::new("p1", "owner/repo");
+        server.add_project(project).await;
+
+        let mut task = Task::new("t1", TaskSource::Internal, "Test", "p1");
+        task.state = TaskState::Running;
+        task.retry_count = 2; // Already retried twice
+        server.add_task(task).await.unwrap();
+
+        // Drain initial events
+        while rx.try_recv().is_ok() {}
+
+        // Handle failure with max_retries=3 (retry_count will be 3 >= 3)
+        server
+            .handle_agent_failure("t1", Some(1), None, false, 3)
+            .await
+            .unwrap();
+
+        // Task should be Failed
+        let task = server.get_task("t1").await.unwrap();
+        assert_eq!(task.state, TaskState::Failed);
+        assert_eq!(task.retry_count, 3);
+
+        // TaskStateFailed event should have been emitted
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.event_type, EventType::TaskStateFailed);
+        assert_eq!(event.data["retry_count"], 3);
+        assert_eq!(event.data["reason"], "max_retries_exceeded");
+    }
+
+    #[tokio::test]
+    async fn agent_failure_persists_retry_state_to_store() {
+        let store = tasks_store::Store::open_memory().unwrap();
+        let dir = tempdir().unwrap();
+        let event_store = EventStore::new(dir.path());
+        let bus = EventBus::new(event_store, 64);
+        let server = Server::with_store(bus, store);
+
+        let project = Project::new("p1", "owner/repo");
+        server.add_project(project).await;
+
+        let mut task = Task::new("t1", TaskSource::Internal, "Test", "p1");
+        task.state = TaskState::Running;
+        server.add_task(task).await.unwrap();
+
+        // Handle failure
+        server
+            .handle_agent_failure("t1", Some(1), None, true, 3)
+            .await
+            .unwrap();
+
+        // Verify state is persisted to store
+        let store_ref = server.store.as_ref().unwrap().lock().unwrap();
+        let stored_task = store_ref.get_task("t1").unwrap().unwrap();
+        assert_eq!(stored_task.retry_count, 1);
+        assert!(stored_task.last_failure_at.is_some());
+        assert_eq!(stored_task.state, TaskState::Waiting);
     }
 }

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -354,7 +354,13 @@ async fn handle_supervisor_event(
     }
 }
 
-/// Handle an agent exit event — publish success or failure.
+/// Handle an agent exit event — publish success or failure (spec §18.2).
+///
+/// For successful exits (code 0), emits `task:state:awaiting_merge`.
+/// For failed exits, emits `agent:exit` with exit metadata. The event handler
+/// then applies retry logic per spec §13.2: increment retry_count, set
+/// last_failure_at, and emit either `task:state:failed` (max retries exceeded)
+/// or `task:state:waiting` (retry eligible).
 async fn handle_exit(
     task_id: &str,
     exit: &runtime::protocol::AgentExitEvent,
@@ -369,8 +375,10 @@ async fn handle_exit(
             serde_json::json!({ "exit_code": 0 }),
         )
     } else {
+        // Emit agent:exit instead of task:state:failed — the event handler
+        // will apply retry logic and emit the appropriate state event.
         (
-            events::EventType::TaskStateFailed,
+            events::EventType::AgentExit,
             serde_json::json!({
                 "exit_code": exit.code,
                 "signal": exit.signal,
@@ -477,7 +485,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exit_nonzero_maps_to_failed() {
+    async fn exit_nonzero_maps_to_agent_exit() {
         let (bus, mut rx) = test_event_bus().await;
         let exit = runtime::protocol::AgentExitEvent {
             code: Some(1),
@@ -487,7 +495,9 @@ mod tests {
         handle_exit("task-1", &exit, false, &bus).await;
 
         let received = rx.recv().await.unwrap();
-        assert_eq!(received.event_type, events::EventType::TaskStateFailed);
+        // Non-zero exit emits AgentExit, not TaskStateFailed — retry logic
+        // is applied by the event handler per spec §13.2.
+        assert_eq!(received.event_type, events::EventType::AgentExit);
         assert_eq!(received.data["exit_code"], 1);
     }
 
@@ -502,7 +512,7 @@ mod tests {
         handle_exit("task-1", &exit, true, &bus).await;
 
         let received = rx.recv().await.unwrap();
-        assert_eq!(received.event_type, events::EventType::TaskStateFailed);
+        assert_eq!(received.event_type, events::EventType::AgentExit);
         assert_eq!(received.data["made_progress"], true);
     }
 }


### PR DESCRIPTION
## Summary

- Implements retry logic for failed agent sessions per spec §13.2 and §18.2
- When an agent exits with a non-zero exit code, the system now:
  1. Increments `task.retry_count`
  2. Sets `task.last_failure_at` to the current time
  3. If `retry_count >= max_retries` (default 3): transitions to `Failed`
  4. Else: transitions to `Waiting` for retry after backoff

## Changes

- **`crates/events/src/event.rs`**: Add `AgentExit` event type for agent exit events
- **`crates/session/src/manager.rs`**: Emit `AgentExit` instead of `TaskStateFailed` for non-zero exits
- **`crates/server/src/server.rs`**: Add `handle_agent_failure()` method implementing retry logic
- **`crates/app/src/run_loop.rs`**: Process `AgentExit` events in the event handler loop

## Test plan

- [x] New tests for retry logic pass:
  - `agent_failure_increments_retry_count`
  - `agent_failure_transitions_to_waiting_when_retries_available`
  - `agent_failure_transitions_to_failed_when_retries_exhausted`
  - `agent_failure_persists_retry_state_to_store`
- [x] All existing tests pass (120+ tests)
- [x] Build succeeds

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)