### PR TITLE
Wire orchestrator into server run loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@ A human-in-the-loop platform that orchestrates coding agents to get project work
   - `app/` — Binary entry point: startup, run loops, component wiring
   - `events/` — Event system: append-only log, pub/sub
   - `github/` — GitHub integration: GraphQL client, normalized model, polling
+  - `agent/` — LLM abstraction layer: Provider trait, Anthropic client, session, chain builder
   - `models/` — Shared domain types: project, task, merge entry, task state
+  - `orchestrator/` — Orchestrator: AI project foreman, quality evaluation, merge authority
   - `runtime/` — Session runtime: container lifecycle, protocol, transport
   - `server/` — Server: domain models, operating modes, merge queue, presence
   - `session/` — Session management: lifecycle, monitoring, event bridging
@@ -31,6 +33,10 @@ A human-in-the-loop platform that orchestrates coding agents to get project work
 - Container images: built with `container build` (apple/container CLI), NOT Docker
 - Data directory: `~/.tasks/` (SQLite + event logs), configurable via `TASKS_DATA_DIR`
 - Config: `.env` file at project root, loaded automatically via dotenvy
+
+## Working on issues
+
+- When making design decisions during brainstorming or implementation, leave comments on the relevant GitHub issue with the decision and reasoning. Don't edit the issue body — comments create a timeline and make active issues more glanceable in the list.
 
 ## Building the container image
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -13,6 +13,7 @@ server = { path = "../server" }
 tasks-session = { path = "../session" }
 tasks-github = { path = "../github" }
 tasks-store = { path = "../store" }
+tasks-orchestrator = { path = "../orchestrator" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -424,7 +424,11 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 continue;
                             }
                         }
-                        Err(_) => continue,
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            warn!(skipped = n, "orchestrator loop lagged");
+                            continue;
+                        }
+                        Err(_) => break, // channel closed, shut down
                     }
                 }
             };
@@ -510,6 +514,11 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                         ).await {
                             error!(entry_id = %entry_id, error = %e, "failed to reject merge entry");
                         }
+                        // TODO: Call orch.feedback(&task, feedback) to deliver
+                        // guidance to the re-dispatched session. Currently the
+                        // feedback only lands in the event payload; the fresh
+                        // session started by the dispatch loop doesn't receive it.
+                        // Needs dispatch loop changes to pass feedback as prompt context.
                     }
                 }
 

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -14,7 +14,30 @@ use server::Server;
 use tasks_github::client::GitHubClient;
 use tasks_github::poller::RepoPoller;
 
+use tasks_orchestrator::Orchestrator;
+
 use crate::config::AppConfig;
+
+/// Enum wrapper for orchestrator implementations.
+///
+/// `trait_variant::make(Send)` generates non-dyn-compatible traits, so we
+/// use an enum to dispatch instead of `Arc<dyn Orchestrator>`.
+enum AnyOrchestrator {
+    Claude(tasks_orchestrator::ClaudeOrchestrator),
+    Mock(tasks_orchestrator::MockOrchestrator),
+}
+
+impl AnyOrchestrator {
+    async fn evaluate(
+        &self,
+        context: &tasks_orchestrator::EvaluationContext,
+    ) -> Result<tasks_orchestrator::QualityEvaluation, tasks_orchestrator::OrchestratorError> {
+        match self {
+            Self::Claude(o) => o.evaluate(context).await,
+            Self::Mock(o) => o.evaluate(context).await,
+        }
+    }
+}
 
 /// Run the Tasks platform.
 ///
@@ -97,6 +120,21 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         .with_soft_time_limit(config.session_soft_limit)
         .with_hard_time_limit(config.session_hard_limit),
     );
+
+    // --- 5b. Create orchestrator ---
+
+    let orchestrator = Arc::new(match tasks_orchestrator::ClaudeOrchestrator::from_env() {
+        Ok(o) => {
+            info!("orchestrator initialized (Claude-backed)");
+            AnyOrchestrator::Claude(o)
+        }
+        Err(e) => {
+            warn!(error = %e, "failed to initialize Claude orchestrator, using mock (always rejects)");
+            AnyOrchestrator::Mock(tasks_orchestrator::MockOrchestrator::rejecting(
+                "orchestrator not configured",
+            ))
+        }
+    });
 
     // --- 6. Emit system:started ---
 
@@ -353,6 +391,134 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
+    // --- 8b. Spawn orchestrator loop ---
+    //
+    // The orchestrator is the project foreman. On each tick it observes
+    // project state and acts: evaluates merge queue entries, comments on
+    // PRs, adjusts tasks. Currently only merge queue evaluation is wired.
+    // In Play mode it auto-approves/rejects. In Pause mode it evaluates
+    // but doesn't merge. In Stop mode it's idle.
+
+    let orch_server = server.clone();
+    let orch = orchestrator.clone();
+    let orch_event_bus = server.event_bus.clone();
+    let orchestrator_interval = config.dispatch_interval; // reuse dispatch interval for now
+
+    let orchestrator_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(orchestrator_interval);
+        let mut event_rx = orch_event_bus.subscribe();
+
+        loop {
+            // Tick on interval or on merge-relevant events
+            tokio::select! {
+                _ = interval.tick() => {},
+                result = event_rx.recv() => {
+                    match result {
+                        Ok(event) => {
+                            if !matches!(
+                                event.event_type,
+                                EventType::MergeQueued
+                                | EventType::SystemModePlay
+                                | EventType::SystemModePause
+                            ) {
+                                continue;
+                            }
+                        }
+                        Err(_) => continue,
+                    }
+                }
+            };
+
+            // Read current mode — idle in Stop
+            let mode = orch_server.mode().await;
+            if mode == server::Mode::Stop {
+                continue;
+            }
+
+            // Snapshot pending merge queue entries with their tasks and projects
+            let pending: Vec<(String, String, String)> = {
+                let state = orch_server.state.read().await;
+                state.merge_queue.pending().iter().map(|entry| {
+                    (entry.id.clone(), entry.task_id.clone(), entry.pr_url.clone())
+                }).collect()
+            };
+
+            for (entry_id, task_id, _pr_url) in pending {
+                // Build evaluation context
+                let (task, project) = {
+                    let state = orch_server.state.read().await;
+                    let task = match state.tasks.get(&task_id) {
+                        Some(t) => t.clone(),
+                        None => continue,
+                    };
+                    let project = match state.projects.get(&task.project) {
+                        Some(p) => p.clone(),
+                        None => continue,
+                    };
+                    (task, project)
+                };
+
+                let entry = {
+                    let state = orch_server.state.read().await;
+                    match state.merge_queue.get(&entry_id) {
+                        Some(e) => e.clone(),
+                        None => continue,
+                    }
+                };
+
+                let context = tasks_orchestrator::EvaluationContext {
+                    entry,
+                    task: task.clone(),
+                    project,
+                };
+
+                // Evaluate
+                let evaluation = match orch.evaluate(&context).await {
+                    Ok(eval) => eval,
+                    Err(e) => {
+                        error!(
+                            entry_id = %entry_id,
+                            task_id = %task_id,
+                            error = %e,
+                            "orchestrator evaluation failed"
+                        );
+                        continue;
+                    }
+                };
+
+                // Always emit a decision event (audit trail)
+                if let Err(e) = orch_server.emit_orchestrator_decision(
+                    &task_id,
+                    &entry_id,
+                    evaluation.approved,
+                    &evaluation.reasoning,
+                ).await {
+                    error!(error = %e, "failed to emit orchestrator decision event");
+                }
+
+                // In Play mode: act on the decision
+                if mode == server::Mode::Play {
+                    if evaluation.approved {
+                        if let Err(e) = orch_server.approve_merge_entry(&entry_id, &evaluation.reasoning).await {
+                            error!(entry_id = %entry_id, error = %e, "failed to approve merge entry");
+                        }
+                    } else {
+                        if let Err(e) = orch_server.reject_merge_entry(
+                            &entry_id,
+                            &evaluation.reasoning,
+                            evaluation.feedback.as_deref(),
+                        ).await {
+                            error!(entry_id = %entry_id, error = %e, "failed to reject merge entry");
+                        }
+                    }
+                }
+
+                // In Pause mode: evaluation is recorded (decision event above)
+                // but no merge/reject action is taken. The human reviews.
+            }
+        }
+    });
+
     // --- 9. Optionally spawn web server ---
 
     let web_handle = if config.web {
@@ -405,6 +571,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     poll_handle.abort();
     dispatch_handle.abort();
     event_handler_handle.abort();
+    orchestrator_handle.abort();
     if let Some(h) = web_handle {
         h.abort();
     }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -11,7 +11,6 @@ runtime = { path = "../runtime" }
 models = { path = "../models" }
 tasks-store = { path = "../store" }
 tasks-github = { path = "../github" }
-tasks-orchestrator = { path = "../orchestrator" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -11,6 +11,7 @@ runtime = { path = "../runtime" }
 models = { path = "../models" }
 tasks-store = { path = "../store" }
 tasks-github = { path = "../github" }
+tasks-orchestrator = { path = "../orchestrator" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -498,6 +498,103 @@ impl Server {
         Ok(flushed)
     }
 
+    /// Approve a merge queue entry and emit a `merge:approved` event.
+    ///
+    /// In Play mode, this is called by the orchestrator loop after a
+    /// positive evaluation. The entry transitions from Pending to Approved.
+    pub async fn approve_merge_entry(
+        &self,
+        entry_id: &str,
+        reasoning: &str,
+    ) -> Result<(), ServerError> {
+        let task_id = {
+            let mut state = self.state.write().await;
+            state
+                .merge_queue
+                .approve(entry_id)
+                .map_err(|e| ServerError::StoreError(e.to_string()))?;
+            let entry = state.merge_queue.get(entry_id)
+                .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
+            entry.task_id.clone()
+        };
+
+        let event = Event::new(
+            EventType::MergeApproved,
+            &task_id,
+            Actor::Orchestrator,
+            serde_json::json!({ "entry_id": entry_id, "reasoning": reasoning }),
+        );
+        self.event_bus.publish(event).await?;
+        Ok(())
+    }
+
+    /// Reject a merge queue entry, re-dispatch the task with feedback,
+    /// and emit a `merge:rejected` event.
+    ///
+    /// The task transitions back to Waiting so the dispatch loop picks
+    /// it up and starts a fresh session with the feedback as context.
+    pub async fn reject_merge_entry(
+        &self,
+        entry_id: &str,
+        reasoning: &str,
+        feedback: Option<&str>,
+    ) -> Result<(), ServerError> {
+        let task_id = {
+            let mut state = self.state.write().await;
+            state
+                .merge_queue
+                .reject(entry_id)
+                .map_err(|e| ServerError::StoreError(e.to_string()))?;
+            let entry = state.merge_queue.get(entry_id)
+                .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
+            entry.task_id.clone()
+        };
+
+        // Emit rejection event
+        let event = Event::new(
+            EventType::MergeRejected,
+            &task_id,
+            Actor::Orchestrator,
+            serde_json::json!({
+                "entry_id": entry_id,
+                "reasoning": reasoning,
+                "feedback": feedback,
+            }),
+        );
+        self.event_bus.publish(event).await?;
+
+        // Transition task back to Waiting for re-dispatch (scenario 2)
+        self.set_task_state(&task_id, TaskState::Waiting, Actor::Orchestrator)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Emit an orchestrator:decision event recording an evaluation.
+    ///
+    /// Called for every evaluation regardless of mode — this is the
+    /// audit trail of the orchestrator's judgment.
+    pub async fn emit_orchestrator_decision(
+        &self,
+        task_id: &str,
+        entry_id: &str,
+        approved: bool,
+        reasoning: &str,
+    ) -> Result<(), ServerError> {
+        let event = Event::new(
+            EventType::OrchestratorDecision,
+            task_id,
+            Actor::Orchestrator,
+            serde_json::json!({
+                "entry_id": entry_id,
+                "approved": approved,
+                "reasoning": reasoning,
+            }),
+        );
+        self.event_bus.publish(event).await?;
+        Ok(())
+    }
+
     // --- Presence (spec Section 4.1) ---
 
     /// Whether the human is present (has active GUI connections).

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1003,4 +1003,69 @@ mod tests {
         assert!(server.get_project("p1").await.is_some());
         assert!(server.get_task("t1").await.is_some());
     }
+
+    #[tokio::test]
+    async fn approve_merge_entry_transitions_and_emits() {
+        let server = test_server().await;
+        let mut rx = server.event_bus.subscribe();
+
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+
+        let task = Task::new("task-1", TaskSource::Internal, "Test task", "proj-1");
+        server.add_task(task).await.unwrap();
+
+        let entry = crate::model::merge_queue::MergeQueueEntry::new(
+            "mq-1", "task-1", "https://github.com/owner/repo/pull/1",
+        );
+        server.add_to_merge_queue(entry).await.unwrap();
+
+        // Drain the queued and task-created events
+        while rx.try_recv().is_ok() {}
+
+        server.approve_merge_entry("mq-1", "looks good").await.unwrap();
+
+        // Check the entry is approved
+        let state = server.state.read().await;
+        let entry = state.merge_queue.get("mq-1").unwrap();
+        assert_eq!(entry.status, crate::model::merge_queue::MergeStatus::Approved);
+        drop(state);
+
+        // Check event was emitted
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.event_type, EventType::MergeApproved);
+        assert_eq!(event.actor, Actor::Orchestrator);
+    }
+
+    #[tokio::test]
+    async fn reject_merge_entry_transitions_task_to_waiting() {
+        let server = test_server().await;
+
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+
+        let mut task = Task::new("task-1", TaskSource::Internal, "Test task", "proj-1");
+        task.set_state(TaskState::AwaitingMerge);
+        server.add_task(task).await.unwrap();
+
+        let entry = crate::model::merge_queue::MergeQueueEntry::new(
+            "mq-1", "task-1", "https://github.com/owner/repo/pull/1",
+        );
+        server.add_to_merge_queue(entry).await.unwrap();
+
+        server
+            .reject_merge_entry("mq-1", "needs tests", Some("add unit tests for the new endpoint"))
+            .await
+            .unwrap();
+
+        // Entry should be rejected
+        let state = server.state.read().await;
+        let entry = state.merge_queue.get("mq-1").unwrap();
+        assert_eq!(entry.status, crate::model::merge_queue::MergeStatus::Rejected);
+        drop(state);
+
+        // Task should be back to Waiting for re-dispatch
+        let task = server.get_task("task-1").await.unwrap();
+        assert_eq!(task.state, TaskState::Waiting);
+    }
 }


### PR DESCRIPTION
## Summary
- Server gets helper methods for orchestrator actions: `approve_merge_entry`, `reject_merge_entry`, `emit_orchestrator_decision`
- New orchestrator loop in `run_loop.rs` runs as a concurrent tokio task alongside dispatch/events/github
- Mode-aware: evaluates in Pause+Play, only acts (approve/reject) in Play, idle in Stop
- On rejection, task transitions back to Waiting for re-dispatch with fresh session (scenario 2)
- 74 server tests passing (2 new), full workspace compiles

## Orchestrator loop behavior

| Mode | Evaluate | Emit decision event | Approve/Reject |
|------|----------|-------------------|----------------|
| Stop | No | No | No |
| Pause | Yes | Yes | No (human reviews) |
| Play | Yes | Yes | Yes (auto) |

## Implementation notes
- `trait_variant::make(Send)` generates non-dyn-compatible traits, so the loop uses an `AnyOrchestrator` enum to dispatch between `ClaudeOrchestrator` and `MockOrchestrator` instead of `Arc<dyn Orchestrator>`
- Falls back to a rejecting MockOrchestrator if `ANTHROPIC_API_KEY` is not set
- Loop wakes on timer tick or merge-relevant events (`MergeQueued`, mode changes)

## Test plan
- [x] `cargo test -p server` — 74 tests pass (including new approve/reject tests)
- [x] `cargo check --workspace` — full workspace compiles
- [ ] End-to-end: start platform in Play mode with a PR in the merge queue, verify orchestrator evaluates it

Closes #85