### PR TITLE
Fix project dropdown showing IDs instead of repo names

### DIFF
--- a/web/src/pages/tasks/columns.tsx
+++ b/web/src/pages/tasks/columns.tsx
@@ -237,9 +237,12 @@ export const columns: ColumnDef<Task>[] = [
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Project" />
     ),
-    cell: ({ row }) => (
-      <span className="text-sm">{row.getValue<string>("project")}</span>
-    ),
+    cell: ({ row, table }) => {
+      const projectId = row.getValue<string>("project");
+      const meta = table.options.meta as { projectIdToRepo?: Record<string, string> } | undefined;
+      const displayName = meta?.projectIdToRepo?.[projectId] ?? projectId;
+      return <span className="text-sm">{displayName}</span>;
+    },
     filterFn: (row, id, value: string[]) => {
       return value.includes(row.getValue(id));
     },

--- a/web/src/pages/tasks/data-table-toolbar.tsx
+++ b/web/src/pages/tasks/data-table-toolbar.tsx
@@ -16,19 +16,24 @@ const stateOptions = Object.entries(taskStateMeta).map(([value, meta]) => ({
 
 interface DataTableToolbarProps {
   table: Table<Task>;
+  projectIdToRepo: Record<string, string>;
 }
 
-export function DataTableToolbar({ table }: DataTableToolbarProps) {
+export function DataTableToolbar({ table, projectIdToRepo }: DataTableToolbarProps) {
   const isFiltered = table.getState().columnFilters.length > 0;
 
-  // Derive unique project names from table data for the project filter.
+  // Derive unique project IDs from table data, display repo names.
   const projectOptions = Array.from(
     new Set(table.getCoreRowModel().rows.map((row) => row.original.project))
   )
-    .sort()
-    .map((project) => ({
-      value: project,
-      label: project,
+    .sort((a, b) => {
+      const repoA = projectIdToRepo[a] ?? a;
+      const repoB = projectIdToRepo[b] ?? b;
+      return repoA.localeCompare(repoB);
+    })
+    .map((projectId) => ({
+      value: projectId,
+      label: projectIdToRepo[projectId] ?? projectId,
     }));
 
   return (

--- a/web/src/pages/tasks/data-table.tsx
+++ b/web/src/pages/tasks/data-table.tsx
@@ -29,11 +29,13 @@ import { DataTableToolbar } from "./data-table-toolbar";
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  projectIdToRepo: Record<string, string>;
 }
 
 export function DataTable<TData extends Task, TValue>({
   columns,
   data,
+  projectIdToRepo,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([
     { id: "state", desc: false },
@@ -73,11 +75,12 @@ export function DataTable<TData extends Task, TValue>({
     getPaginationRowModel: getPaginationRowModel(),
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
+    meta: { projectIdToRepo },
   });
 
   return (
     <div className="space-y-4">
-      <DataTableToolbar table={table as unknown as import("@tanstack/react-table").Table<Task>} />
+      <DataTableToolbar table={table as unknown as import("@tanstack/react-table").Table<Task>} projectIdToRepo={projectIdToRepo} />
       <div className="rounded-md border">
         <Table>
           <TableHeader>

--- a/web/src/pages/tasks/page.tsx
+++ b/web/src/pages/tasks/page.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useAppState } from "@/hooks/use-app-state";
 import { columns } from "./columns";
 import { DataTable } from "./data-table";
@@ -5,6 +6,16 @@ import { DataTable } from "./data-table";
 export function TasksPage() {
   const { snapshot } = useAppState();
   const tasks = snapshot?.tasks ?? [];
+  const projects = snapshot?.projects ?? [];
+
+  // Create a map from project ID to repo name for display
+  const projectIdToRepo = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const p of projects) {
+      map[p.id] = p.repo;
+    }
+    return map;
+  }, [projects]);
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 md:p-8">
@@ -14,7 +25,7 @@ export function TasksPage() {
           Manage and monitor your coding tasks.
         </p>
       </div>
-      <DataTable columns={columns} data={tasks} />
+      <DataTable columns={columns} data={tasks} projectIdToRepo={projectIdToRepo} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Fix project filter dropdown in tasks table displaying IDs instead of owner/repo names
- Create a mapping from project ID to repo name and pass it through the table components
- Update both the filter dropdown options and the project column cell to show repo names

Fixes #24

## Test plan

- [ ] Open the Tasks page with multiple projects
- [ ] Verify the Project column shows `owner/repo` format instead of UUIDs
- [ ] Click the Project filter dropdown and verify it shows repo names
- [ ] Select a project filter and verify filtering works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)