### PR TITLE
Add missing agent and orchestrator crates to Dockerfile

### DIFF
--- a/src/runtime/Dockerfile
+++ b/src/runtime/Dockerfile
@@ -7,10 +7,12 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock* ./
 
 # Copy all crate Cargo.toml files (workspace glob requires them to exist).
+COPY crates/agent/Cargo.toml crates/agent/Cargo.toml
 COPY crates/app/Cargo.toml crates/app/Cargo.toml
 COPY crates/events/Cargo.toml crates/events/Cargo.toml
 COPY crates/github/Cargo.toml crates/github/Cargo.toml
 COPY crates/models/Cargo.toml crates/models/Cargo.toml
+COPY crates/orchestrator/Cargo.toml crates/orchestrator/Cargo.toml
 COPY crates/runtime/Cargo.toml crates/runtime/Cargo.toml
 COPY crates/server/Cargo.toml crates/server/Cargo.toml
 COPY crates/session/Cargo.toml crates/session/Cargo.toml


### PR DESCRIPTION
## Summary
- The Dockerfile hardcodes COPY lines for each workspace crate, but the new `agent` and `orchestrator` crates were never added
- This breaks `container build` because `app` depends on `orchestrator`, and cargo can't resolve the workspace

## Test plan
- [ ] `container build --dns 8.8.8.8 -f src/runtime/Dockerfile -t tasks-agent:latest .` completes successfully