### PR TITLE
Add agent crate (LLM abstraction layer)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 trait-variant = "0.1"
+reqwest = { version = "0.12", features = ["json", "stream"] }
+bytes = "1.11"
+futures = "0.3"

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -14,9 +14,9 @@ uuid.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 trait-variant.workspace = true
-reqwest = { version = "0.12", features = ["json", "stream"] }
-bytes = "1.11"
-futures = "0.3"
+reqwest.workspace = true
+bytes.workspace = true
+futures.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "tasks-agent"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+trait-variant.workspace = true
+reqwest = { version = "0.12", features = ["json", "stream"] }
+bytes = "1.11"
+futures = "0.3"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/agent/src/chain.rs
+++ b/crates/agent/src/chain.rs
@@ -1,0 +1,257 @@
+//! Chain execution for sequential prompt and programmatic steps.
+//!
+//! A chain is a sequence of steps where each step can be:
+//! - An LLM prompt that gets a response
+//! - A programmatic transform that modifies data
+//! - A gate/validator that can pass or fail, stopping the chain
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::error::AgentError;
+use crate::message::{Message, Response, Tool, ToolCall, Usage};
+use crate::provider::{CompletionConfig, Provider};
+use crate::session::{Session, SessionState};
+
+/// Result of a chain step execution.
+#[derive(Debug, Clone)]
+pub enum StepResult {
+    Continue(StepOutput),
+    Stop(String),
+    NeedsToolResults(Vec<ToolCall>),
+}
+
+/// Output from a chain step.
+#[derive(Debug, Clone)]
+pub struct StepOutput {
+    pub text: String,
+    pub response: Option<Response>,
+    pub metadata: serde_json::Value,
+}
+
+impl Default for StepOutput {
+    fn default() -> Self {
+        Self { text: String::new(), response: None, metadata: serde_json::Value::Null }
+    }
+}
+
+impl StepOutput {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self { text: text.into(), ..Default::default() }
+    }
+
+    pub fn from_response(response: Response) -> Self {
+        Self { text: response.text(), response: Some(response), metadata: serde_json::Value::Null }
+    }
+}
+
+pub type Validator = Box<dyn Fn(&StepOutput) -> Result<(), String> + Send + Sync>;
+pub type Transform = Box<dyn Fn(StepOutput) -> StepOutput + Send + Sync>;
+
+pub enum ChainStep<P: Provider> {
+    Prompt { message: String, validator: Option<Validator> },
+    Transform { name: String, transform: Transform },
+    Gate { name: String, validator: Validator },
+    Custom {
+        name: String,
+        func: Box<dyn Fn(StepOutput, Arc<P>) -> Pin<Box<dyn Future<Output = Result<StepResult, AgentError>> + Send>> + Send + Sync>,
+    },
+}
+
+pub struct ChainBuilder<P: Provider> {
+    provider: Arc<P>,
+    session: Session,
+    steps: Vec<ChainStep<P>>,
+}
+
+impl<P: Provider> ChainBuilder<P> {
+    pub fn new(provider: Arc<P>, model: impl Into<String>) -> Self {
+        Self {
+            provider,
+            session: Session::new(CompletionConfig::new(model)),
+            steps: Vec::new(),
+        }
+    }
+
+    pub fn system(mut self, prompt: impl Into<String>) -> Self {
+        self.session.set_system_prompt(prompt);
+        self
+    }
+
+    pub fn tools(mut self, tools: Vec<Tool>) -> Self {
+        self.session.set_tools(tools);
+        self
+    }
+
+    pub fn prompt(mut self, message: impl Into<String>) -> Self {
+        self.steps.push(ChainStep::Prompt { message: message.into(), validator: None });
+        self
+    }
+
+    pub fn prompt_validated<F>(mut self, message: impl Into<String>, validator: F) -> Self
+    where
+        F: Fn(&StepOutput) -> Result<(), String> + Send + Sync + 'static,
+    {
+        self.steps.push(ChainStep::Prompt {
+            message: message.into(),
+            validator: Some(Box::new(validator)),
+        });
+        self
+    }
+
+    pub fn transform<F>(mut self, name: impl Into<String>, f: F) -> Self
+    where
+        F: Fn(StepOutput) -> StepOutput + Send + Sync + 'static,
+    {
+        self.steps.push(ChainStep::Transform { name: name.into(), transform: Box::new(f) });
+        self
+    }
+
+    pub fn gate<F>(mut self, name: impl Into<String>, validator: F) -> Self
+    where
+        F: Fn(&StepOutput) -> Result<(), String> + Send + Sync + 'static,
+    {
+        self.steps.push(ChainStep::Gate { name: name.into(), validator: Box::new(validator) });
+        self
+    }
+
+    pub fn custom<F, Fut>(mut self, name: impl Into<String>, f: F) -> Self
+    where
+        F: Fn(StepOutput, Arc<P>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<StepResult, AgentError>> + Send + 'static,
+    {
+        let name = name.into();
+        self.steps.push(ChainStep::Custom {
+            name,
+            func: Box::new(move |output, provider| Box::pin(f(output, provider))),
+        });
+        self
+    }
+
+    pub async fn run(mut self) -> Result<ChainResult, AgentError> {
+        let mut current_output = StepOutput::default();
+        let mut executed_steps = Vec::new();
+        let steps = std::mem::take(&mut self.steps);
+
+        for (idx, step) in steps.into_iter().enumerate() {
+            let step_name = match &step {
+                ChainStep::Prompt { message, .. } => format!("prompt_{}: {}", idx, &message[..message.len().min(30)]),
+                ChainStep::Transform { name, .. } => format!("transform: {}", name),
+                ChainStep::Gate { name, .. } => format!("gate: {}", name),
+                ChainStep::Custom { name, .. } => format!("custom: {}", name),
+            };
+
+            let result = self.execute_step(step, current_output.clone()).await?;
+
+            match result {
+                StepResult::Continue(output) => {
+                    executed_steps.push((step_name, true));
+                    current_output = output;
+                }
+                StepResult::Stop(reason) => {
+                    executed_steps.push((step_name, false));
+                    let total_usage = self.session.total_usage;
+                    return Ok(ChainResult {
+                        output: current_output,
+                        session: self.session,
+                        executed_steps,
+                        stopped_reason: Some(reason),
+                        total_usage,
+                    });
+                }
+                StepResult::NeedsToolResults(tool_calls) => {
+                    executed_steps.push((step_name, false));
+                    let total_usage = self.session.total_usage;
+                    return Ok(ChainResult {
+                        output: current_output,
+                        session: self.session,
+                        executed_steps,
+                        stopped_reason: Some(format!(
+                            "Chain stopped: needs tool results for {:?}",
+                            tool_calls.iter().map(|t| &t.name).collect::<Vec<_>>()
+                        )),
+                        total_usage,
+                    });
+                }
+            }
+        }
+
+        let total_usage = self.session.total_usage;
+        Ok(ChainResult {
+            output: current_output,
+            session: self.session,
+            executed_steps,
+            stopped_reason: None,
+            total_usage,
+        })
+    }
+
+    async fn execute_step(
+        &mut self,
+        step: ChainStep<P>,
+        current_output: StepOutput,
+    ) -> Result<StepResult, AgentError> {
+        match step {
+            ChainStep::Prompt { message, validator } => {
+                self.session.add_user_message(&message);
+                self.session.state = SessionState::Processing;
+                let request = self.session.build_request();
+                let response = self.provider.complete(request).await?;
+
+                if !response.tool_calls.is_empty() {
+                    self.session.apply_response(&response);
+                    return Ok(StepResult::NeedsToolResults(response.tool_calls.clone()));
+                }
+
+                self.session.apply_response(&response);
+                let output = StepOutput::from_response(response);
+
+                if let Some(validator) = validator {
+                    if let Err(reason) = validator(&output) {
+                        return Ok(StepResult::Stop(reason));
+                    }
+                }
+
+                Ok(StepResult::Continue(output))
+            }
+            ChainStep::Transform { transform, .. } => {
+                Ok(StepResult::Continue(transform(current_output)))
+            }
+            ChainStep::Gate { validator, .. } => {
+                if let Err(reason) = validator(&current_output) {
+                    Ok(StepResult::Stop(reason))
+                } else {
+                    Ok(StepResult::Continue(current_output))
+                }
+            }
+            ChainStep::Custom { func, .. } => {
+                func(current_output, Arc::clone(&self.provider)).await
+            }
+        }
+    }
+}
+
+/// Result of executing a chain.
+#[derive(Debug)]
+pub struct ChainResult {
+    pub output: StepOutput,
+    pub session: Session,
+    pub executed_steps: Vec<(String, bool)>,
+    pub stopped_reason: Option<String>,
+    pub total_usage: Usage,
+}
+
+impl ChainResult {
+    pub fn succeeded(&self) -> bool {
+        self.stopped_reason.is_none()
+    }
+
+    pub fn text(&self) -> &str {
+        &self.output.text
+    }
+
+    pub fn history(&self) -> &[Message] {
+        self.session.history()
+    }
+}

--- a/crates/agent/src/chain.rs
+++ b/crates/agent/src/chain.rs
@@ -136,7 +136,10 @@ impl<P: Provider> ChainBuilder<P> {
 
         for (idx, step) in steps.into_iter().enumerate() {
             let step_name = match &step {
-                ChainStep::Prompt { message, .. } => format!("prompt_{}: {}", idx, &message[..message.len().min(30)]),
+                ChainStep::Prompt { message, .. } => {
+                    let truncated: String = message.chars().take(30).collect();
+                    format!("prompt_{}: {}", idx, truncated)
+                }
                 ChainStep::Transform { name, .. } => format!("transform: {}", name),
                 ChainStep::Gate { name, .. } => format!("gate: {}", name),
                 ChainStep::Custom { name, .. } => format!("custom: {}", name),

--- a/crates/agent/src/error.rs
+++ b/crates/agent/src/error.rs
@@ -1,0 +1,68 @@
+//! Error types for the agent crate.
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AgentError {
+    #[error("Provider error: {0}")]
+    Provider(String),
+
+    #[error("API error: {message} (status: {status})")]
+    Api { status: u16, message: String },
+
+    #[error("Rate limited, retry after {retry_after:?} seconds")]
+    RateLimited { retry_after: Option<u64> },
+
+    #[error("Authentication failed: {0}")]
+    Auth(String),
+
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
+
+    #[error("Session not found: {0}")]
+    SessionNotFound(String),
+
+    #[error("Session already exists: {0}")]
+    SessionExists(String),
+
+    #[error("Tool not found: {0}")]
+    ToolNotFound(String),
+
+    #[error("Tool execution failed: {0}")]
+    ToolExecution(String),
+
+    #[error("Validation error: {0}")]
+    Validation(String),
+
+    #[error("Cancelled")]
+    Cancelled,
+
+    #[error("Network error: {0}")]
+    Network(#[from] reqwest::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+impl AgentError {
+    pub fn provider(msg: impl Into<String>) -> Self {
+        AgentError::Provider(msg.into())
+    }
+
+    pub fn api(status: u16, message: impl Into<String>) -> Self {
+        AgentError::Api {
+            status,
+            message: message.into(),
+        }
+    }
+
+    pub fn invalid_request(msg: impl Into<String>) -> Self {
+        AgentError::InvalidRequest(msg.into())
+    }
+}

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,0 +1,11 @@
+//! LLM agent abstraction layer for the Tasks platform.
+//!
+//! Provides provider-agnostic types for interacting with LLM APIs.
+//! Lifted and adapted from agent-foundry.
+
+pub mod error;
+
+pub use error::AgentError;
+
+/// Convenience result type.
+pub type Result<T> = std::result::Result<T, AgentError>;

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -4,8 +4,10 @@
 //! Lifted and adapted from agent-foundry.
 
 pub mod error;
+pub mod message;
 
 pub use error::AgentError;
+pub use message::{Content, Message, Response, Role, StopReason, Tool, ToolCall, ToolResult, Usage};
 
 /// Convenience result type.
 pub type Result<T> = std::result::Result<T, AgentError>;

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -6,12 +6,14 @@
 pub mod error;
 pub mod message;
 pub mod provider;
+pub mod providers;
 
 pub use error::AgentError;
 pub use message::{Content, Message, Response, Role, StopReason, Tool, ToolCall, ToolResult, Usage};
 pub use provider::{
     CompletionConfig, CompletionRequest, Provider, StreamChunk, streaming_from_complete,
 };
+pub use providers::AnthropicProvider;
 
 /// Convenience result type.
 pub type Result<T> = std::result::Result<T, AgentError>;

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod message;
 pub mod provider;
 pub mod providers;
+pub mod session;
 
 pub use error::AgentError;
 pub use message::{Content, Message, Response, Role, StopReason, Tool, ToolCall, ToolResult, Usage};
@@ -14,6 +15,7 @@ pub use provider::{
     CompletionConfig, CompletionRequest, Provider, StreamChunk, streaming_from_complete,
 };
 pub use providers::AnthropicProvider;
+pub use session::{Chain, Session, SessionBuilder, SessionId, SessionState};
 
 /// Convenience result type.
 pub type Result<T> = std::result::Result<T, AgentError>;

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides provider-agnostic types for interacting with LLM APIs.
 //! Lifted and adapted from agent-foundry.
 
+pub mod chain;
 pub mod error;
 pub mod message;
 pub mod provider;
@@ -16,6 +17,7 @@ pub use provider::{
 };
 pub use providers::AnthropicProvider;
 pub use session::{Chain, Session, SessionBuilder, SessionId, SessionState};
+pub use chain::{ChainBuilder, ChainResult, StepOutput, StepResult};
 
 /// Convenience result type.
 pub type Result<T> = std::result::Result<T, AgentError>;

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -5,9 +5,13 @@
 
 pub mod error;
 pub mod message;
+pub mod provider;
 
 pub use error::AgentError;
 pub use message::{Content, Message, Response, Role, StopReason, Tool, ToolCall, ToolResult, Usage};
+pub use provider::{
+    CompletionConfig, CompletionRequest, Provider, StreamChunk, streaming_from_complete,
+};
 
 /// Convenience result type.
 pub type Result<T> = std::result::Result<T, AgentError>;

--- a/crates/agent/src/message.rs
+++ b/crates/agent/src/message.rs
@@ -1,0 +1,227 @@
+//! Message types for LLM conversations.
+//!
+//! These types are provider-agnostic and map to/from provider-specific formats.
+
+use serde::{Deserialize, Serialize};
+
+/// Role of a message in the conversation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    System,
+    User,
+    Assistant,
+}
+
+/// Content within a message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Content {
+    Text { text: String },
+    Thinking { thinking: String },
+    Image { media_type: String, data: String },
+    ToolUse { id: String, name: String, input: serde_json::Value },
+    ToolResult { tool_use_id: String, content: String, is_error: bool },
+}
+
+impl Content {
+    pub fn text(text: impl Into<String>) -> Self {
+        Content::Text { text: text.into() }
+    }
+
+    pub fn thinking(thinking: impl Into<String>) -> Self {
+        Content::Thinking { thinking: thinking.into() }
+    }
+
+    pub fn image(media_type: impl Into<String>, base64_data: impl Into<String>) -> Self {
+        Content::Image {
+            media_type: media_type.into(),
+            data: base64_data.into(),
+        }
+    }
+
+    pub fn tool_result(tool_use_id: impl Into<String>, content: impl Into<String>, is_error: bool) -> Self {
+        Content::ToolResult {
+            tool_use_id: tool_use_id.into(),
+            content: content.into(),
+            is_error,
+        }
+    }
+
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            Content::Text { text } => Some(text),
+            _ => None,
+        }
+    }
+
+    pub fn as_thinking(&self) -> Option<&str> {
+        match self {
+            Content::Thinking { thinking } => Some(thinking),
+            _ => None,
+        }
+    }
+}
+
+/// A message in the conversation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: Role,
+    pub content: Vec<Content>,
+}
+
+impl Message {
+    pub fn new(role: Role, content: Vec<Content>) -> Self {
+        Self { role, content }
+    }
+
+    pub fn system(text: impl Into<String>) -> Self {
+        Self { role: Role::System, content: vec![Content::text(text)] }
+    }
+
+    pub fn user(text: impl Into<String>) -> Self {
+        Self { role: Role::User, content: vec![Content::text(text)] }
+    }
+
+    pub fn assistant(text: impl Into<String>) -> Self {
+        Self { role: Role::Assistant, content: vec![Content::text(text)] }
+    }
+
+    /// Get the text content of this message, concatenating all text blocks.
+    pub fn text(&self) -> String {
+        self.content.iter().filter_map(|c| c.as_text()).collect::<Vec<_>>().join("")
+    }
+}
+
+/// Tool definition for function calling.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tool {
+    pub name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+}
+
+impl Tool {
+    pub fn new(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        parameters: serde_json::Value,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            parameters,
+        }
+    }
+}
+
+/// A tool call requested by the model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub arguments: serde_json::Value,
+}
+
+/// Result of a tool execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResult {
+    pub tool_call_id: String,
+    pub content: String,
+    pub is_error: bool,
+}
+
+impl ToolResult {
+    pub fn success(tool_call_id: impl Into<String>, content: impl Into<String>) -> Self {
+        Self { tool_call_id: tool_call_id.into(), content: content.into(), is_error: false }
+    }
+
+    pub fn error(tool_call_id: impl Into<String>, error: impl Into<String>) -> Self {
+        Self { tool_call_id: tool_call_id.into(), content: error.into(), is_error: true }
+    }
+}
+
+/// Reason the model stopped generating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopReason {
+    EndTurn,
+    MaxTokens,
+    ToolUse,
+    StopSequence,
+    Refusal,
+}
+
+/// Response from the LLM provider.
+#[derive(Debug, Clone)]
+pub struct Response {
+    pub content: Vec<Content>,
+    pub tool_calls: Vec<ToolCall>,
+    pub stop_reason: Option<StopReason>,
+    pub usage: Option<Usage>,
+}
+
+impl Response {
+    pub fn text(&self) -> String {
+        self.content.iter().filter_map(|c| c.as_text()).collect::<Vec<_>>().join("")
+    }
+}
+
+/// Token usage information.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct Usage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+impl Usage {
+    pub fn total(&self) -> u32 {
+        self.input_tokens + self.output_tokens
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_content_text() {
+        let content = Content::text("hello");
+        assert_eq!(content.as_text(), Some("hello"));
+    }
+
+    #[test]
+    fn test_content_thinking() {
+        let content = Content::thinking("reasoning");
+        assert_eq!(content.as_thinking(), Some("reasoning"));
+    }
+
+    #[test]
+    fn test_message_text_concatenation() {
+        let msg = Message::new(Role::User, vec![
+            Content::text("hello "),
+            Content::text("world"),
+        ]);
+        assert_eq!(msg.text(), "hello world");
+    }
+
+    #[test]
+    fn test_tool_result_success() {
+        let result = ToolResult::success("id-1", "output");
+        assert!(!result.is_error);
+        assert_eq!(result.content, "output");
+    }
+
+    #[test]
+    fn test_tool_result_error() {
+        let result = ToolResult::error("id-1", "failed");
+        assert!(result.is_error);
+        assert_eq!(result.content, "failed");
+    }
+
+    #[test]
+    fn test_usage_total() {
+        let usage = Usage { input_tokens: 100, output_tokens: 50 };
+        assert_eq!(usage.total(), 150);
+    }
+}

--- a/crates/agent/src/provider.rs
+++ b/crates/agent/src/provider.rs
@@ -1,0 +1,169 @@
+//! Provider trait for LLM backends.
+//!
+//! Abstracts over different LLM APIs (Anthropic, etc.)
+//! allowing the agent to be provider-agnostic.
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+use crate::error::AgentError;
+use crate::message::{Message, Response, Tool, ToolResult};
+
+/// Configuration for a completion request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompletionConfig {
+    /// Model identifier (e.g., "claude-sonnet-4-20250514")
+    pub model: String,
+    /// Maximum tokens to generate
+    #[serde(default = "default_max_tokens")]
+    pub max_tokens: u32,
+    /// Temperature for sampling (0.0 - 1.0)
+    #[serde(default)]
+    pub temperature: Option<f32>,
+    /// Top-p sampling parameter
+    #[serde(default)]
+    pub top_p: Option<f32>,
+    /// Stop sequences
+    #[serde(default)]
+    pub stop_sequences: Vec<String>,
+}
+
+fn default_max_tokens() -> u32 {
+    4096
+}
+
+impl Default for CompletionConfig {
+    fn default() -> Self {
+        Self {
+            model: String::new(),
+            max_tokens: default_max_tokens(),
+            temperature: None,
+            top_p: None,
+            stop_sequences: Vec::new(),
+        }
+    }
+}
+
+impl CompletionConfig {
+    pub fn new(model: impl Into<String>) -> Self {
+        Self { model: model.into(), ..Default::default() }
+    }
+
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = max_tokens;
+        self
+    }
+
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.temperature = Some(temperature);
+        self
+    }
+}
+
+/// Request to the LLM provider.
+#[derive(Debug, Clone)]
+pub struct CompletionRequest {
+    pub config: CompletionConfig,
+    pub system: Option<String>,
+    pub messages: Vec<Message>,
+    pub tools: Vec<Tool>,
+    pub tool_results: Vec<ToolResult>,
+}
+
+impl CompletionRequest {
+    pub fn new(config: CompletionConfig, messages: Vec<Message>) -> Self {
+        Self {
+            config,
+            system: None,
+            messages,
+            tools: Vec::new(),
+            tool_results: Vec::new(),
+        }
+    }
+
+    pub fn with_system(mut self, system: impl Into<String>) -> Self {
+        self.system = Some(system.into());
+        self
+    }
+
+    pub fn with_tools(mut self, tools: Vec<Tool>) -> Self {
+        self.tools = tools;
+        self
+    }
+
+    pub fn with_tool_results(mut self, results: Vec<ToolResult>) -> Self {
+        self.tool_results = results;
+        self
+    }
+}
+
+/// A chunk of streamed content from an LLM provider.
+#[derive(Debug, Clone)]
+pub enum StreamChunk {
+    Text(String),
+    Thinking(String),
+    ToolUseStart { id: String, name: String },
+    ToolUseInput(String),
+    Complete(Response),
+    Error(String),
+}
+
+/// Trait for LLM providers.
+#[trait_variant::make(Send)]
+pub trait Provider: Sync {
+    /// Returns the name of this provider.
+    fn name(&self) -> &str;
+
+    /// Returns available models for this provider.
+    fn models(&self) -> &[&str];
+
+    /// Complete a conversation and return the response.
+    async fn complete(&self, request: CompletionRequest) -> std::result::Result<Response, AgentError>;
+
+    /// Check if the provider is configured and ready.
+    fn is_available(&self) -> bool {
+        true
+    }
+
+    /// Check if this provider supports streaming.
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    /// Complete with streaming.
+    ///
+    /// Implementations that don't support native streaming can use
+    /// [`streaming_from_complete`] as a fallback that wraps `complete()`.
+    async fn complete_streaming(
+        &self,
+        request: CompletionRequest,
+    ) -> std::result::Result<mpsc::UnboundedReceiver<StreamChunk>, AgentError>;
+}
+
+/// Fallback streaming implementation that wraps a non-streaming response.
+///
+/// Providers that don't support native streaming can call this from their
+/// `complete_streaming` implementation:
+///
+/// ```ignore
+/// async fn complete_streaming(&self, request: CompletionRequest)
+///     -> Result<mpsc::UnboundedReceiver<StreamChunk>, AgentError>
+/// {
+///     let response = self.complete(request).await?;
+///     Ok(streaming_from_complete(response))
+/// }
+/// ```
+pub fn streaming_from_complete(response: Response) -> mpsc::UnboundedReceiver<StreamChunk> {
+    let (tx, rx) = mpsc::unbounded_channel();
+
+    for content in &response.content {
+        if let Some(text) = content.as_text() {
+            let _ = tx.send(StreamChunk::Text(text.to_string()));
+        } else if let Some(thinking) = content.as_thinking() {
+            let _ = tx.send(StreamChunk::Thinking(thinking.to_string()));
+        }
+    }
+    let _ = tx.send(StreamChunk::Complete(response));
+
+    rx
+}

--- a/crates/agent/src/providers/anthropic.rs
+++ b/crates/agent/src/providers/anthropic.rs
@@ -1,0 +1,633 @@
+//! Anthropic Claude provider implementation with streaming support.
+
+use bytes::Bytes;
+use futures::Stream;
+use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+use crate::error::AgentError;
+use crate::message::{Content, Response, StopReason, ToolCall, Usage};
+use crate::provider::{CompletionRequest, Provider, StreamChunk};
+
+const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// Anthropic Claude provider.
+#[derive(Debug, Clone)]
+pub struct AnthropicProvider {
+    api_key: String,
+    client: reqwest::Client,
+}
+
+impl AnthropicProvider {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self { api_key: api_key.into(), client: reqwest::Client::new() }
+    }
+
+    pub fn from_env() -> Result<Self, AgentError> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY")
+            .map_err(|_| AgentError::Auth("ANTHROPIC_API_KEY environment variable not set".into()))?;
+        Ok(Self::new(api_key))
+    }
+
+    fn build_headers(&self) -> Result<HeaderMap, AgentError> {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert(
+            "x-api-key",
+            HeaderValue::from_str(&self.api_key)
+                .map_err(|_| AgentError::Auth("Invalid API key".into()))?,
+        );
+        headers.insert("anthropic-version", HeaderValue::from_static(ANTHROPIC_VERSION));
+        Ok(headers)
+    }
+}
+
+// --- Anthropic API types (private) ---
+
+#[derive(Debug, Serialize)]
+struct AnthropicRequest {
+    model: String,
+    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<String>,
+    messages: Vec<AnthropicMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    stop_sequences: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tools: Vec<AnthropicTool>,
+}
+
+#[derive(Debug, Serialize)]
+struct AnthropicStreamRequest {
+    model: String,
+    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<String>,
+    messages: Vec<AnthropicMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    stop_sequences: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tools: Vec<AnthropicTool>,
+    stream: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AnthropicMessage {
+    role: String,
+    content: Vec<AnthropicContent>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AnthropicContent {
+    Text { text: String },
+    Image { source: ImageSource },
+    ToolUse { id: String, name: String, input: serde_json::Value },
+    ToolResult { tool_use_id: String, content: String },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ImageSource {
+    #[serde(rename = "type")]
+    source_type: String,
+    media_type: String,
+    data: String,
+}
+
+#[derive(Debug, Serialize)]
+struct AnthropicTool {
+    name: String,
+    description: String,
+    input_schema: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicResponse {
+    content: Vec<AnthropicResponseContent>,
+    stop_reason: Option<String>,
+    usage: AnthropicUsage,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AnthropicResponseContent {
+    Text { text: String },
+    Thinking { thinking: String },
+    ToolUse { id: String, name: String, input: serde_json::Value },
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicError {
+    error: AnthropicErrorDetail,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnthropicErrorDetail {
+    #[serde(rename = "type")]
+    #[allow(dead_code)]
+    error_type: String,
+    message: String,
+}
+
+// --- Streaming SSE types ---
+
+#[derive(Debug, Deserialize)]
+struct StreamMessageStart { message: StreamMessageStartMessage }
+
+#[derive(Debug, Deserialize)]
+struct StreamMessageStartMessage { usage: StreamUsage }
+
+#[derive(Debug, Deserialize)]
+struct StreamUsage {
+    input_tokens: u32,
+    #[serde(default)]
+    output_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamContentBlockStart { content_block: StreamContentBlock }
+
+#[derive(Debug, Deserialize)]
+struct StreamContentBlock {
+    #[serde(rename = "type")]
+    block_type: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamContentBlockDelta { delta: StreamDelta }
+
+#[derive(Debug, Deserialize)]
+struct StreamDelta {
+    #[serde(rename = "type")]
+    delta_type: String,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    thinking: Option<String>,
+    #[serde(default)]
+    partial_json: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamMessageDelta {
+    delta: StreamMessageDeltaContent,
+    #[serde(default)]
+    usage: Option<StreamUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamMessageDeltaContent {
+    #[serde(default)]
+    stop_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamError { error: StreamErrorDetail }
+
+#[derive(Debug, Deserialize)]
+struct StreamErrorDetail { message: String }
+
+// --- Message conversion ---
+
+impl From<&crate::message::Message> for AnthropicMessage {
+    fn from(msg: &crate::message::Message) -> Self {
+        let role = match msg.role {
+            crate::message::Role::User => "user",
+            crate::message::Role::Assistant => "assistant",
+            crate::message::Role::System => "user",
+        };
+
+        let content = msg.content.iter().map(|c| match c {
+            Content::Text { text } => AnthropicContent::Text { text: text.clone() },
+            Content::Thinking { thinking } => AnthropicContent::Text {
+                text: format!("[Internal reasoning: {}]", thinking),
+            },
+            Content::Image { media_type, data } => AnthropicContent::Image {
+                source: ImageSource {
+                    source_type: "base64".to_string(),
+                    media_type: media_type.clone(),
+                    data: data.clone(),
+                },
+            },
+            Content::ToolUse { id, name, input } => AnthropicContent::ToolUse {
+                id: id.clone(), name: name.clone(), input: input.clone(),
+            },
+            Content::ToolResult { tool_use_id, content, .. } => AnthropicContent::ToolResult {
+                tool_use_id: tool_use_id.clone(), content: content.clone(),
+            },
+        }).collect();
+
+        AnthropicMessage { role: role.to_string(), content }
+    }
+}
+
+// --- SSE stream processing ---
+
+async fn process_sse_stream<S>(stream: S, tx: mpsc::UnboundedSender<StreamChunk>)
+where
+    S: Stream<Item = Result<Bytes, reqwest::Error>> + Unpin,
+{
+    use futures::StreamExt;
+
+    let mut stream = stream;
+    let mut buffer = String::new();
+    let mut content: Vec<Content> = Vec::new();
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
+    let mut usage = Usage::default();
+    let mut stop_reason: Option<StopReason> = None;
+    let mut current_text = String::new();
+    let mut current_thinking = String::new();
+    let mut current_tool_id = String::new();
+    let mut current_tool_name = String::new();
+    let mut current_tool_input = String::new();
+    let mut current_block_type: Option<String> = None;
+
+    while let Some(chunk_result) = stream.next().await {
+        let chunk = match chunk_result {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = tx.send(StreamChunk::Error(e.to_string()));
+                return;
+            }
+        };
+
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        while let Some(event_end) = buffer.find("\n\n") {
+            let event_data = buffer[..event_end].to_string();
+            buffer = buffer[event_end + 2..].to_string();
+
+            let mut event_type = String::new();
+            let mut data = String::new();
+
+            for line in event_data.lines() {
+                if let Some(et) = line.strip_prefix("event: ") {
+                    event_type = et.to_string();
+                } else if let Some(d) = line.strip_prefix("data: ") {
+                    data = d.to_string();
+                }
+            }
+
+            if data.is_empty() { continue; }
+
+            match event_type.as_str() {
+                "message_start" => {
+                    if let Ok(msg) = serde_json::from_str::<StreamMessageStart>(&data) {
+                        usage.input_tokens = msg.message.usage.input_tokens;
+                    }
+                }
+                "content_block_start" => {
+                    if let Ok(block) = serde_json::from_str::<StreamContentBlockStart>(&data) {
+                        current_block_type = Some(block.content_block.block_type.clone());
+                        match block.content_block.block_type.as_str() {
+                            "text" => current_text.clear(),
+                            "thinking" => current_thinking.clear(),
+                            "tool_use" => {
+                                current_tool_id = block.content_block.id.unwrap_or_default();
+                                current_tool_name = block.content_block.name.unwrap_or_default();
+                                current_tool_input.clear();
+                                let _ = tx.send(StreamChunk::ToolUseStart {
+                                    id: current_tool_id.clone(),
+                                    name: current_tool_name.clone(),
+                                });
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                "content_block_delta" => {
+                    if let Ok(delta) = serde_json::from_str::<StreamContentBlockDelta>(&data) {
+                        match delta.delta.delta_type.as_str() {
+                            "text_delta" => {
+                                if let Some(text) = delta.delta.text {
+                                    current_text.push_str(&text);
+                                    let _ = tx.send(StreamChunk::Text(text));
+                                }
+                            }
+                            "thinking_delta" => {
+                                if let Some(thinking) = delta.delta.thinking {
+                                    current_thinking.push_str(&thinking);
+                                    let _ = tx.send(StreamChunk::Thinking(thinking));
+                                }
+                            }
+                            "input_json_delta" => {
+                                if let Some(partial) = delta.delta.partial_json {
+                                    current_tool_input.push_str(&partial);
+                                    let _ = tx.send(StreamChunk::ToolUseInput(partial));
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                "content_block_stop" => {
+                    if let Some(ref block_type) = current_block_type {
+                        match block_type.as_str() {
+                            "text" => {
+                                if !current_text.is_empty() {
+                                    content.push(Content::text(current_text.clone()));
+                                }
+                            }
+                            "thinking" => {
+                                if !current_thinking.is_empty() {
+                                    content.push(Content::thinking(current_thinking.clone()));
+                                }
+                            }
+                            "tool_use" => {
+                                let input: serde_json::Value = serde_json::from_str(&current_tool_input)
+                                    .unwrap_or(serde_json::Value::Null);
+                                content.push(Content::ToolUse {
+                                    id: current_tool_id.clone(),
+                                    name: current_tool_name.clone(),
+                                    input: input.clone(),
+                                });
+                                tool_calls.push(ToolCall {
+                                    id: current_tool_id.clone(),
+                                    name: current_tool_name.clone(),
+                                    arguments: input,
+                                });
+                            }
+                            _ => {}
+                        }
+                    }
+                    current_block_type = None;
+                }
+                "message_delta" => {
+                    if let Ok(delta) = serde_json::from_str::<StreamMessageDelta>(&data) {
+                        stop_reason = delta.delta.stop_reason.map(|r| match r.as_str() {
+                            "end_turn" => StopReason::EndTurn,
+                            "max_tokens" => StopReason::MaxTokens,
+                            "tool_use" => StopReason::ToolUse,
+                            "stop_sequence" => StopReason::StopSequence,
+                            _ => StopReason::EndTurn,
+                        });
+                        if let Some(u) = delta.usage {
+                            usage.output_tokens = u.output_tokens;
+                        }
+                    }
+                }
+                "message_stop" => {
+                    let response = Response {
+                        content: content.clone(),
+                        tool_calls: tool_calls.clone(),
+                        stop_reason,
+                        usage: Some(usage),
+                    };
+                    let _ = tx.send(StreamChunk::Complete(response));
+                    return;
+                }
+                "error" => {
+                    if let Ok(err) = serde_json::from_str::<StreamError>(&data) {
+                        let _ = tx.send(StreamChunk::Error(err.error.message));
+                        return;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let response = Response { content, tool_calls, stop_reason, usage: Some(usage) };
+    let _ = tx.send(StreamChunk::Complete(response));
+}
+
+// --- Provider implementation ---
+
+impl Provider for AnthropicProvider {
+    fn name(&self) -> &str { "anthropic" }
+
+    fn models(&self) -> &[&str] {
+        &[
+            "claude-sonnet-4-20250514",
+            "claude-opus-4-0-20250514",
+            "claude-3-5-haiku-20241022",
+        ]
+    }
+
+    fn is_available(&self) -> bool { !self.api_key.is_empty() }
+
+    fn supports_streaming(&self) -> bool { true }
+
+    async fn complete(&self, request: CompletionRequest) -> std::result::Result<Response, AgentError> {
+        let headers = self.build_headers()?;
+
+        let messages: Vec<AnthropicMessage> = request.messages.iter()
+            .filter(|m| m.role != crate::message::Role::System)
+            .map(AnthropicMessage::from)
+            .collect();
+
+        let tools: Vec<AnthropicTool> = request.tools.iter()
+            .map(|t| AnthropicTool {
+                name: t.name.clone(),
+                description: t.description.clone(),
+                input_schema: t.parameters.clone(),
+            })
+            .collect();
+
+        let anthropic_request = AnthropicRequest {
+            model: request.config.model,
+            max_tokens: request.config.max_tokens,
+            system: request.system,
+            messages,
+            temperature: request.config.temperature,
+            top_p: request.config.top_p,
+            stop_sequences: request.config.stop_sequences,
+            tools,
+        };
+
+        let response = self.client
+            .post(ANTHROPIC_API_URL)
+            .headers(headers)
+            .json(&anthropic_request)
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_body: AnthropicError = response.json().await.map_err(|e| {
+                AgentError::api(status.as_u16(), format!("Failed to parse error response: {}", e))
+            })?;
+            return match status.as_u16() {
+                401 => Err(AgentError::Auth(error_body.error.message)),
+                429 => Err(AgentError::RateLimited { retry_after: None }),
+                _ => Err(AgentError::api(status.as_u16(), error_body.error.message)),
+            };
+        }
+
+        let anthropic_response: AnthropicResponse = response.json().await?;
+
+        let mut content = Vec::new();
+        let mut tool_calls = Vec::new();
+
+        for item in anthropic_response.content {
+            match item {
+                AnthropicResponseContent::Text { text } => {
+                    content.push(Content::text(text));
+                }
+                AnthropicResponseContent::Thinking { thinking } => {
+                    content.push(Content::thinking(thinking));
+                }
+                AnthropicResponseContent::ToolUse { id, name, input } => {
+                    content.push(Content::ToolUse {
+                        id: id.clone(), name: name.clone(), input: input.clone(),
+                    });
+                    tool_calls.push(ToolCall { id, name, arguments: input });
+                }
+            }
+        }
+
+        let stop_reason = anthropic_response.stop_reason.map(|r| match r.as_str() {
+            "end_turn" => StopReason::EndTurn,
+            "max_tokens" => StopReason::MaxTokens,
+            "tool_use" => StopReason::ToolUse,
+            "stop_sequence" => StopReason::StopSequence,
+            _ => StopReason::EndTurn,
+        });
+
+        Ok(Response {
+            content,
+            tool_calls,
+            stop_reason,
+            usage: Some(Usage {
+                input_tokens: anthropic_response.usage.input_tokens,
+                output_tokens: anthropic_response.usage.output_tokens,
+            }),
+        })
+    }
+
+    async fn complete_streaming(
+        &self,
+        request: CompletionRequest,
+    ) -> std::result::Result<mpsc::UnboundedReceiver<StreamChunk>, AgentError> {
+        let headers = self.build_headers()?;
+
+        let messages: Vec<AnthropicMessage> = request.messages.iter()
+            .filter(|m| m.role != crate::message::Role::System)
+            .map(AnthropicMessage::from)
+            .collect();
+
+        let tools: Vec<AnthropicTool> = request.tools.iter()
+            .map(|t| AnthropicTool {
+                name: t.name.clone(),
+                description: t.description.clone(),
+                input_schema: t.parameters.clone(),
+            })
+            .collect();
+
+        let anthropic_request = AnthropicStreamRequest {
+            model: request.config.model,
+            max_tokens: request.config.max_tokens,
+            system: request.system,
+            messages,
+            temperature: request.config.temperature,
+            top_p: request.config.top_p,
+            stop_sequences: request.config.stop_sequences,
+            tools,
+            stream: true,
+        };
+
+        let response = self.client
+            .post(ANTHROPIC_API_URL)
+            .headers(headers)
+            .json(&anthropic_request)
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response.text().await.unwrap_or_default();
+            if let Ok(error_body) = serde_json::from_str::<AnthropicError>(&error_text) {
+                return match status.as_u16() {
+                    401 => Err(AgentError::Auth(error_body.error.message)),
+                    429 => Err(AgentError::RateLimited { retry_after: None }),
+                    _ => Err(AgentError::api(status.as_u16(), error_body.error.message)),
+                };
+            }
+            return Err(AgentError::api(status.as_u16(), error_text));
+        }
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        let byte_stream = response.bytes_stream();
+        tokio::spawn(async move {
+            process_sse_stream(byte_stream, tx).await;
+        });
+
+        Ok(rx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{Message, Role, Content};
+
+    #[test]
+    fn test_message_conversion_user() {
+        let msg = Message::user("hello");
+        let anthropic: AnthropicMessage = (&msg).into();
+        assert_eq!(anthropic.role, "user");
+        assert_eq!(anthropic.content.len(), 1);
+    }
+
+    #[test]
+    fn test_message_conversion_assistant() {
+        let msg = Message::assistant("response");
+        let anthropic: AnthropicMessage = (&msg).into();
+        assert_eq!(anthropic.role, "assistant");
+    }
+
+    #[test]
+    fn test_message_conversion_system_becomes_user() {
+        let msg = Message::system("you are helpful");
+        let anthropic: AnthropicMessage = (&msg).into();
+        assert_eq!(anthropic.role, "user");
+    }
+
+    #[test]
+    fn test_message_conversion_tool_use() {
+        let msg = Message::new(Role::Assistant, vec![
+            Content::ToolUse {
+                id: "tool-1".into(),
+                name: "read_file".into(),
+                input: serde_json::json!({"path": "/tmp/test"}),
+            },
+        ]);
+        let anthropic: AnthropicMessage = (&msg).into();
+        assert_eq!(anthropic.content.len(), 1);
+        match &anthropic.content[0] {
+            AnthropicContent::ToolUse { id, name, .. } => {
+                assert_eq!(id, "tool-1");
+                assert_eq!(name, "read_file");
+            }
+            _ => panic!("Expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn test_from_env_missing_key() {
+        let result = AnthropicProvider::from_env();
+        if std::env::var("ANTHROPIC_API_KEY").is_err() {
+            assert!(result.is_err());
+        }
+    }
+}

--- a/crates/agent/src/providers/anthropic.rs
+++ b/crates/agent/src/providers/anthropic.rs
@@ -61,23 +61,7 @@ struct AnthropicRequest {
     stop_sequences: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<AnthropicTool>,
-}
-
-#[derive(Debug, Serialize)]
-struct AnthropicStreamRequest {
-    model: String,
-    max_tokens: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    system: Option<String>,
-    messages: Vec<AnthropicMessage>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    temperature: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    top_p: Option<f32>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    stop_sequences: Vec<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<AnthropicTool>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
     stream: bool,
 }
 
@@ -93,7 +77,7 @@ enum AnthropicContent {
     Text { text: String },
     Image { source: ImageSource },
     ToolUse { id: String, name: String, input: serde_json::Value },
-    ToolResult { tool_use_id: String, content: String },
+    ToolResult { tool_use_id: String, content: String, #[serde(default, skip_serializing_if = "std::ops::Not::not")] is_error: bool },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -217,24 +201,25 @@ impl From<&crate::message::Message> for AnthropicMessage {
             crate::message::Role::System => "user",
         };
 
-        let content = msg.content.iter().map(|c| match c {
-            Content::Text { text } => AnthropicContent::Text { text: text.clone() },
-            Content::Thinking { thinking } => AnthropicContent::Text {
-                text: format!("[Internal reasoning: {}]", thinking),
-            },
-            Content::Image { media_type, data } => AnthropicContent::Image {
+        let content = msg.content.iter().filter_map(|c| match c {
+            Content::Text { text } => Some(AnthropicContent::Text { text: text.clone() }),
+            // Thinking blocks are internal reasoning from prior turns — filter
+            // them out rather than replaying as plain text, which would confuse
+            // the model.
+            Content::Thinking { .. } => None,
+            Content::Image { media_type, data } => Some(AnthropicContent::Image {
                 source: ImageSource {
                     source_type: "base64".to_string(),
                     media_type: media_type.clone(),
                     data: data.clone(),
                 },
-            },
-            Content::ToolUse { id, name, input } => AnthropicContent::ToolUse {
+            }),
+            Content::ToolUse { id, name, input } => Some(AnthropicContent::ToolUse {
                 id: id.clone(), name: name.clone(), input: input.clone(),
-            },
-            Content::ToolResult { tool_use_id, content, .. } => AnthropicContent::ToolResult {
-                tool_use_id: tool_use_id.clone(), content: content.clone(),
-            },
+            }),
+            Content::ToolResult { tool_use_id, content, is_error } => Some(AnthropicContent::ToolResult {
+                tool_use_id: tool_use_id.clone(), content: content.clone(), is_error: *is_error,
+            }),
         }).collect();
 
         AnthropicMessage { role: role.to_string(), content }
@@ -453,6 +438,7 @@ impl Provider for AnthropicProvider {
             top_p: request.config.top_p,
             stop_sequences: request.config.stop_sequences,
             tools,
+            stream: false,
         };
 
         let response = self.client
@@ -534,7 +520,7 @@ impl Provider for AnthropicProvider {
             })
             .collect();
 
-        let anthropic_request = AnthropicStreamRequest {
+        let anthropic_request = AnthropicRequest {
             model: request.config.model,
             max_tokens: request.config.max_tokens,
             system: request.system,

--- a/crates/agent/src/providers/mod.rs
+++ b/crates/agent/src/providers/mod.rs
@@ -1,0 +1,3 @@
+pub mod anthropic;
+
+pub use anthropic::AnthropicProvider;

--- a/crates/agent/src/session.rs
+++ b/crates/agent/src/session.rs
@@ -151,19 +151,12 @@ impl Session {
     }
 
     /// Apply tool results and prepare for the next turn.
+    ///
+    /// Stores results in `pending_tool_results` so that `build_request()`
+    /// emits them as proper `Content::ToolResult` blocks (required by the
+    /// Anthropic API), rather than plain text.
     pub fn apply_tool_results(&mut self, results: Vec<ToolResult>) {
-        let result_text = results.iter()
-            .map(|r| {
-                if r.is_error {
-                    format!("Tool {} error: {}", r.tool_call_id, r.content)
-                } else {
-                    format!("Tool {} result: {}", r.tool_call_id, r.content)
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n\n");
-
-        self.messages.push(Message::user(result_text));
+        self.pending_tool_results = results;
         self.pending_tool_calls.clear();
         self.state = SessionState::Ready;
     }
@@ -424,5 +417,39 @@ mod tests {
         let mut session = Session::new(CompletionConfig::new("test-model"));
         session.cancel();
         assert_eq!(session.state, SessionState::Cancelled);
+    }
+
+    #[test]
+    fn test_apply_tool_results_emits_structured_content() {
+        let mut session = Session::new(CompletionConfig::new("test-model"));
+        session.add_user_message("hello");
+
+        // Simulate a response with tool calls
+        let response = Response {
+            content: vec![Content::text("let me check")],
+            tool_calls: vec![ToolCall {
+                id: "tc-1".into(),
+                name: "read_file".into(),
+                arguments: serde_json::json!({"path": "/tmp"}),
+            }],
+            stop_reason: Some(StopReason::ToolUse),
+            usage: Some(Usage { input_tokens: 10, output_tokens: 5 }),
+        };
+        session.apply_response(&response);
+
+        // Apply tool results — should go to pending_tool_results, not as text
+        session.apply_tool_results(vec![
+            ToolResult::success("tc-1", "file contents here"),
+        ]);
+
+        assert_eq!(session.state, SessionState::Ready);
+        assert!(!session.has_pending_tool_calls());
+        assert_eq!(session.pending_tool_results.len(), 1);
+
+        // build_request should emit proper ToolResult content blocks
+        let request = session.build_request();
+        let last_msg = request.messages.last().unwrap();
+        assert_eq!(last_msg.role, Role::User);
+        assert!(matches!(&last_msg.content[0], Content::ToolResult { tool_use_id, .. } if tool_use_id == "tc-1"));
     }
 }

--- a/crates/agent/src/session.rs
+++ b/crates/agent/src/session.rs
@@ -1,0 +1,428 @@
+//! Session management for multi-turn conversations.
+//!
+//! A session maintains conversation history and state across multiple prompt turns.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::error::AgentError;
+use crate::message::{Content, Message, Role, Response, Tool, ToolCall, ToolResult, Usage};
+use crate::provider::{CompletionConfig, CompletionRequest, Provider};
+
+/// Unique session identifier.
+pub type SessionId = String;
+
+/// State of a session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionState {
+    Ready,
+    Processing,
+    AwaitingToolResults,
+    Cancelled,
+}
+
+/// A conversation session.
+#[derive(Debug, Clone)]
+pub struct Session {
+    pub id: SessionId,
+    pub state: SessionState,
+    pub system_prompt: Option<String>,
+    pub messages: Vec<Message>,
+    pub tools: Vec<Tool>,
+    pub pending_tool_calls: Vec<ToolCall>,
+    pub pending_tool_results: Vec<ToolResult>,
+    pub config: CompletionConfig,
+    pub total_usage: Usage,
+    pub metadata: HashMap<String, serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl Session {
+    pub fn new(config: CompletionConfig) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            state: SessionState::Ready,
+            system_prompt: None,
+            messages: Vec::new(),
+            tools: Vec::new(),
+            pending_tool_calls: Vec::new(),
+            pending_tool_results: Vec::new(),
+            config,
+            total_usage: Usage::default(),
+            metadata: HashMap::new(),
+            created_at: Utc::now(),
+        }
+    }
+
+    pub fn with_id(id: impl Into<String>, config: CompletionConfig) -> Self {
+        Self { id: id.into(), ..Self::new(config) }
+    }
+
+    pub fn set_system_prompt(&mut self, prompt: impl Into<String>) {
+        self.system_prompt = Some(prompt.into());
+    }
+
+    pub fn add_tool(&mut self, tool: Tool) {
+        self.tools.push(tool);
+    }
+
+    pub fn set_tools(&mut self, tools: Vec<Tool>) {
+        self.tools = tools;
+    }
+
+    pub fn add_user_message(&mut self, text: impl Into<String>) {
+        self.messages.push(Message::user(text));
+    }
+
+    pub fn add_assistant_message(&mut self, text: impl Into<String>) {
+        self.messages.push(Message::assistant(text));
+    }
+
+    pub fn add_message(&mut self, message: Message) {
+        self.messages.push(message);
+    }
+
+    pub fn history(&self) -> &[Message] {
+        &self.messages
+    }
+
+    pub fn clear_history(&mut self) {
+        self.messages.clear();
+        self.pending_tool_calls.clear();
+        self.pending_tool_results.clear();
+        self.state = SessionState::Ready;
+    }
+
+    pub fn has_pending_tool_calls(&self) -> bool {
+        !self.pending_tool_calls.is_empty()
+    }
+
+    pub fn pending_tool_calls(&self) -> &[ToolCall] {
+        &self.pending_tool_calls
+    }
+
+    /// Build a completion request from the current session state.
+    ///
+    /// Consumes pending_tool_results — they are added to message history
+    /// as a user message with ToolResult content blocks, then cleared.
+    pub fn build_request(&mut self) -> CompletionRequest {
+        if !self.pending_tool_results.is_empty() {
+            let tool_result_content: Vec<Content> = std::mem::take(&mut self.pending_tool_results)
+                .into_iter()
+                .map(|r| Content::tool_result(r.tool_call_id, r.content, r.is_error))
+                .collect();
+            self.messages.push(Message::new(Role::User, tool_result_content));
+        }
+
+        let mut request = CompletionRequest::new(self.config.clone(), self.messages.clone());
+
+        if let Some(ref system) = self.system_prompt {
+            request = request.with_system(system.clone());
+        }
+
+        if !self.tools.is_empty() {
+            request = request.with_tools(self.tools.clone());
+        }
+
+        request
+    }
+
+    /// Apply a response to the session, updating state.
+    pub fn apply_response(&mut self, response: &Response) {
+        if !response.content.is_empty() {
+            self.messages.push(Message::new(Role::Assistant, response.content.clone()));
+        }
+
+        self.pending_tool_calls = response.tool_calls.clone();
+
+        if !self.pending_tool_calls.is_empty() {
+            self.state = SessionState::AwaitingToolResults;
+        } else {
+            self.state = SessionState::Ready;
+        }
+
+        if let Some(usage) = response.usage {
+            self.total_usage.input_tokens += usage.input_tokens;
+            self.total_usage.output_tokens += usage.output_tokens;
+        }
+    }
+
+    /// Apply tool results and prepare for the next turn.
+    pub fn apply_tool_results(&mut self, results: Vec<ToolResult>) {
+        let result_text = results.iter()
+            .map(|r| {
+                if r.is_error {
+                    format!("Tool {} error: {}", r.tool_call_id, r.content)
+                } else {
+                    format!("Tool {} result: {}", r.tool_call_id, r.content)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        self.messages.push(Message::user(result_text));
+        self.pending_tool_calls.clear();
+        self.state = SessionState::Ready;
+    }
+
+    pub fn cancel(&mut self) {
+        self.state = SessionState::Cancelled;
+        self.pending_tool_calls.clear();
+    }
+}
+
+/// Builder for creating and configuring sessions.
+pub struct SessionBuilder {
+    config: CompletionConfig,
+    system_prompt: Option<String>,
+    tools: Vec<Tool>,
+    initial_messages: Vec<Message>,
+}
+
+impl SessionBuilder {
+    pub fn new(model: impl Into<String>) -> Self {
+        Self {
+            config: CompletionConfig::new(model),
+            system_prompt: None,
+            tools: Vec::new(),
+            initial_messages: Vec::new(),
+        }
+    }
+
+    pub fn system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.system_prompt = Some(prompt.into());
+        self
+    }
+
+    pub fn max_tokens(mut self, max_tokens: u32) -> Self {
+        self.config.max_tokens = max_tokens;
+        self
+    }
+
+    pub fn temperature(mut self, temperature: f32) -> Self {
+        self.config.temperature = Some(temperature);
+        self
+    }
+
+    pub fn tool(mut self, tool: Tool) -> Self {
+        self.tools.push(tool);
+        self
+    }
+
+    pub fn tools(mut self, tools: Vec<Tool>) -> Self {
+        self.tools = tools;
+        self
+    }
+
+    pub fn message(mut self, message: Message) -> Self {
+        self.initial_messages.push(message);
+        self
+    }
+
+    pub fn build(self) -> Session {
+        let mut session = Session::new(self.config);
+        session.system_prompt = self.system_prompt;
+        session.tools = self.tools;
+        session.messages = self.initial_messages;
+        session
+    }
+}
+
+/// Simple chain for multi-turn conversations.
+///
+/// For more complex chains with validation gates and programmatic steps,
+/// use [`crate::chain::ChainBuilder`].
+pub struct Chain<P: Provider> {
+    provider: Arc<P>,
+    session: Session,
+}
+
+impl<P: Provider> Chain<P> {
+    pub fn new(provider: Arc<P>, session: Session) -> Self {
+        Self { provider, session }
+    }
+
+    pub fn with_model(provider: Arc<P>, model: impl Into<String>) -> Self {
+        Self::new(provider, Session::new(CompletionConfig::new(model)))
+    }
+
+    pub fn system(mut self, prompt: impl Into<String>) -> Self {
+        self.session.set_system_prompt(prompt);
+        self
+    }
+
+    pub fn tools(mut self, tools: Vec<Tool>) -> Self {
+        self.session.set_tools(tools);
+        self
+    }
+
+    pub async fn user(mut self, message: impl Into<String>) -> Result<Self, AgentError> {
+        self.session.add_user_message(message);
+        self.session.state = SessionState::Processing;
+
+        let request = self.session.build_request();
+        let response = self.provider.complete(request).await?;
+        self.session.apply_response(&response);
+
+        Ok(self)
+    }
+
+    pub async fn user_validated<F>(
+        mut self,
+        message: impl Into<String>,
+        validator: F,
+    ) -> Result<Self, AgentError>
+    where
+        F: FnOnce(&str) -> Result<(), String>,
+    {
+        self.session.add_user_message(message);
+        self.session.state = SessionState::Processing;
+
+        let request = self.session.build_request();
+        let response = self.provider.complete(request).await?;
+
+        let response_text = response.text();
+        validator(&response_text).map_err(|e| AgentError::Other(format!("Validation failed: {}", e)))?;
+
+        self.session.apply_response(&response);
+
+        Ok(self)
+    }
+
+    pub fn last_response(&self) -> Option<String> {
+        self.session.messages.iter().rev()
+            .find(|m| m.role == Role::Assistant)
+            .map(|m| m.text())
+    }
+
+    pub fn history(&self) -> &[Message] {
+        self.session.history()
+    }
+
+    pub fn session(&self) -> &Session {
+        &self.session
+    }
+
+    pub fn into_session(self) -> Session {
+        self.session
+    }
+
+    pub fn pending_tool_calls(&self) -> &[ToolCall] {
+        self.session.pending_tool_calls()
+    }
+
+    pub async fn tool_results(mut self, results: Vec<ToolResult>) -> Result<Self, AgentError> {
+        self.session.apply_tool_results(results);
+        self.session.state = SessionState::Processing;
+
+        let request = self.session.build_request();
+        let response = self.provider.complete(request).await?;
+        self.session.apply_response(&response);
+
+        Ok(self)
+    }
+
+    pub fn usage(&self) -> Usage {
+        self.session.total_usage
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{Content, StopReason};
+
+    #[test]
+    fn test_session_new() {
+        let session = Session::new(CompletionConfig::new("test-model"));
+        assert_eq!(session.state, SessionState::Ready);
+        assert!(session.messages.is_empty());
+        assert!(!session.id.is_empty());
+    }
+
+    #[test]
+    fn test_session_add_messages() {
+        let mut session = Session::new(CompletionConfig::new("test-model"));
+        session.add_user_message("hello");
+        session.add_assistant_message("hi there");
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[0].text(), "hello");
+        assert_eq!(session.messages[1].text(), "hi there");
+    }
+
+    #[test]
+    fn test_session_build_request() {
+        let mut session = Session::new(CompletionConfig::new("test-model"));
+        session.set_system_prompt("be helpful");
+        session.add_user_message("hello");
+        let request = session.build_request();
+        assert_eq!(request.config.model, "test-model");
+        assert_eq!(request.system, Some("be helpful".to_string()));
+        assert_eq!(request.messages.len(), 1);
+    }
+
+    #[test]
+    fn test_session_apply_response() {
+        let mut session = Session::new(CompletionConfig::new("test-model"));
+        let response = Response {
+            content: vec![Content::text("hello back")],
+            tool_calls: vec![],
+            stop_reason: Some(StopReason::EndTurn),
+            usage: Some(Usage { input_tokens: 10, output_tokens: 5 }),
+        };
+        session.apply_response(&response);
+        assert_eq!(session.state, SessionState::Ready);
+        assert_eq!(session.messages.len(), 1);
+        assert_eq!(session.total_usage.input_tokens, 10);
+    }
+
+    #[test]
+    fn test_session_apply_response_with_tool_calls() {
+        let mut session = Session::new(CompletionConfig::new("test-model"));
+        let response = Response {
+            content: vec![Content::text("let me check")],
+            tool_calls: vec![ToolCall {
+                id: "tc-1".into(),
+                name: "read_file".into(),
+                arguments: serde_json::json!({"path": "/tmp"}),
+            }],
+            stop_reason: Some(StopReason::ToolUse),
+            usage: Some(Usage { input_tokens: 10, output_tokens: 5 }),
+        };
+        session.apply_response(&response);
+        assert_eq!(session.state, SessionState::AwaitingToolResults);
+        assert!(session.has_pending_tool_calls());
+    }
+
+    #[test]
+    fn test_session_clear_history() {
+        let mut session = Session::new(CompletionConfig::new("test-model"));
+        session.add_user_message("hello");
+        session.clear_history();
+        assert!(session.messages.is_empty());
+        assert_eq!(session.state, SessionState::Ready);
+    }
+
+    #[test]
+    fn test_session_builder() {
+        let session = SessionBuilder::new("claude-sonnet-4-20250514")
+            .system_prompt("be helpful")
+            .max_tokens(1024)
+            .temperature(0.7)
+            .build();
+        assert_eq!(session.config.model, "claude-sonnet-4-20250514");
+        assert_eq!(session.system_prompt, Some("be helpful".to_string()));
+        assert_eq!(session.config.max_tokens, 1024);
+        assert_eq!(session.config.temperature, Some(0.7));
+    }
+
+    #[test]
+    fn test_session_cancel() {
+        let mut session = Session::new(CompletionConfig::new("test-model"));
+        session.cancel();
+        assert_eq!(session.state, SessionState::Cancelled);
+    }
+}


### PR DESCRIPTION
## Summary
- New `crates/agent/` crate providing a provider-agnostic LLM abstraction layer, lifted and adapted from `agent-foundry`
- Includes Anthropic Claude provider with streaming support, session management, and chain builder for multi-step workflows
- 19 tests, full workspace compiles clean

## What's included

| Module | Purpose |
|--------|---------|
| `error` | `AgentError` with 14 variants (API, auth, rate limit, network, etc.) |
| `message` | `Message`, `Content`, `Tool`, `ToolCall`, `ToolResult`, `Response`, `Usage` |
| `provider` | `Provider` trait (via `trait_variant`), `CompletionConfig`, `CompletionRequest` |
| `providers/anthropic` | `AnthropicProvider` — HTTP + SSE streaming Claude API client |
| `session` | `Session`, `SessionBuilder`, `Chain<P>` for multi-turn conversations |
| `chain` | `ChainBuilder<P>` with validation gates, transforms, custom async steps |

## Key adaptations from agent-foundry
- `async_trait` → `trait_variant::make(Send)` to match codebase conventions
- Stripped ACP/transport/voice/server concerns (not needed host-side)
- Stripped Audio/ResourceLink/EmbeddedResource content types (YAGNI)
- Stripped SessionManager (YAGNI — orchestrator manages its own sessions)
- `complete_streaming` is a required trait method (trait_variant limitation with default async methods) with `streaming_from_complete()` helper for fallback

## Test plan
- [x] `cargo test -p tasks-agent` — 19 tests pass
- [x] `cargo check --workspace` — full workspace compiles
- [ ] Verify orchestrator crate (#80) can consume this as a dependency

Closes #88