### PR TITLE
Reduce font sizes in frontend UI to 2 sizes

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -37,7 +37,7 @@ export function Layout() {
       <aside className="flex w-60 flex-col border-r border-border bg-background">
         {/* App title */}
         <div className="border-b border-border px-4 py-4">
-          <h1 className="text-lg font-bold tracking-tight">Tasks</h1>
+          <h1 className="text-base font-bold tracking-tight">Tasks</h1>
         </div>
 
         {/* Project switcher */}

--- a/web/src/components/project-switcher.tsx
+++ b/web/src/components/project-switcher.tsx
@@ -123,7 +123,7 @@ export function ProjectSwitcher() {
                       )}
                     />
                     <span className="truncate">All Projects</span>
-                    <span className="text-xs text-muted-foreground">
+                    <span className="text-sm text-muted-foreground">
                       ({projects.length})
                     </span>
                   </span>

--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -91,7 +91,7 @@ export function DashboardPage() {
   if (!snapshot) {
     return (
       <div className="flex items-center justify-center h-full py-32">
-        <p className="text-muted-foreground text-lg">No data yet</p>
+        <p className="text-muted-foreground text-sm">No data yet</p>
       </div>
     );
   }
@@ -111,9 +111,9 @@ export function DashboardPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-bold">
+            <p className="text-base font-bold">
               {snapshot.slot_utilization.active}
-              <span className="text-muted-foreground text-base font-normal">
+              <span className="text-muted-foreground font-normal">
                 {" "}
                 / {snapshot.slot_utilization.max}
               </span>
@@ -128,7 +128,7 @@ export function DashboardPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-bold">{runningCount}</p>
+            <p className="text-base font-bold">{runningCount}</p>
           </CardContent>
         </Card>
 
@@ -139,7 +139,7 @@ export function DashboardPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-bold">{waitingCount}</p>
+            <p className="text-base font-bold">{waitingCount}</p>
           </CardContent>
         </Card>
 
@@ -150,14 +150,14 @@ export function DashboardPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-bold">{filteredMergeQueue.length}</p>
+            <p className="text-base font-bold">{filteredMergeQueue.length}</p>
           </CardContent>
         </Card>
       </div>
 
       {/* Active Tasks */}
       <section>
-        <h2 className="text-lg font-semibold mb-3">Active Tasks</h2>
+        <h2 className="text-base font-semibold mb-3">Active Tasks</h2>
 
         {activeTasks.length === 0 ? (
           <p className="text-muted-foreground text-sm">
@@ -178,11 +178,11 @@ export function DashboardPage() {
                   </span>
                   {/* Only show project when viewing all projects */}
                   {!selectedProject && (
-                    <span className="text-muted-foreground text-xs shrink-0">
+                    <span className="text-muted-foreground text-sm shrink-0">
                       {task.project}
                     </span>
                   )}
-                  <span className="text-muted-foreground text-xs shrink-0">
+                  <span className="text-muted-foreground text-sm shrink-0">
                     {formatRelativeTime(task.updated_at)}
                   </span>
                 </div>
@@ -194,7 +194,7 @@ export function DashboardPage() {
 
       {/* Recent Events */}
       <section>
-        <h2 className="text-lg font-semibold mb-3">Recent Events</h2>
+        <h2 className="text-base font-semibold mb-3">Recent Events</h2>
 
         {recentEvents.length === 0 ? (
           <p className="text-muted-foreground text-sm">No events yet.</p>
@@ -205,21 +205,21 @@ export function DashboardPage() {
                 key={event.id}
                 className="flex items-start gap-3 rounded-lg border bg-card px-3 py-2 text-sm"
               >
-                <span className="text-muted-foreground text-xs whitespace-nowrap pt-0.5">
+                <span className="text-muted-foreground text-sm whitespace-nowrap pt-0.5">
                   {formatRelativeTime(event.ts)}
                 </span>
-                <Badge variant="outline" className="shrink-0 text-xs">
+                <Badge variant="outline" className="shrink-0">
                   {event.type}
                 </Badge>
-                <span className="text-muted-foreground text-xs shrink-0">
+                <span className="text-muted-foreground text-sm shrink-0">
                   {event.actor}
                 </span>
                 {event.task && (
-                  <span className="font-mono text-xs text-muted-foreground shrink-0">
+                  <span className="font-mono text-sm text-muted-foreground shrink-0">
                     {event.task.slice(0, 8)}
                   </span>
                 )}
-                <span className="text-xs text-muted-foreground truncate flex-1">
+                <span className="text-sm text-muted-foreground truncate flex-1">
                   {eventDataPreview(event.data)}
                 </span>
               </div>

--- a/web/src/pages/events/page.tsx
+++ b/web/src/pages/events/page.tsx
@@ -95,7 +95,7 @@ export function EventsPage() {
               size="sm"
               variant={activeFilter === key ? "default" : "outline"}
               onClick={() => setActiveFilter(key)}
-              className="h-7 text-xs"
+              className="h-7"
             >
               {label}
             </Button>
@@ -145,22 +145,22 @@ export function EventsPage() {
             <TableBody>
               {filteredEvents.map((event) => (
                 <TableRow key={event.id}>
-                  <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                  <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
                     {formatRelativeTime(event.ts)}
                   </TableCell>
                   <TableCell>
                     <Badge
                       variant="outline"
-                      className={cn("text-xs font-mono", badgeClasses(event.type))}
+                      className={cn("font-mono", badgeClasses(event.type))}
                     >
                       {event.type}
                     </Badge>
                   </TableCell>
-                  <TableCell className="text-sm">{event.actor}</TableCell>
-                  <TableCell className="font-mono text-xs text-muted-foreground">
+                  <TableCell>{event.actor}</TableCell>
+                  <TableCell className="font-mono text-sm text-muted-foreground">
                     {event.task ? event.task.slice(0, 8) : "\u2014"}
                   </TableCell>
-                  <TableCell className="text-xs text-muted-foreground max-w-[400px] truncate font-mono">
+                  <TableCell className="text-sm text-muted-foreground max-w-[400px] truncate font-mono">
                     {truncateData(event.data)}
                   </TableCell>
                 </TableRow>

--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -37,7 +37,7 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
     accessorKey: "id",
     header: "ID",
     cell: ({ row }) => (
-      <span className="font-mono text-xs">{row.original.id.slice(0, 8)}</span>
+      <span className="font-mono text-sm">{row.original.id.slice(0, 8)}</span>
     ),
   },
   {
@@ -54,7 +54,7 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
       return (
         <Link
           to={`/tasks/${row.original.task_id}`}
-          className="font-mono text-sm text-blue-400 hover:underline"
+          className="font-mono text-blue-400 hover:underline"
         >
           {label}
         </Link>
@@ -68,7 +68,7 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
       const tasks = (table.options.meta as { tasks?: Task[] })?.tasks ?? [];
       const task = tasks.find((t) => t.id === row.original.task_id);
       return (
-        <span className="text-sm text-muted-foreground">
+        <span className="text-muted-foreground">
           {task?.project ?? "—"}
         </span>
       );
@@ -87,7 +87,7 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-blue-400 hover:underline text-xs"
+          className="inline-flex items-center gap-1 text-blue-400 hover:underline text-sm"
         >
           PR
           <ExternalLink className="h-3 w-3" />
@@ -104,7 +104,7 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
     accessorKey: "queued_at",
     header: "Queued",
     cell: ({ row }) => (
-      <span className="text-xs text-muted-foreground whitespace-nowrap">
+      <span className="text-sm text-muted-foreground whitespace-nowrap">
         {formatRelativeTime(row.original.queued_at)}
       </span>
     ),

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -93,7 +93,7 @@ export function MergeQueuePage() {
   if (!snapshot) {
     return (
       <div className="flex items-center justify-center h-full py-32">
-        <p className="text-muted-foreground text-lg">Loading...</p>
+        <p className="text-muted-foreground text-sm">Loading...</p>
       </div>
     );
   }
@@ -108,7 +108,7 @@ export function MergeQueuePage() {
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-3">
-            <h1 className="text-2xl font-bold">Merge Queue</h1>
+            <h1 className="text-base font-bold">Merge Queue</h1>
             {mode && modeBadge(mode)}
           </div>
           {selectedProjectName && (

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -230,7 +230,7 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
 function BlockView({ block }: { block: ParsedBlock }) {
   if (block.kind === "tool_use") {
     return (
-      <div className="flex items-center gap-2 py-1 text-muted-foreground text-xs">
+      <div className="flex items-center gap-2 py-1 text-muted-foreground text-sm">
         <Terminal className="h-3 w-3 shrink-0" />
         <span className="font-medium">{block.toolName}</span>
         {block.content && (
@@ -247,7 +247,7 @@ function BlockView({ block }: { block: ParsedBlock }) {
       <div className="rounded-md border border-border bg-muted/50 text-sm overflow-hidden">
         <button
           onClick={() => setOpen(!open)}
-          className="flex items-center gap-2 px-3 py-1.5 w-full text-left text-muted-foreground text-xs hover:bg-muted/80"
+          className="flex items-center gap-2 px-3 py-1.5 w-full text-left text-muted-foreground text-sm hover:bg-muted/80"
         >
           <FileText className="h-3 w-3 shrink-0" />
           <span>Output</span>
@@ -258,7 +258,7 @@ function BlockView({ block }: { block: ParsedBlock }) {
           )}
         </button>
         {(open || !isLong) && (
-          <pre className="px-3 py-2 text-xs font-mono overflow-x-auto whitespace-pre-wrap max-h-64 overflow-y-auto text-muted-foreground border-t border-border">
+          <pre className="px-3 py-2 text-sm font-mono overflow-x-auto whitespace-pre-wrap max-h-64 overflow-y-auto text-muted-foreground border-t border-border">
             {block.content}
           </pre>
         )}
@@ -268,7 +268,7 @@ function BlockView({ block }: { block: ParsedBlock }) {
 
   if (block.kind === "lifecycle") {
     return (
-      <div className="flex items-center gap-2 py-1.5 text-xs text-muted-foreground">
+      <div className="flex items-center gap-2 py-1.5 text-sm text-muted-foreground">
         <div className="h-px flex-1 bg-border" />
         <span>{block.content}</span>
         <div className="h-px flex-1 bg-border" />
@@ -455,7 +455,7 @@ export function TaskDetailPage() {
   if (!snapshot) {
     return (
       <div className="flex items-center justify-center h-full py-32">
-        <p className="text-muted-foreground text-lg">Loading...</p>
+        <p className="text-muted-foreground text-sm">Loading...</p>
       </div>
     );
   }
@@ -485,7 +485,7 @@ export function TaskDetailPage() {
         </Link>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <h1 className="text-xl font-bold truncate">{task.title}</h1>
+            <h1 className="text-base font-bold truncate">{task.title}</h1>
             {stateBadge(task.state)}
             {isSessionActive && (
               <Button
@@ -501,7 +501,7 @@ export function TaskDetailPage() {
             )}
           </div>
           <div className="flex items-center gap-3 mt-1 text-sm text-muted-foreground">
-            <span className="font-mono text-xs">{task.id.slice(0, 8)}</span>
+            <span className="font-mono text-sm">{task.id.slice(0, 8)}</span>
             <Separator orientation="vertical" className="h-4" />
             {sourceDisplay(task)}
             <Separator orientation="vertical" className="h-4" />
@@ -511,7 +511,7 @@ export function TaskDetailPage() {
                 <Separator orientation="vertical" className="h-4" />
                 <span className="flex gap-1">
                   {task.labels.map((l) => (
-                    <Badge key={l} variant="outline" className="text-xs">
+                    <Badge key={l} variant="outline">
                       {l}
                     </Badge>
                   ))}
@@ -572,7 +572,7 @@ export function TaskDetailPage() {
                   {task.session_id && (
                     <div>
                       <dt className="text-muted-foreground">Session</dt>
-                      <dd className="font-mono text-xs">
+                      <dd className="font-mono text-sm">
                         {task.session_id.slice(0, 12)}
                       </dd>
                     </div>
@@ -583,7 +583,7 @@ export function TaskDetailPage() {
                       <dd>
                         <Link
                           to={`/tasks/${task.parent_id}`}
-                          className="text-blue-400 hover:underline font-mono text-xs"
+                          className="text-blue-400 hover:underline font-mono text-sm"
                         >
                           {task.parent_id.slice(0, 8)}
                         </Link>
@@ -598,7 +598,7 @@ export function TaskDetailPage() {
                           <Link
                             key={bid}
                             to={`/tasks/${bid}`}
-                            className="text-blue-400 hover:underline font-mono text-xs"
+                            className="text-blue-400 hover:underline font-mono text-sm"
                           >
                             {bid.slice(0, 8)}
                           </Link>
@@ -656,18 +656,18 @@ export function TaskDetailPage() {
                   <TableBody>
                     {events.map((event) => (
                       <TableRow key={event.id}>
-                        <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                        <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
                           {formatRelativeTime(event.ts)}
                         </TableCell>
                         <TableCell>
-                          <Badge variant="outline" className="text-xs">
+                          <Badge variant="outline">
                             {event.type}
                           </Badge>
                         </TableCell>
-                        <TableCell className="text-xs text-muted-foreground">
+                        <TableCell className="text-sm text-muted-foreground">
                           {event.actor}
                         </TableCell>
-                        <TableCell className="text-xs font-mono text-muted-foreground max-w-md truncate">
+                        <TableCell className="text-sm font-mono text-muted-foreground max-w-md truncate">
                           {eventDataPreview(event.data)}
                         </TableCell>
                       </TableRow>

--- a/web/src/pages/tasks/columns.tsx
+++ b/web/src/pages/tasks/columns.tsx
@@ -168,7 +168,7 @@ export const columns: ColumnDef<Task>[] = [
           ? `#${source.number}`
           : row.original.id.slice(0, 8);
       return (
-        <span className="font-mono text-xs text-muted-foreground">
+        <span className="font-mono text-sm text-muted-foreground">
           {label}
         </span>
       );
@@ -194,7 +194,7 @@ export const columns: ColumnDef<Task>[] = [
             {row.getValue<string>("title")}
           </a>
           {labels.map((label) => (
-            <Badge key={label} variant="outline" className="text-xs">
+            <Badge key={label} variant="outline">
               {label}
             </Badge>
           ))}
@@ -241,7 +241,7 @@ export const columns: ColumnDef<Task>[] = [
       const projectId = row.getValue<string>("project");
       const meta = table.options.meta as { projectIdToRepo?: Record<string, string> } | undefined;
       const displayName = meta?.projectIdToRepo?.[projectId] ?? projectId;
-      return <span className="text-sm">{displayName}</span>;
+      return <span>{displayName}</span>;
     },
     filterFn: (row, id, value: string[]) => {
       return value.includes(row.getValue(id));
@@ -260,19 +260,19 @@ export const columns: ColumnDef<Task>[] = [
         return (
           <span className="flex items-center gap-1 text-gray-500">
             <Minus className="h-4 w-4" />
-            <span className="text-xs">None</span>
+            <span className="text-sm">None</span>
           </span>
         );
       }
       const config = priorityConfig[priority];
       if (!config) {
-        return <span className="text-xs text-muted-foreground">{priority}</span>;
+        return <span className="text-sm text-muted-foreground">{priority}</span>;
       }
       const Icon = config.icon;
       return (
         <span className={cn("flex items-center gap-1", config.className)}>
           <Icon className="h-4 w-4" />
-          <span className="text-xs">{config.label}</span>
+          <span className="text-sm">{config.label}</span>
         </span>
       );
     },
@@ -290,7 +290,7 @@ export const columns: ColumnDef<Task>[] = [
       <DataTableColumnHeader column={column} title="Updated" />
     ),
     cell: ({ row }) => (
-      <span className="text-sm text-muted-foreground">
+      <span className="text-muted-foreground">
         {formatRelativeTime(row.getValue<string>("updated_at"))}
       </span>
     ),

--- a/web/src/pages/tasks/data-table-faceted-filter.tsx
+++ b/web/src/pages/tasks/data-table-faceted-filter.tsx
@@ -118,7 +118,7 @@ export function DataTableFacetedFilter<TData, TValue>({
                     )}
                     <span>{option.label}</span>
                     {facets?.get(option.value) != null && (
-                      <span className="ml-auto flex h-4 w-4 items-center justify-center font-mono text-xs">
+                      <span className="ml-auto flex h-4 w-4 items-center justify-center font-mono text-sm">
                         {facets.get(option.value)}
                       </span>
                     )}

--- a/web/src/pages/tasks/page.tsx
+++ b/web/src/pages/tasks/page.tsx
@@ -24,7 +24,7 @@ export function TasksPage() {
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 md:p-8">
       <div>
-        <h2 className="text-2xl font-bold tracking-tight">Tasks</h2>
+        <h2 className="text-base font-bold tracking-tight">Tasks</h2>
         <p className="text-muted-foreground">
           {selectedProjectName
             ? `Tasks for ${selectedProjectName}`


### PR DESCRIPTION
## Summary

- Consolidate font sizes to just `text-base` (headings) and `text-sm` (body text) in page/application code
- Remove usage of `text-xs`, `text-lg`, `text-xl`, and `text-2xl` from custom components
- Keep shadcn/ui primitives (`components/ui/`) unchanged as they have appropriate defaults

## Test plan

- [ ] Verify build passes (`npm run build`)
- [ ] Visual review of all pages (Dashboard, Tasks, Task Detail, Merge Queue, Events)
- [ ] Confirm text is readable and hierarchy is clear with the simplified font scale

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)