### PR TITLE
Add orchestrator crate scaffolding

### DIFF
--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tasks-orchestrator"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+models = { path = "../models" }
+tasks-agent = { path = "../agent" }
+tasks-github = { path = "../github" }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+trait-variant.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -8,9 +8,7 @@ rust-version.workspace = true
 [dependencies]
 models = { path = "../models" }
 tasks-agent = { path = "../agent" }
-tasks-github = { path = "../github" }
 serde.workspace = true
-serde_json.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -29,7 +29,7 @@ impl ClaudeOrchestrator {
     /// Create from environment variables (ANTHROPIC_API_KEY).
     pub fn from_env() -> Result<Self, OrchestratorError> {
         let provider = AnthropicProvider::from_env()
-            .map_err(|e| OrchestratorError::Agent(e))?;
+            .map_err(OrchestratorError::Agent)?;
         Ok(Self::new(provider))
     }
 }

--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -1,0 +1,72 @@
+//! Claude-backed orchestrator implementation.
+//!
+//! Uses the tasks-agent crate to talk to Claude API and tasks-github
+//! to fetch PR data from GitHub.
+
+use tracing::info;
+
+use crate::error::OrchestratorError;
+use crate::orchestrator::Orchestrator;
+use crate::types::{EvaluationContext, QualityEvaluation};
+use models::task::Task;
+use tasks_agent::AnthropicProvider;
+
+/// Orchestrator implementation backed by Claude.
+///
+/// Holds a Claude API provider for LLM calls. In future, will also
+/// hold a GitHub client for fetching PR data.
+pub struct ClaudeOrchestrator {
+    #[allow(dead_code)]
+    provider: AnthropicProvider,
+}
+
+impl ClaudeOrchestrator {
+    /// Create a new ClaudeOrchestrator with the given provider.
+    pub fn new(provider: AnthropicProvider) -> Self {
+        Self { provider }
+    }
+
+    /// Create from environment variables (ANTHROPIC_API_KEY).
+    pub fn from_env() -> Result<Self, OrchestratorError> {
+        let provider = AnthropicProvider::from_env()
+            .map_err(|e| OrchestratorError::Agent(e))?;
+        Ok(Self::new(provider))
+    }
+}
+
+impl Orchestrator for ClaudeOrchestrator {
+    async fn evaluate(
+        &self,
+        context: &EvaluationContext,
+    ) -> Result<QualityEvaluation, OrchestratorError> {
+        info!(
+            task_id = %context.task.id,
+            pr_url = %context.entry.pr_url,
+            project = %context.project.repo,
+            "Evaluating merge queue entry"
+        );
+
+        // TODO(#81): Implement actual quality evaluation with LLM.
+        // For now, return a placeholder that signals "not yet implemented".
+        Ok(QualityEvaluation {
+            approved: false,
+            reasoning: "Orchestrator evaluation not yet implemented".to_string(),
+            feedback: None,
+        })
+    }
+
+    async fn feedback(
+        &self,
+        task: &Task,
+        feedback: &str,
+    ) -> Result<(), OrchestratorError> {
+        info!(
+            task_id = %task.id,
+            feedback_len = feedback.len(),
+            "Sending feedback to task"
+        );
+
+        // TODO(#81): Implement actual feedback delivery via agent session.
+        Ok(())
+    }
+}

--- a/crates/orchestrator/src/error.rs
+++ b/crates/orchestrator/src/error.rs
@@ -1,0 +1,21 @@
+//! Error types for the orchestrator.
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum OrchestratorError {
+    #[error("Evaluation failed: {0}")]
+    Evaluation(String),
+
+    #[error("Feedback delivery failed: {0}")]
+    Feedback(String),
+
+    #[error("GitHub error: {0}")]
+    GitHub(String),
+
+    #[error("Agent error: {0}")]
+    Agent(#[from] tasks_agent::AgentError),
+
+    #[error("{0}")]
+    Other(String),
+}

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -1,0 +1,11 @@
+//! Orchestrator for the Tasks platform.
+//!
+//! The orchestrator is an AI agent that evaluates merge queue entries
+//! for quality and provides feedback to implementor agents.
+//! See spec §4.2.
+
+pub mod error;
+pub mod types;
+
+pub use error::OrchestratorError;
+pub use types::{EvaluationContext, QualityEvaluation};

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -5,7 +5,9 @@
 //! See spec §4.2.
 
 pub mod error;
+mod orchestrator;
 pub mod types;
 
 pub use error::OrchestratorError;
+pub use orchestrator::Orchestrator;
 pub use types::{EvaluationContext, QualityEvaluation};

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -6,10 +6,12 @@
 
 pub mod error;
 mod claude;
+pub mod mock;
 mod orchestrator;
 pub mod types;
 
 pub use claude::ClaudeOrchestrator;
 pub use error::OrchestratorError;
+pub use mock::MockOrchestrator;
 pub use orchestrator::Orchestrator;
 pub use types::{EvaluationContext, QualityEvaluation};

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -5,9 +5,11 @@
 //! See spec §4.2.
 
 pub mod error;
+mod claude;
 mod orchestrator;
 pub mod types;
 
+pub use claude::ClaudeOrchestrator;
 pub use error::OrchestratorError;
 pub use orchestrator::Orchestrator;
 pub use types::{EvaluationContext, QualityEvaluation};

--- a/crates/orchestrator/src/mock.rs
+++ b/crates/orchestrator/src/mock.rs
@@ -1,0 +1,131 @@
+//! Mock orchestrator for testing.
+
+use std::sync::Mutex;
+
+use crate::error::OrchestratorError;
+use crate::orchestrator::Orchestrator;
+use crate::types::{EvaluationContext, QualityEvaluation};
+use models::task::Task;
+
+/// A mock orchestrator that returns configurable responses.
+///
+/// Used in tests to verify server integration without hitting
+/// a real LLM.
+pub struct MockOrchestrator {
+    /// The evaluation to return from `evaluate()`.
+    evaluation: Mutex<QualityEvaluation>,
+    /// Count of evaluate calls (for assertions).
+    pub evaluate_count: Mutex<u32>,
+    /// Count of feedback calls (for assertions).
+    pub feedback_count: Mutex<u32>,
+}
+
+impl MockOrchestrator {
+    /// Create a mock that always approves.
+    pub fn approving() -> Self {
+        Self {
+            evaluation: Mutex::new(QualityEvaluation {
+                approved: true,
+                reasoning: "Mock: approved".to_string(),
+                feedback: None,
+            }),
+            evaluate_count: Mutex::new(0),
+            feedback_count: Mutex::new(0),
+        }
+    }
+
+    /// Create a mock that always rejects with the given feedback.
+    pub fn rejecting(feedback: impl Into<String>) -> Self {
+        let feedback = feedback.into();
+        Self {
+            evaluation: Mutex::new(QualityEvaluation {
+                approved: false,
+                reasoning: "Mock: rejected".to_string(),
+                feedback: Some(feedback),
+            }),
+            evaluate_count: Mutex::new(0),
+            feedback_count: Mutex::new(0),
+        }
+    }
+
+    /// Set what evaluation to return next.
+    pub fn set_evaluation(&self, eval: QualityEvaluation) {
+        *self.evaluation.lock().unwrap() = eval;
+    }
+}
+
+impl Orchestrator for MockOrchestrator {
+    async fn evaluate(
+        &self,
+        _context: &EvaluationContext,
+    ) -> Result<QualityEvaluation, OrchestratorError> {
+        *self.evaluate_count.lock().unwrap() += 1;
+        Ok(self.evaluation.lock().unwrap().clone())
+    }
+
+    async fn feedback(
+        &self,
+        _task: &Task,
+        _feedback: &str,
+    ) -> Result<(), OrchestratorError> {
+        *self.feedback_count.lock().unwrap() += 1;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::EvaluationContext;
+    use models::merge_queue::MergeQueueEntry;
+    use models::project::Project;
+    use models::task::{Task, TaskSource};
+
+    fn test_context() -> EvaluationContext {
+        EvaluationContext {
+            entry: MergeQueueEntry::new("mq-1", "task-1", "https://github.com/owner/repo/pull/1"),
+            task: Task::new("task-1", TaskSource::Internal, "Test task", "proj-1"),
+            project: Project::new("proj-1", "owner/repo"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mock_approving() {
+        let mock = MockOrchestrator::approving();
+        let ctx = test_context();
+        let result = mock.evaluate(&ctx).await.unwrap();
+        assert!(result.approved);
+        assert_eq!(*mock.evaluate_count.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mock_rejecting() {
+        let mock = MockOrchestrator::rejecting("needs tests");
+        let ctx = test_context();
+        let result = mock.evaluate(&ctx).await.unwrap();
+        assert!(!result.approved);
+        assert_eq!(result.feedback, Some("needs tests".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_mock_feedback() {
+        let mock = MockOrchestrator::approving();
+        let task = Task::new("task-1", TaskSource::Internal, "Test task", "proj-1");
+        mock.feedback(&task, "fix the tests").await.unwrap();
+        assert_eq!(*mock.feedback_count.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mock_set_evaluation() {
+        let mock = MockOrchestrator::approving();
+        mock.set_evaluation(QualityEvaluation {
+            approved: false,
+            reasoning: "changed my mind".to_string(),
+            feedback: Some("redo everything".to_string()),
+        });
+        let ctx = test_context();
+        let result = mock.evaluate(&ctx).await.unwrap();
+        assert!(!result.approved);
+        assert_eq!(result.reasoning, "changed my mind");
+    }
+}

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -1,0 +1,38 @@
+//! Orchestrator trait — the core abstraction.
+//!
+//! Spec §4.2: The orchestrator evaluates work quality and provides feedback.
+//! The trait is intentionally narrow — `evaluate` returns a verdict, and the
+//! caller (server run loop) decides whether to act on it based on mode.
+
+use crate::error::OrchestratorError;
+use crate::types::{EvaluationContext, QualityEvaluation};
+use models::task::Task;
+
+/// Trait for orchestrator implementations.
+///
+/// The orchestrator is pluggable — `ClaudeOrchestrator` is the default
+/// implementation, but tests can use a `MockOrchestrator`.
+#[trait_variant::make(Send)]
+pub trait Orchestrator: Sync {
+    /// Evaluate a merge queue entry for merge worthiness.
+    ///
+    /// Spec §7.3: Checks issue alignment, test/CI status, conflicts,
+    /// and project conventions. Returns a verdict with reasoning.
+    ///
+    /// The orchestrator fetches PR details from GitHub using the
+    /// `pr_url` on the entry — it is not given stale inline data.
+    async fn evaluate(
+        &self,
+        context: &EvaluationContext,
+    ) -> Result<QualityEvaluation, OrchestratorError>;
+
+    /// Send feedback to a task's agent session.
+    ///
+    /// Used after rejection to re-engage the implementor with specific
+    /// guidance on what needs to change.
+    async fn feedback(
+        &self,
+        task: &Task,
+        feedback: &str,
+    ) -> Result<(), OrchestratorError>;
+}

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -1,0 +1,39 @@
+//! Orchestrator domain types.
+//!
+//! EvaluationContext: what the orchestrator receives.
+//! QualityEvaluation: what the orchestrator returns.
+
+use models::merge_queue::MergeQueueEntry;
+use models::project::Project;
+use models::task::Task;
+use serde::{Deserialize, Serialize};
+
+/// Context for evaluating a merge queue entry.
+///
+/// The orchestrator receives the entry, the associated task, and the project.
+/// It fetches PR details (diff, CI status, etc.) from GitHub itself using
+/// the `pr_url` on the entry — the remote PR is the source of truth.
+pub struct EvaluationContext {
+    /// The merge queue entry being evaluated.
+    pub entry: MergeQueueEntry,
+    /// The task that produced this PR.
+    pub task: Task,
+    /// The project this task belongs to.
+    pub project: Project,
+}
+
+/// Verdict from the orchestrator's quality evaluation.
+///
+/// Spec §7.3: The orchestrator evaluates whether a PR meets quality standards
+/// before it can be merged. The caller (server run loop) decides whether to
+/// act on the verdict based on the current operating mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QualityEvaluation {
+    /// Whether the orchestrator approves this for merge.
+    pub approved: bool,
+    /// The orchestrator's reasoning for its decision.
+    pub reasoning: String,
+    /// Specific feedback for the implementor, if the PR needs work.
+    /// Used to re-engage the task's agent session.
+    pub feedback: Option<String>,
+}


### PR DESCRIPTION
## Summary
- New `crates/orchestrator/` crate with the core `Orchestrator` trait and supporting types
- `ClaudeOrchestrator` stub wired to the agent crate (actual LLM evaluation logic deferred to #81)
- `MockOrchestrator` for testing with configurable responses and call counting
- 4 tests passing, full workspace compiles clean

## What's included

| Module | Purpose |
|--------|---------|
| `error` | `OrchestratorError` — evaluation, feedback, GitHub, agent errors |
| `types` | `EvaluationContext` (entry + task + project), `QualityEvaluation` (approved + reasoning + feedback) |
| `orchestrator` | `Orchestrator` trait — `evaluate()` returns verdict, `feedback()` re-engages tasks |
| `claude` | `ClaudeOrchestrator` — stub impl backed by `AnthropicProvider` |
| `mock` | `MockOrchestrator` — configurable mock for testing |

## Design decisions (from #80)
- **Trait + concrete impl** — matches `ContainerRuntime` / `MockRuntime` pattern
- **`evaluate` returns verdict, caller acts** — server run loop owns mode-awareness
- **EvaluationContext passes PR URL, not inline data** — orchestrator fetches from GitHub itself
- **Depends on agent crate (#88)** for LLM abstractions

## Test plan
- [x] `cargo test -p tasks-orchestrator` — 4 tests pass
- [x] `cargo check --workspace` — full workspace compiles
- [ ] Wire into server (#85) and verify merge queue processing

Closes #80