### PR TITLE
Merge approved entries via GitHub API

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -326,13 +326,48 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    // --- 8. Optionally spawn web server ---
+    // --- 8. Spawn merge processor loop (Play mode) ---
+    //
+    // In Play mode, the orchestrator continuously merges approved entries.
+    // This loop checks for approved entries and merges them via the GitHub API.
+
+    let merge_server = server.clone();
+    let merge_github_token = config.github_token.clone();
+
+    let merge_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+        let github_client = GitHubClient::new(&merge_github_token);
+
+        loop {
+            interval.tick().await;
+
+            // Only process in Play mode
+            let mode = merge_server.mode().await;
+            if mode != server::Mode::Play {
+                continue;
+            }
+
+            // Merge approved entries
+            match merge_server.merge_approved_entries(&github_client).await {
+                Ok(merged) if !merged.is_empty() => {
+                    info!(count = merged.len(), "merged approved entries in Play mode");
+                }
+                Ok(_) => { /* no approved entries */ }
+                Err(e) => {
+                    error!(error = %e, "failed to merge approved entries");
+                }
+            }
+        }
+    });
+
+    // --- 9. Optionally spawn web server ---
 
     let web_handle = if config.web {
         let api_state = crate::web::ApiState {
             server: server.clone(),
             max_sessions: config.max_sessions,
             session_manager: Some(session_manager.clone()),
+            github_token: Some(config.github_token.clone()),
         };
         let web_port = config.web_port;
 
@@ -362,7 +397,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         None
     };
 
-    // --- 9. Wait for shutdown (TUI or headless) ---
+    // --- 10. Wait for shutdown (TUI or headless) ---
 
     if config.tui {
         crate::tui::run_tui(server.clone(), server.event_bus.clone(), config.max_sessions).await?;
@@ -378,6 +413,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     poll_handle.abort();
     dispatch_handle.abort();
     event_handler_handle.abort();
+    merge_handle.abort();
     if let Some(h) = web_handle {
         h.abort();
     }

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -33,6 +33,8 @@ pub struct ApiState {
     pub server: Arc<Server>,
     pub max_sessions: u32,
     pub session_manager: Option<Arc<tasks_session::SessionManager<runtime::AppleContainerRuntime>>>,
+    /// GitHub token for API operations (merging PRs, etc.)
+    pub github_token: Option<String>,
 }
 
 /// Build the API router.
@@ -221,13 +223,26 @@ async fn list_merge_queue(
 }
 
 /// POST /api/merge-queue/flush — Flush approved entries (Pause mode only).
+///
+/// This merges all approved entries via the GitHub API, updating their
+/// status to `merged` on success or `conflict` on failure.
 async fn flush_merge_queue(State(state): State<ApiState>) -> Result<Json<Vec<String>>, ApiError> {
-    state
+    // Get the GitHub token
+    let token = state.github_token.as_ref().ok_or_else(|| {
+        ApiError::BadRequest("GitHub token not configured".to_string())
+    })?;
+
+    // Create a GitHub client
+    let github_client = tasks_github::client::GitHubClient::new(token);
+
+    // Merge all approved entries
+    let merged = state
         .server
-        .flush_merge_queue()
+        .merge_approved_entries(&github_client)
         .await
-        .map(Json)
-        .map_err(ApiError::Server)
+        .map_err(ApiError::Server)?;
+
+    Ok(Json(merged))
 }
 
 /// POST /api/merge-queue/:id/approve — Approve a merge queue entry.

--- a/crates/github/Cargo.toml
+++ b/crates/github/Cargo.toml
@@ -11,7 +11,7 @@ serde_json.workspace = true
 chrono.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -11,7 +11,10 @@ use crate::model::{
     Issue, IssueFilters, IssueState, PullRequest, PullRequestFilters, PullRequestState, RateLimit,
 };
 use crate::queries;
-use crate::response::*;
+use crate::response::{
+    GetIssueData, GetPullRequestData, GraphQLResponse, GqlComment, GqlUser, IssueCommentsData,
+    ListIssuesData, ListPullRequestsData, MergePullRequestData, PrCommentsData, PrReviewsData,
+};
 
 /// Maximum items per page (GitHub's limit).
 const DEFAULT_PAGE_SIZE: u32 = 100;
@@ -401,6 +404,109 @@ impl GitHubClient {
             .map(String::from);
 
         Ok(url)
+    }
+
+    // -----------------------------------------------------------------------
+    // PR mutations
+    // -----------------------------------------------------------------------
+
+    /// Merge a pull request by number.
+    ///
+    /// Returns `Ok(())` on successful merge. Returns `Err(MergeConflict(..))` if
+    /// the PR has merge conflicts. Returns `Err(NotMergeable(..))` if the PR
+    /// cannot be merged for other reasons (e.g., checks failed, review required).
+    pub async fn merge_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+    ) -> Result<(), GitHubError> {
+        // First, fetch the PR to get its node_id and check mergeability.
+        let pr = self.get_pull_request(owner, repo, number).await?;
+
+        // Check if PR is already merged or closed
+        if pr.state == crate::model::PullRequestState::Merged {
+            return Ok(()); // Already merged, nothing to do
+        }
+        if pr.state == crate::model::PullRequestState::Closed {
+            return Err(GitHubError::NotMergeable(format!(
+                "PR #{number} is closed"
+            )));
+        }
+
+        // Check mergeability state
+        match pr.mergeable {
+            Some(crate::model::MergeableState::Conflicting) => {
+                return Err(GitHubError::MergeConflict(format!(
+                    "PR #{number} has merge conflicts"
+                )));
+            }
+            Some(crate::model::MergeableState::Unknown) => {
+                // GitHub might still be computing — this is a transient state.
+                // We'll attempt the merge anyway and let the mutation fail if needed.
+            }
+            Some(crate::model::MergeableState::Mergeable) => {
+                // Good to go
+            }
+            None => {
+                // Shouldn't happen for open PRs, but attempt merge anyway
+            }
+        }
+
+        // Execute the merge mutation
+        let mutation = r#"
+            mutation MergePullRequest($pullRequestId: ID!) {
+                mergePullRequest(input: { pullRequestId: $pullRequestId }) {
+                    pullRequest {
+                        number
+                        merged
+                    }
+                }
+            }
+        "#;
+
+        let variables = json!({ "pullRequestId": pr.node_id });
+
+        let resp: GraphQLResponse<MergePullRequestData> =
+            self.execute(mutation, variables).await?;
+
+        // Check for GraphQL errors first
+        if let Some(errors) = &resp.errors {
+            if !errors.is_empty() {
+                // Check for merge-specific errors
+                let error_msg = &errors[0].message;
+                if error_msg.contains("conflict") || error_msg.contains("Conflict") {
+                    return Err(GitHubError::MergeConflict(error_msg.clone()));
+                }
+                if error_msg.contains("not mergeable")
+                    || error_msg.contains("cannot be merged")
+                    || error_msg.contains("Pull request is not mergeable")
+                {
+                    return Err(GitHubError::NotMergeable(error_msg.clone()));
+                }
+                return Err(GitHubError::GraphQL(errors.clone()));
+            }
+        }
+
+        let data = resp
+            .data
+            .ok_or_else(|| GitHubError::Decode("merge response contained no data".to_string()))?;
+
+        let payload = data
+            .merge_pull_request
+            .ok_or_else(|| GitHubError::Decode("merge mutation returned null".to_string()))?;
+
+        let merged_pr = payload
+            .pull_request
+            .ok_or_else(|| GitHubError::Decode("merged PR data is null".to_string()))?;
+
+        if !merged_pr.merged {
+            return Err(GitHubError::NotMergeable(format!(
+                "PR #{number} merge mutation succeeded but merged=false"
+            )));
+        }
+
+        Ok(())
     }
 
     // -----------------------------------------------------------------------

--- a/crates/github/src/error.rs
+++ b/crates/github/src/error.rs
@@ -31,6 +31,14 @@ pub enum GitHubError {
     /// Response did not match expected shape.
     #[error("decode error: {0}")]
     Decode(String),
+
+    /// Merge conflict — PR cannot be merged due to conflicts.
+    #[error("merge conflict: {0}")]
+    MergeConflict(String),
+
+    /// PR is not mergeable (e.g., checks failed, review required).
+    #[error("PR not mergeable: {0}")]
+    NotMergeable(String),
 }
 
 /// A single error from a GraphQL response.

--- a/crates/github/src/response.rs
+++ b/crates/github/src/response.rs
@@ -541,6 +541,28 @@ pub(crate) struct PrReviewsNode {
 }
 
 // ---------------------------------------------------------------------------
+// Merge PR mutation response
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MergePullRequestData {
+    pub merge_pull_request: Option<MergePullRequestPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MergePullRequestPayload {
+    pub pull_request: Option<MergedPullRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct MergedPullRequest {
+    pub number: u64,
+    pub merged: bool,
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/crates/models/src/merge_queue.rs
+++ b/crates/models/src/merge_queue.rs
@@ -41,4 +41,88 @@ impl MergeQueueEntry {
             queued_at: Utc::now(),
         }
     }
+
+    /// Parse the PR URL to extract owner, repo, and PR number.
+    ///
+    /// Expected format: `https://github.com/{owner}/{repo}/pull/{number}`
+    ///
+    /// Returns `None` if the URL doesn't match the expected format.
+    pub fn parse_pr_url(&self) -> Option<PrRef> {
+        parse_github_pr_url(&self.pr_url)
+    }
+}
+
+/// Parsed reference to a GitHub pull request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrRef {
+    pub owner: String,
+    pub repo: String,
+    pub number: u64,
+}
+
+/// Parse a GitHub PR URL into its components.
+///
+/// Expected format: `https://github.com/{owner}/{repo}/pull/{number}`
+///
+/// Returns `None` if the URL doesn't match the expected format.
+pub fn parse_github_pr_url(url: &str) -> Option<PrRef> {
+    // Remove trailing slash if present
+    let url = url.trim_end_matches('/');
+
+    // Expected: https://github.com/{owner}/{repo}/pull/{number}
+    let url = url.strip_prefix("https://github.com/")?;
+
+    let parts: Vec<&str> = url.split('/').collect();
+    if parts.len() != 4 {
+        return None;
+    }
+
+    if parts[2] != "pull" {
+        return None;
+    }
+
+    let owner = parts[0].to_string();
+    let repo = parts[1].to_string();
+    let number: u64 = parts[3].parse().ok()?;
+
+    Some(PrRef { owner, repo, number })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_pr_url() {
+        let url = "https://github.com/owner/repo/pull/123";
+        let pr_ref = parse_github_pr_url(url).unwrap();
+        assert_eq!(pr_ref.owner, "owner");
+        assert_eq!(pr_ref.repo, "repo");
+        assert_eq!(pr_ref.number, 123);
+    }
+
+    #[test]
+    fn parse_pr_url_with_trailing_slash() {
+        let url = "https://github.com/owner/repo/pull/456/";
+        let pr_ref = parse_github_pr_url(url).unwrap();
+        assert_eq!(pr_ref.number, 456);
+    }
+
+    #[test]
+    fn parse_invalid_urls() {
+        assert!(parse_github_pr_url("https://github.com/owner/repo/issues/123").is_none());
+        assert!(parse_github_pr_url("https://gitlab.com/owner/repo/pull/123").is_none());
+        assert!(parse_github_pr_url("https://github.com/owner/repo/pull/abc").is_none());
+        assert!(parse_github_pr_url("not a url").is_none());
+        assert!(parse_github_pr_url("").is_none());
+    }
+
+    #[test]
+    fn entry_parse_pr_url() {
+        let entry = MergeQueueEntry::new("e1", "t1", "https://github.com/foo/bar/pull/42");
+        let pr_ref = entry.parse_pr_url().unwrap();
+        assert_eq!(pr_ref.owner, "foo");
+        assert_eq!(pr_ref.repo, "bar");
+        assert_eq!(pr_ref.number, 42);
+    }
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -14,6 +14,7 @@ use events::{Actor, Event, EventBus, EventType};
 
 use crate::merge_queue::MergeQueue;
 use crate::mode::{Mode, ModeTransitionError};
+use crate::model::merge_queue::MergeStatus;
 use crate::model::project::Project;
 use crate::model::task::{Task, TaskSource, TaskState};
 use crate::dispatcher::{self, DispatchPlan};
@@ -473,7 +474,9 @@ impl Server {
 
     /// Flush the merge queue (spec Section 6.2).
     ///
-    /// Only valid in Pause mode.
+    /// Only valid in Pause mode. This marks entries as flushed but does not
+    /// actually merge them via GitHub. Use [`merge_approved_entries`] to
+    /// perform actual merges.
     pub async fn flush_merge_queue(&self) -> Result<Vec<String>, ServerError> {
         let mut state = self.state.write().await;
         let mode = state.mode;
@@ -496,6 +499,174 @@ impl Server {
         self.event_bus.publish(event).await?;
 
         Ok(flushed)
+    }
+
+    /// Merge a single approved entry via the GitHub API.
+    ///
+    /// This method:
+    /// 1. Calls the GitHub API to merge the PR
+    /// 2. Updates the entry status to `merged` on success, `conflict` on failure
+    /// 3. Transitions the task state to `completed` on success
+    /// 4. Emits appropriate events
+    ///
+    /// Returns `Ok(true)` if merged successfully, `Ok(false)` if the entry
+    /// could not be merged (e.g., conflicts), or `Err` on other failures.
+    pub async fn merge_entry(
+        &self,
+        entry_id: &str,
+        github_client: &tasks_github::client::GitHubClient,
+    ) -> Result<bool, ServerError> {
+        // Get the entry
+        let (entry, task_id) = {
+            let state = self.state.read().await;
+            let entry = state
+                .merge_queue
+                .get(entry_id)
+                .ok_or_else(|| ServerError::TaskNotFound(format!("merge entry {entry_id}")))?
+                .clone();
+            let task_id = entry.task_id.clone();
+            (entry, task_id)
+        };
+
+        // Parse the PR URL
+        let pr_ref = entry.parse_pr_url().ok_or_else(|| {
+            ServerError::StoreError(format!("invalid PR URL: {}", entry.pr_url))
+        })?;
+
+        // Attempt to merge via GitHub API
+        let merge_result = github_client
+            .merge_pull_request(&pr_ref.owner, &pr_ref.repo, pr_ref.number)
+            .await;
+
+        match merge_result {
+            Ok(()) => {
+                // Mark as merged and update task state
+                {
+                    let mut state = self.state.write().await;
+                    if let Some(e) = state.merge_queue.get_mut(entry_id) {
+                        e.status = MergeStatus::Merged;
+                    }
+                    // Persist the updated entry
+                    if let Some(ref store) = self.store {
+                        if let Ok(store) = store.lock() {
+                            if let Some(e) = state.merge_queue.get(entry_id) {
+                                if let Err(err) = store.save_merge_entry(e) {
+                                    tracing::error!(entry_id = %entry_id, error = %err, "failed to persist merged entry");
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Transition task to Completed
+                self.set_task_state(&task_id, TaskState::Completed, Actor::Orchestrator)
+                    .await?;
+
+                // Emit merge:completed event
+                let event = Event::new(
+                    EventType::MergeCompleted,
+                    &task_id,
+                    Actor::Orchestrator,
+                    serde_json::json!({
+                        "entry_id": entry_id,
+                        "pr_url": entry.pr_url,
+                    }),
+                );
+                self.event_bus.publish(event).await?;
+
+                Ok(true)
+            }
+            Err(tasks_github::error::GitHubError::MergeConflict(msg)) => {
+                // Mark as conflict
+                {
+                    let mut state = self.state.write().await;
+                    if let Some(e) = state.merge_queue.get_mut(entry_id) {
+                        e.status = MergeStatus::Conflict;
+                    }
+                    // Persist the updated entry
+                    if let Some(ref store) = self.store {
+                        if let Ok(store) = store.lock() {
+                            if let Some(e) = state.merge_queue.get(entry_id) {
+                                if let Err(err) = store.save_merge_entry(e) {
+                                    tracing::error!(entry_id = %entry_id, error = %err, "failed to persist conflict entry");
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Transition task to Conflict
+                self.set_task_state(&task_id, TaskState::Conflict, Actor::Orchestrator)
+                    .await?;
+
+                // Emit merge:conflict event
+                let event = Event::new(
+                    EventType::MergeConflict,
+                    &task_id,
+                    Actor::Orchestrator,
+                    serde_json::json!({
+                        "entry_id": entry_id,
+                        "pr_url": entry.pr_url,
+                        "reason": msg,
+                    }),
+                );
+                self.event_bus.publish(event).await?;
+
+                Ok(false)
+            }
+            Err(tasks_github::error::GitHubError::NotMergeable(msg)) => {
+                // Log but don't change status — may be transient (e.g., checks pending)
+                tracing::warn!(
+                    entry_id = %entry_id,
+                    pr_url = %entry.pr_url,
+                    reason = %msg,
+                    "PR is not mergeable"
+                );
+                Ok(false)
+            }
+            Err(e) => {
+                tracing::error!(
+                    entry_id = %entry_id,
+                    pr_url = %entry.pr_url,
+                    error = %e,
+                    "failed to merge PR"
+                );
+                Err(ServerError::StoreError(format!("GitHub API error: {e}")))
+            }
+        }
+    }
+
+    /// Merge all approved entries via the GitHub API.
+    ///
+    /// This method iterates over all entries with `Approved` status and
+    /// attempts to merge each one. Returns the IDs of successfully merged entries.
+    pub async fn merge_approved_entries(
+        &self,
+        github_client: &tasks_github::client::GitHubClient,
+    ) -> Result<Vec<String>, ServerError> {
+        // Get all approved entry IDs
+        let entry_ids: Vec<String> = {
+            let state = self.state.read().await;
+            state
+                .merge_queue
+                .approved()
+                .iter()
+                .map(|e| e.id.clone())
+                .collect()
+        };
+
+        let mut merged = Vec::new();
+        for entry_id in entry_ids {
+            match self.merge_entry(&entry_id, github_client).await {
+                Ok(true) => merged.push(entry_id),
+                Ok(false) => { /* conflict or not mergeable, already handled */ }
+                Err(e) => {
+                    tracing::error!(entry_id = %entry_id, error = %e, "merge_entry failed");
+                }
+            }
+        }
+
+        Ok(merged)
     }
 
     // --- Presence (spec Section 4.1) ---


### PR DESCRIPTION
## Summary

- Adds `merge_pull_request` method to GitHub client that calls the GitHub GraphQL API to merge PRs
- Adds `MergeConflict` and `NotMergeable` error variants for proper error handling
- Adds `parse_github_pr_url` helper to extract owner/repo/number from PR URLs
- Adds `merge_entry` and `merge_approved_entries` methods to Server that orchestrate the merge flow
- Updates flush endpoint to actually merge entries via GitHub API instead of just marking them
- Adds merge processor loop in Play mode that continuously merges approved entries every 30s
- Switches reqwest to use rustls instead of native-tls for better portability

When an entry is approved (or auto-approved in Play mode), the platform now:
1. Calls the GitHub API to merge the PR associated with the entry
2. Updates the entry status to `merged` on success, `conflict` on failure
3. Transitions the task state to `completed` on success, `conflict` on failure
4. Emits appropriate events (`merge:completed` or `merge:conflict`)

## Test plan

- [x] Build compiles successfully
- [x] All existing tests pass
- [x] PR URL parsing tests added and passing
- [ ] Manual testing with actual GitHub PRs (requires running environment)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)