### PR TITLE
Implement actual PR merging in flush_merge_queue

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -45,7 +45,10 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
 
     // --- 2. Create server ---
 
-    let server = Arc::new(Server::with_store(bus, store));
+    let server = Arc::new(
+        Server::with_store(bus, store)
+            .with_github_token(&config.github_token)
+    );
     server
         .load_from_store()
         .await

--- a/crates/github/Cargo.toml
+++ b/crates/github/Cargo.toml
@@ -11,7 +11,7 @@ serde_json.workspace = true
 chrono.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -404,6 +404,122 @@ impl GitHubClient {
     }
 
     // -----------------------------------------------------------------------
+    // PR mutations (spec Section 7 — merge queue)
+    // -----------------------------------------------------------------------
+
+    /// Merge a pull request by number.
+    ///
+    /// Returns `Ok(())` on success, `Err(GitHubError::MergeConflict)` if the
+    /// PR cannot be merged due to conflicts or other merge blockers.
+    pub async fn merge_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+    ) -> Result<(), GitHubError> {
+        // First, fetch the PR's node ID and check if it's mergeable.
+        let info_query = queries::get_pr_merge_info_query();
+        let info_variables = json!({
+            "owner": owner,
+            "name": repo,
+            "number": number as i64,
+        });
+
+        let info_resp: GraphQLResponse<serde_json::Value> =
+            self.execute(info_query, info_variables).await?;
+        let info_data = self.unwrap_data(info_resp)?;
+
+        let pr_data = info_data
+            .get("repository")
+            .and_then(|r| r.get("pullRequest"))
+            .ok_or_else(|| GitHubError::NotFound(format!("{owner}/{repo}#{number}")))?;
+
+        let pr_id = pr_data
+            .get("id")
+            .and_then(|id| id.as_str())
+            .ok_or_else(|| GitHubError::Decode("missing PR id".to_string()))?;
+
+        let state = pr_data
+            .get("state")
+            .and_then(|s| s.as_str())
+            .unwrap_or("UNKNOWN");
+
+        // If the PR is already merged or closed, handle appropriately.
+        if state == "MERGED" {
+            // Already merged, nothing to do.
+            return Ok(());
+        }
+        if state == "CLOSED" {
+            return Err(GitHubError::MergeConflict(
+                "PR is closed and cannot be merged".to_string(),
+            ));
+        }
+
+        let mergeable = pr_data
+            .get("mergeable")
+            .and_then(|m| m.as_str())
+            .unwrap_or("UNKNOWN");
+
+        // CONFLICTING means there are merge conflicts.
+        if mergeable == "CONFLICTING" {
+            return Err(GitHubError::MergeConflict(
+                "PR has merge conflicts".to_string(),
+            ));
+        }
+
+        // UNKNOWN means GitHub hasn't computed mergeability yet.
+        // We proceed with the merge attempt and let GitHub reject it if needed.
+
+        // Now perform the actual merge.
+        let merge_query = queries::merge_pull_request_mutation();
+        let merge_variables = json!({
+            "pullRequestId": pr_id,
+            "mergeMethod": "SQUASH",
+        });
+
+        let merge_resp: GraphQLResponse<serde_json::Value> =
+            self.execute(merge_query, merge_variables).await?;
+
+        // Check for GraphQL errors that indicate merge failure.
+        if let Some(errors) = &merge_resp.errors {
+            for error in errors {
+                let msg = error.message.to_lowercase();
+                if msg.contains("conflict")
+                    || msg.contains("not mergeable")
+                    || msg.contains("head branch was modified")
+                    || msg.contains("blocked")
+                {
+                    return Err(GitHubError::MergeConflict(error.message.clone()));
+                }
+            }
+            // If there are other errors, return them as GraphQL errors.
+            if !errors.is_empty() {
+                return Err(GitHubError::GraphQL(errors.clone()));
+            }
+        }
+
+        // Verify the merge succeeded.
+        let data = merge_resp
+            .data
+            .ok_or_else(|| GitHubError::Decode("no data in merge response".to_string()))?;
+
+        let merged = data
+            .get("mergePullRequest")
+            .and_then(|m| m.get("pullRequest"))
+            .and_then(|pr| pr.get("merged"))
+            .and_then(|m| m.as_bool())
+            .unwrap_or(false);
+
+        if !merged {
+            return Err(GitHubError::MergeConflict(
+                "merge request completed but PR was not merged".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
     // Nested pagination helpers
     // -----------------------------------------------------------------------
 

--- a/crates/github/src/error.rs
+++ b/crates/github/src/error.rs
@@ -31,6 +31,10 @@ pub enum GitHubError {
     /// Response did not match expected shape.
     #[error("decode error: {0}")]
     Decode(String),
+
+    /// Pull request cannot be merged due to conflicts.
+    #[error("merge conflict: {0}")]
+    MergeConflict(String),
 }
 
 /// A single error from a GraphQL response.

--- a/crates/github/src/queries.rs
+++ b/crates/github/src/queries.rs
@@ -240,3 +240,29 @@ pub fn pr_reviews_query() -> &'static str {
   }
 }"#
 }
+
+/// Merge a pull request (spec Section 7 — merge queue flush).
+pub fn merge_pull_request_mutation() -> &'static str {
+    r#"mutation MergePullRequest($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod) {
+  mergePullRequest(input: { pullRequestId: $pullRequestId, mergeMethod: $mergeMethod }) {
+    pullRequest {
+      merged
+      mergedAt
+      url
+    }
+  }
+}"#
+}
+
+/// Fetch the node ID and mergeable state of a pull request by number.
+pub fn get_pr_merge_info_query() -> &'static str {
+    r#"query GetPrMergeInfo($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      id
+      mergeable
+      state
+    }
+  }
+}"#
+}

--- a/crates/models/src/merge_queue.rs
+++ b/crates/models/src/merge_queue.rs
@@ -41,4 +41,73 @@ impl MergeQueueEntry {
             queued_at: Utc::now(),
         }
     }
+
+    /// Parse the PR URL into (owner, repo, number).
+    ///
+    /// Expected format: `https://github.com/{owner}/{repo}/pull/{number}`
+    pub fn parse_pr_url(&self) -> Option<(String, String, u64)> {
+        parse_pr_url(&self.pr_url)
+    }
+}
+
+/// Parse a GitHub PR URL into (owner, repo, number).
+///
+/// Expected format: `https://github.com/{owner}/{repo}/pull/{number}`
+pub fn parse_pr_url(url: &str) -> Option<(String, String, u64)> {
+    // Handle both https://github.com/... and github.com/...
+    let path = url
+        .strip_prefix("https://github.com/")
+        .or_else(|| url.strip_prefix("http://github.com/"))
+        .or_else(|| url.strip_prefix("github.com/"))?;
+
+    let parts: Vec<&str> = path.split('/').collect();
+    // Expected: [owner, repo, "pull", number]
+    if parts.len() < 4 || parts[2] != "pull" {
+        return None;
+    }
+
+    let owner = parts[0].to_string();
+    let repo = parts[1].to_string();
+    let number = parts[3].parse::<u64>().ok()?;
+
+    Some((owner, repo, number))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pr_url_valid() {
+        let url = "https://github.com/owner/repo/pull/123";
+        let (owner, repo, number) = parse_pr_url(url).unwrap();
+        assert_eq!(owner, "owner");
+        assert_eq!(repo, "repo");
+        assert_eq!(number, 123);
+    }
+
+    #[test]
+    fn parse_pr_url_no_scheme() {
+        let url = "github.com/owner/repo/pull/456";
+        let (owner, repo, number) = parse_pr_url(url).unwrap();
+        assert_eq!(owner, "owner");
+        assert_eq!(repo, "repo");
+        assert_eq!(number, 456);
+    }
+
+    #[test]
+    fn parse_pr_url_invalid() {
+        assert!(parse_pr_url("https://github.com/owner/repo").is_none());
+        assert!(parse_pr_url("https://github.com/owner/repo/issues/123").is_none());
+        assert!(parse_pr_url("not a url").is_none());
+    }
+
+    #[test]
+    fn entry_parse_pr_url() {
+        let entry = MergeQueueEntry::new("m1", "t1", "https://github.com/test/repo/pull/42");
+        let (owner, repo, number) = entry.parse_pr_url().unwrap();
+        assert_eq!(owner, "test");
+        assert_eq!(repo, "repo");
+        assert_eq!(number, 42);
+    }
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -82,6 +82,8 @@ pub struct Server {
     pub event_bus: Arc<EventBus>,
     pub presence: Arc<PresenceTracker>,
     pub(crate) store: Option<Arc<StdMutex<tasks_store::Store>>>,
+    /// GitHub token for API operations (merge queue flush).
+    github_token: Option<String>,
 }
 
 impl Server {
@@ -91,6 +93,7 @@ impl Server {
             event_bus: Arc::new(event_bus),
             presence: Arc::new(PresenceTracker::new()),
             store: None,
+            github_token: None,
         }
     }
 
@@ -101,7 +104,14 @@ impl Server {
             event_bus: Arc::new(event_bus),
             presence: Arc::new(PresenceTracker::new()),
             store: Some(Arc::new(StdMutex::new(store))),
+            github_token: None,
         }
+    }
+
+    /// Set the GitHub token for API operations (merge queue flush).
+    pub fn with_github_token(mut self, token: impl Into<String>) -> Self {
+        self.github_token = Some(token.into());
+        self
     }
 
     /// Load projects, tasks, and merge queue entries from the store into memory.
@@ -473,29 +483,145 @@ impl Server {
 
     /// Flush the merge queue (spec Section 6.2).
     ///
-    /// Only valid in Pause mode.
+    /// Iterates all approved entries and attempts to merge each PR via the
+    /// GitHub API. Entries are marked as `merged` on success or `conflict`
+    /// on failure. Only valid in Pause mode.
     pub async fn flush_merge_queue(&self) -> Result<Vec<String>, ServerError> {
-        let mut state = self.state.write().await;
-        let mode = state.mode;
-        let flushed = state
-            .merge_queue
-            .flush(mode)
-            .map_err(|e| ServerError::EventStore(events::StoreError::Io(
-                std::io::Error::new(std::io::ErrorKind::Other, e.to_string()),
-            )))?;
+        // Check mode first
+        let mode = {
+            let state = self.state.read().await;
+            state.mode
+        };
 
-        drop(state);
+        if !mode.flush_available() {
+            return Err(ServerError::EventStore(events::StoreError::Io(
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("merge queue is held in {:?} mode", mode),
+                ),
+            )));
+        }
+
+        // Get approved entries
+        let approved_entries: Vec<_> = {
+            let state = self.state.read().await;
+            state
+                .merge_queue
+                .approved()
+                .iter()
+                .map(|e| (*e).clone())
+                .collect()
+        };
+
+        if approved_entries.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Create GitHub client if we have a token
+        let github_client = self.github_token.as_ref().map(|token| {
+            tasks_github::GitHubClient::new(token)
+        });
+
+        let mut merged_ids = Vec::new();
+        let mut conflict_ids = Vec::new();
+
+        for entry in &approved_entries {
+            let result = if let Some(ref client) = github_client {
+                // Parse PR URL to get owner/repo/number
+                if let Some((owner, repo, number)) = entry.parse_pr_url() {
+                    match client.merge_pull_request(&owner, &repo, number).await {
+                        Ok(()) => {
+                            tracing::info!(
+                                entry_id = %entry.id,
+                                pr_url = %entry.pr_url,
+                                "successfully merged PR"
+                            );
+                            Ok(())
+                        }
+                        Err(tasks_github::GitHubError::MergeConflict(reason)) => {
+                            tracing::warn!(
+                                entry_id = %entry.id,
+                                pr_url = %entry.pr_url,
+                                reason = %reason,
+                                "PR has merge conflict"
+                            );
+                            Err(reason)
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                entry_id = %entry.id,
+                                pr_url = %entry.pr_url,
+                                error = %e,
+                                "failed to merge PR"
+                            );
+                            Err(e.to_string())
+                        }
+                    }
+                } else {
+                    tracing::error!(
+                        entry_id = %entry.id,
+                        pr_url = %entry.pr_url,
+                        "invalid PR URL format"
+                    );
+                    Err("invalid PR URL format".to_string())
+                }
+            } else {
+                // No GitHub token configured — just mark as merged (legacy behavior)
+                tracing::warn!(
+                    entry_id = %entry.id,
+                    "no GitHub token configured, marking as merged without API call"
+                );
+                Ok(())
+            };
+
+            match result {
+                Ok(()) => merged_ids.push(entry.id.clone()),
+                Err(_) => conflict_ids.push(entry.id.clone()),
+            }
+        }
+
+        // Update entry statuses
+        {
+            let mut state = self.state.write().await;
+            for id in &merged_ids {
+                if let Err(e) = state.merge_queue.mark_merged(id) {
+                    tracing::error!(entry_id = %id, error = %e, "failed to mark entry as merged");
+                }
+            }
+            for id in &conflict_ids {
+                if let Err(e) = state.merge_queue.mark_conflict(id) {
+                    tracing::error!(entry_id = %id, error = %e, "failed to mark entry as conflict");
+                }
+            }
+        }
+
+        // Persist status changes to store
+        if let Some(ref store) = self.store {
+            let state = self.state.read().await;
+            if let Ok(store) = store.lock() {
+                for id in merged_ids.iter().chain(conflict_ids.iter()) {
+                    if let Some(entry) = state.merge_queue.get(id) {
+                        if let Err(e) = store.save_merge_entry(entry) {
+                            tracing::error!(entry_id = %id, error = %e, "failed to persist merge entry status");
+                        }
+                    }
+                }
+            }
+        }
 
         // Emit flush event
         let event = Event::new(
             EventType::SystemFlush,
             "system",
             Actor::Human,
-            serde_json::json!({ "flushed": flushed }),
+            serde_json::json!({
+                "merged": merged_ids,
+                "conflicts": conflict_ids,
+            }),
         );
         self.event_bus.publish(event).await?;
 
-        Ok(flushed)
+        Ok(merged_ids)
     }
 
     // --- Presence (spec Section 4.1) ---


### PR DESCRIPTION
## Summary

- Implements actual GitHub PR merging when flushing the merge queue in Pause mode
- Adds `merge_pull_request` method to GitHub client using GraphQL `mergePullRequest` mutation
- Handles merge conflicts by marking entries as `conflict` instead of `merged`
- Falls back to legacy behavior (mark as merged without API call) if no GitHub token is configured

## Changes

- **`crates/github/src/client.rs`**: Add `merge_pull_request` method that fetches PR info, checks mergeability, and calls the merge mutation
- **`crates/github/src/error.rs`**: Add `MergeConflict` error variant for merge failures
- **`crates/github/src/queries.rs`**: Add GraphQL mutation and query for merging PRs
- **`crates/models/src/merge_queue.rs`**: Add `parse_pr_url` helper to extract owner/repo/number from PR URLs
- **`crates/server/src/server.rs`**: Update `flush_merge_queue` to iterate entries and call GitHub API, store github_token in Server
- **`crates/app/src/run_loop.rs`**: Pass GitHub token to Server on creation
- **`crates/github/Cargo.toml`**: Switch from native-tls to rustls-tls for better portability

## Test plan

- [x] All existing tests pass (64 server tests, 4 models tests)
- [x] New `parse_pr_url` tests cover valid URLs, URLs without scheme, and invalid URLs
- [ ] Manual test: Create a PR, approve it in the merge queue, and flush in Pause mode

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)