### PR TITLE
Implement orchestrator mode lowering (spec §6.4)

### DIFF
--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -56,8 +56,8 @@ impl AppConfig {
         let container_image = std::env::var("TASKS_CONTAINER_IMAGE")
             .unwrap_or_else(|_| "tasks-agent:latest".to_string());
 
-        let container_memory = std::env::var("TASKS_CONTAINER_MEMORY")
-            .unwrap_or_else(|_| "8G".to_string());
+        let container_memory =
+            std::env::var("TASKS_CONTAINER_MEMORY").unwrap_or_else(|_| "8G".to_string());
 
         let max_sessions = std::env::var("TASKS_MAX_SESSIONS")
             .ok()

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -5,6 +5,7 @@
 
 mod config;
 mod memory;
+mod problem_tracker;
 mod run_loop;
 mod tui;
 mod web;
@@ -109,8 +110,7 @@ async fn main() {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
-    let stderr_layer = tracing_subscriber::fmt::layer()
-        .with_writer(std::io::stderr);
+    let stderr_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
 
     let file_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::sync::Mutex::new(log_file))

--- a/crates/app/src/problem_tracker.rs
+++ b/crates/app/src/problem_tracker.rs
@@ -1,0 +1,409 @@
+//! Problem tracker for orchestrator mode lowering (spec §6.4).
+//!
+//! Tracks failure patterns that warrant lowering operating mode from Play
+//! to Pause. The orchestrator can lower mode (but not raise it).
+//!
+//! Tracked patterns:
+//! - Consecutive evaluation failures (API/internal errors)
+//! - Consecutive PR rejections (pattern of bad PRs)
+//! - Merge conflicts within a time window
+//! - Agent errors within a time window
+//! - Task failures within a time window
+
+use std::time::{Duration, Instant};
+
+/// Reason for recommending mode lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LowerReason {
+    /// Multiple consecutive evaluation failures (API errors, etc.)
+    ConsecutiveEvalFailures(u32),
+    /// Multiple consecutive PR rejections (bad PR pattern)
+    ConsecutiveRejections(u32),
+    /// Too many merge conflicts in a short time
+    RepeatedConflicts(u32),
+    /// Too many agent errors in a short time
+    RepeatedAgentErrors(u32),
+    /// Too many task failures in a short time
+    RepeatedTaskFailures(u32),
+}
+
+impl std::fmt::Display for LowerReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LowerReason::ConsecutiveEvalFailures(n) => {
+                write!(f, "{} consecutive evaluation failures", n)
+            }
+            LowerReason::ConsecutiveRejections(n) => {
+                write!(f, "{} consecutive PR rejections", n)
+            }
+            LowerReason::RepeatedConflicts(n) => {
+                write!(f, "{} merge conflicts in tracking window", n)
+            }
+            LowerReason::RepeatedAgentErrors(n) => {
+                write!(f, "{} agent errors in tracking window", n)
+            }
+            LowerReason::RepeatedTaskFailures(n) => {
+                write!(f, "{} task failures in tracking window", n)
+            }
+        }
+    }
+}
+
+/// Configuration for problem thresholds.
+#[derive(Debug, Clone)]
+pub struct ProblemThresholds {
+    /// Number of consecutive evaluation failures before lowering mode.
+    pub eval_failure_threshold: u32,
+    /// Number of consecutive PR rejections before lowering mode.
+    pub rejection_threshold: u32,
+    /// Number of merge conflicts within window before lowering mode.
+    pub conflict_threshold: u32,
+    /// Number of agent errors within window before lowering mode.
+    pub agent_error_threshold: u32,
+    /// Number of task failures within window before lowering mode.
+    pub task_failure_threshold: u32,
+    /// Time window for tracking windowed events.
+    pub window_duration: Duration,
+}
+
+impl Default for ProblemThresholds {
+    fn default() -> Self {
+        Self {
+            eval_failure_threshold: 3,
+            rejection_threshold: 5,
+            conflict_threshold: 3,
+            agent_error_threshold: 3,
+            task_failure_threshold: 3,
+            window_duration: Duration::from_secs(10 * 60), // 10 minutes
+        }
+    }
+}
+
+/// Tracks problem patterns and determines when to lower operating mode.
+///
+/// Used by the orchestrator loop to detect situations that warrant
+/// transitioning from Play to Pause mode.
+#[derive(Debug)]
+pub struct ProblemTracker {
+    thresholds: ProblemThresholds,
+    /// Consecutive evaluation failures (API errors, not rejections).
+    consecutive_eval_failures: u32,
+    /// Consecutive PR rejections (bad PR pattern).
+    consecutive_rejections: u32,
+    /// Timestamps of recent merge conflicts.
+    recent_conflicts: Vec<Instant>,
+    /// Timestamps of recent agent errors.
+    recent_agent_errors: Vec<Instant>,
+    /// Timestamps of recent task failures.
+    recent_task_failures: Vec<Instant>,
+    /// Whether mode has already been lowered (to avoid repeated lowering).
+    mode_lowered: bool,
+}
+
+impl ProblemTracker {
+    /// Create a new problem tracker with default thresholds.
+    pub fn new() -> Self {
+        Self::with_thresholds(ProblemThresholds::default())
+    }
+
+    /// Create a problem tracker with custom thresholds.
+    pub fn with_thresholds(thresholds: ProblemThresholds) -> Self {
+        Self {
+            thresholds,
+            consecutive_eval_failures: 0,
+            consecutive_rejections: 0,
+            recent_conflicts: Vec::new(),
+            recent_agent_errors: Vec::new(),
+            recent_task_failures: Vec::new(),
+            mode_lowered: false,
+        }
+    }
+
+    /// Record a successful evaluation (resets consecutive failures).
+    pub fn record_eval_success(&mut self) {
+        self.consecutive_eval_failures = 0;
+    }
+
+    /// Record an evaluation failure (API error, not a rejection).
+    pub fn record_eval_failure(&mut self) {
+        self.consecutive_eval_failures += 1;
+    }
+
+    /// Record a PR approval (resets consecutive rejections).
+    pub fn record_approval(&mut self) {
+        self.consecutive_rejections = 0;
+    }
+
+    /// Record a PR rejection (bad PR pattern).
+    pub fn record_rejection(&mut self) {
+        self.consecutive_rejections += 1;
+    }
+
+    /// Record a merge conflict.
+    pub fn record_conflict(&mut self) {
+        self.recent_conflicts.push(Instant::now());
+    }
+
+    /// Record an agent error.
+    pub fn record_agent_error(&mut self) {
+        self.recent_agent_errors.push(Instant::now());
+    }
+
+    /// Record a task failure.
+    pub fn record_task_failure(&mut self) {
+        self.recent_task_failures.push(Instant::now());
+    }
+
+    /// Clean up old entries outside the tracking window.
+    fn prune_old_entries(&mut self) {
+        let cutoff = Instant::now() - self.thresholds.window_duration;
+        self.recent_conflicts.retain(|&t| t > cutoff);
+        self.recent_agent_errors.retain(|&t| t > cutoff);
+        self.recent_task_failures.retain(|&t| t > cutoff);
+    }
+
+    /// Check if mode should be lowered, returning the reason if so.
+    ///
+    /// Returns `None` if no threshold has been exceeded or if mode
+    /// has already been lowered (to avoid repeated lowering events).
+    pub fn should_lower_mode(&mut self) -> Option<LowerReason> {
+        // Don't repeatedly lower
+        if self.mode_lowered {
+            return None;
+        }
+
+        // Prune old entries first
+        self.prune_old_entries();
+
+        // Check thresholds in order of severity
+        if self.consecutive_eval_failures >= self.thresholds.eval_failure_threshold {
+            self.mode_lowered = true;
+            return Some(LowerReason::ConsecutiveEvalFailures(
+                self.consecutive_eval_failures,
+            ));
+        }
+
+        if self.recent_agent_errors.len() as u32 >= self.thresholds.agent_error_threshold {
+            self.mode_lowered = true;
+            return Some(LowerReason::RepeatedAgentErrors(
+                self.recent_agent_errors.len() as u32,
+            ));
+        }
+
+        if self.recent_task_failures.len() as u32 >= self.thresholds.task_failure_threshold {
+            self.mode_lowered = true;
+            return Some(LowerReason::RepeatedTaskFailures(
+                self.recent_task_failures.len() as u32,
+            ));
+        }
+
+        if self.recent_conflicts.len() as u32 >= self.thresholds.conflict_threshold {
+            self.mode_lowered = true;
+            return Some(LowerReason::RepeatedConflicts(
+                self.recent_conflicts.len() as u32
+            ));
+        }
+
+        if self.consecutive_rejections >= self.thresholds.rejection_threshold {
+            self.mode_lowered = true;
+            return Some(LowerReason::ConsecutiveRejections(
+                self.consecutive_rejections,
+            ));
+        }
+
+        None
+    }
+
+    /// Reset the tracker when mode is raised back to Play.
+    ///
+    /// Called when the human raises mode, allowing the tracker to
+    /// detect new problems and lower mode again if needed.
+    pub fn reset(&mut self) {
+        self.consecutive_eval_failures = 0;
+        self.consecutive_rejections = 0;
+        self.recent_conflicts.clear();
+        self.recent_agent_errors.clear();
+        self.recent_task_failures.clear();
+        self.mode_lowered = false;
+    }
+
+    /// Check if mode has been lowered by this tracker.
+    pub fn is_mode_lowered(&self) -> bool {
+        self.mode_lowered
+    }
+}
+
+impl Default for ProblemTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consecutive_eval_failures_triggers_lowering() {
+        let thresholds = ProblemThresholds {
+            eval_failure_threshold: 3,
+            ..Default::default()
+        };
+        let mut tracker = ProblemTracker::with_thresholds(thresholds);
+
+        // Two failures: not enough
+        tracker.record_eval_failure();
+        tracker.record_eval_failure();
+        assert!(tracker.should_lower_mode().is_none());
+
+        // Third failure: should trigger
+        tracker.record_eval_failure();
+        let reason = tracker.should_lower_mode();
+        assert!(matches!(
+            reason,
+            Some(LowerReason::ConsecutiveEvalFailures(3))
+        ));
+    }
+
+    #[test]
+    fn eval_success_resets_failure_count() {
+        let thresholds = ProblemThresholds {
+            eval_failure_threshold: 3,
+            ..Default::default()
+        };
+        let mut tracker = ProblemTracker::with_thresholds(thresholds);
+
+        tracker.record_eval_failure();
+        tracker.record_eval_failure();
+        tracker.record_eval_success(); // Reset
+        tracker.record_eval_failure();
+        tracker.record_eval_failure();
+
+        assert!(tracker.should_lower_mode().is_none());
+    }
+
+    #[test]
+    fn consecutive_rejections_triggers_lowering() {
+        let thresholds = ProblemThresholds {
+            rejection_threshold: 3,
+            ..Default::default()
+        };
+        let mut tracker = ProblemTracker::with_thresholds(thresholds);
+
+        tracker.record_rejection();
+        tracker.record_rejection();
+        assert!(tracker.should_lower_mode().is_none());
+
+        tracker.record_rejection();
+        let reason = tracker.should_lower_mode();
+        assert!(matches!(
+            reason,
+            Some(LowerReason::ConsecutiveRejections(3))
+        ));
+    }
+
+    #[test]
+    fn approval_resets_rejection_count() {
+        let thresholds = ProblemThresholds {
+            rejection_threshold: 3,
+            ..Default::default()
+        };
+        let mut tracker = ProblemTracker::with_thresholds(thresholds);
+
+        tracker.record_rejection();
+        tracker.record_rejection();
+        tracker.record_approval(); // Reset
+        tracker.record_rejection();
+        tracker.record_rejection();
+
+        assert!(tracker.should_lower_mode().is_none());
+    }
+
+    #[test]
+    fn agent_errors_trigger_lowering() {
+        let thresholds = ProblemThresholds {
+            agent_error_threshold: 2,
+            ..Default::default()
+        };
+        let mut tracker = ProblemTracker::with_thresholds(thresholds);
+
+        tracker.record_agent_error();
+        assert!(tracker.should_lower_mode().is_none());
+
+        tracker.record_agent_error();
+        let reason = tracker.should_lower_mode();
+        assert!(matches!(reason, Some(LowerReason::RepeatedAgentErrors(2))));
+    }
+
+    #[test]
+    fn task_failures_trigger_lowering() {
+        let thresholds = ProblemThresholds {
+            task_failure_threshold: 2,
+            ..Default::default()
+        };
+        let mut tracker = ProblemTracker::with_thresholds(thresholds);
+
+        tracker.record_task_failure();
+        assert!(tracker.should_lower_mode().is_none());
+
+        tracker.record_task_failure();
+        let reason = tracker.should_lower_mode();
+        assert!(matches!(reason, Some(LowerReason::RepeatedTaskFailures(2))));
+    }
+
+    #[test]
+    fn conflicts_trigger_lowering() {
+        let thresholds = ProblemThresholds {
+            conflict_threshold: 2,
+            ..Default::default()
+        };
+        let mut tracker = ProblemTracker::with_thresholds(thresholds);
+
+        tracker.record_conflict();
+        assert!(tracker.should_lower_mode().is_none());
+
+        tracker.record_conflict();
+        let reason = tracker.should_lower_mode();
+        assert!(matches!(reason, Some(LowerReason::RepeatedConflicts(2))));
+    }
+
+    #[test]
+    fn mode_lowered_flag_prevents_repeated_lowering() {
+        let thresholds = ProblemThresholds {
+            eval_failure_threshold: 2,
+            ..Default::default()
+        };
+        let mut tracker = ProblemTracker::with_thresholds(thresholds);
+
+        tracker.record_eval_failure();
+        tracker.record_eval_failure();
+        assert!(tracker.should_lower_mode().is_some());
+
+        // More failures shouldn't trigger again
+        tracker.record_eval_failure();
+        assert!(tracker.should_lower_mode().is_none());
+        assert!(tracker.is_mode_lowered());
+    }
+
+    #[test]
+    fn reset_allows_new_lowering() {
+        let thresholds = ProblemThresholds {
+            eval_failure_threshold: 2,
+            ..Default::default()
+        };
+        let mut tracker = ProblemTracker::with_thresholds(thresholds);
+
+        tracker.record_eval_failure();
+        tracker.record_eval_failure();
+        assert!(tracker.should_lower_mode().is_some());
+
+        // Reset (human raised mode)
+        tracker.reset();
+        assert!(!tracker.is_mode_lowered());
+
+        // New failures can trigger again
+        tracker.record_eval_failure();
+        tracker.record_eval_failure();
+        assert!(tracker.should_lower_mode().is_some());
+    }
+}

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -5,6 +5,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use std::sync::Mutex as StdMutex;
+
 use tracing::{error, info, warn};
 
 use events::{Actor, Event, EventBus, EventStore, EventType};
@@ -18,6 +20,7 @@ use tasks_orchestrator::Orchestrator;
 
 use crate::config::AppConfig;
 use crate::memory::{MemoryGate, MemoryThresholds};
+use crate::problem_tracker::ProblemTracker;
 
 /// Enum wrapper for orchestrator implementations.
 ///
@@ -38,6 +41,47 @@ impl AnyOrchestrator {
             Self::Mock(o) => o.evaluate(context).await,
         }
     }
+}
+
+/// Lower operating mode from Play to Pause (spec §6.4).
+///
+/// Called by the orchestrator loop when problem patterns are detected.
+/// Logs the reason and emits an escalation event.
+async fn lower_mode(server: &Arc<server::Server>, reason: &crate::problem_tracker::LowerReason) {
+    // Only lower from Play — if already in Pause/Stop, nothing to do
+    let current_mode = server.mode().await;
+    if current_mode != server::Mode::Play {
+        return;
+    }
+
+    warn!(reason = %reason, "orchestrator lowering mode to Pause");
+
+    // Lower mode
+    if let Err(e) = server
+        .set_mode(server::Mode::Pause, &events::Actor::Orchestrator)
+        .await
+    {
+        error!(error = %e, "failed to lower mode");
+        return;
+    }
+
+    // Emit escalation event so human knows why mode was lowered
+    let event = events::Event::new(
+        events::EventType::OrchestratorEscalation,
+        "system",
+        events::Actor::Orchestrator,
+        serde_json::json!({
+            "action": "mode_lowered",
+            "from": "play",
+            "to": "pause",
+            "reason": reason.to_string(),
+        }),
+    );
+    if let Err(e) = server.event_bus.publish(event).await {
+        error!(error = %e, "failed to emit escalation event for mode lowering");
+    }
+
+    info!("mode lowered to Pause by orchestrator");
 }
 
 /// Run the Tasks platform.
@@ -575,32 +619,29 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // PRs, adjusts tasks. Currently only merge queue evaluation is wired.
     // In Play mode it auto-approves/rejects. In Pause mode it evaluates
     // but doesn't merge. In Stop mode it's idle.
+    //
+    // Mode lowering (spec §6.4): The orchestrator tracks problem patterns
+    // and can lower mode from Play to Pause when things go wrong.
 
     let orch_server = server.clone();
     let orch = orchestrator.clone();
     let orch_event_bus = server.event_bus.clone();
     let orchestrator_interval = config.dispatch_interval; // reuse dispatch interval for now
 
+    // Problem tracker for mode lowering (spec §6.4)
+    let problem_tracker = Arc::new(StdMutex::new(ProblemTracker::new()));
+
     let orchestrator_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(orchestrator_interval);
         let mut event_rx = orch_event_bus.subscribe();
 
         loop {
-            // Tick on interval or on merge-relevant events
-            tokio::select! {
-                _ = interval.tick() => {},
+            // Tick on interval or on relevant events
+            let event_opt = tokio::select! {
+                _ = interval.tick() => None,
                 result = event_rx.recv() => {
                     match result {
-                        Ok(event) => {
-                            if !matches!(
-                                event.event_type,
-                                EventType::MergeQueued
-                                | EventType::SystemModePlay
-                                | EventType::SystemModePause
-                            ) {
-                                continue;
-                            }
-                        }
+                        Ok(event) => Some(event),
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                             warn!(skipped = n, "orchestrator loop lagged");
                             continue;
@@ -609,6 +650,63 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
             };
+
+            // Handle specific events for problem tracking and mode lowering
+            if let Some(ref event) = event_opt {
+                match event.event_type {
+                    // Reset problem tracker when human raises mode to Play
+                    EventType::SystemModePlay => {
+                        if let Ok(mut tracker) = problem_tracker.lock() {
+                            tracker.reset();
+                            info!("problem tracker reset (mode raised to Play)");
+                        }
+                    }
+                    // Track agent errors
+                    EventType::AgentError => {
+                        let should_lower = {
+                            let mut tracker = problem_tracker.lock().unwrap();
+                            tracker.record_agent_error();
+                            tracker.should_lower_mode()
+                        };
+                        if let Some(reason) = should_lower {
+                            lower_mode(&orch_server, &reason).await;
+                        }
+                    }
+                    // Track task failures
+                    EventType::TaskStateFailed => {
+                        let should_lower = {
+                            let mut tracker = problem_tracker.lock().unwrap();
+                            tracker.record_task_failure();
+                            tracker.should_lower_mode()
+                        };
+                        if let Some(reason) = should_lower {
+                            lower_mode(&orch_server, &reason).await;
+                        }
+                    }
+                    // Track merge conflicts
+                    EventType::MergeConflict => {
+                        let should_lower = {
+                            let mut tracker = problem_tracker.lock().unwrap();
+                            tracker.record_conflict();
+                            tracker.should_lower_mode()
+                        };
+                        if let Some(reason) = should_lower {
+                            lower_mode(&orch_server, &reason).await;
+                        }
+                    }
+                    // Skip non-relevant events for merge queue processing
+                    _ if !matches!(
+                        event.event_type,
+                        EventType::MergeQueued
+                            | EventType::SystemModePlay
+                            | EventType::SystemModePause
+                    ) =>
+                    {
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
 
             // Read current mode — idle in Stop
             let mode = orch_server.mode().await;
@@ -664,7 +762,13 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
 
                 // Evaluate
                 let evaluation = match orch.evaluate(&context).await {
-                    Ok(eval) => eval,
+                    Ok(eval) => {
+                        // Track successful evaluation
+                        if let Ok(mut tracker) = problem_tracker.lock() {
+                            tracker.record_eval_success();
+                        }
+                        eval
+                    }
                     Err(e) => {
                         error!(
                             entry_id = %entry_id,
@@ -672,6 +776,15 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                             error = %e,
                             "orchestrator evaluation failed"
                         );
+                        // Track evaluation failure and check for mode lowering
+                        let should_lower = {
+                            let mut tracker = problem_tracker.lock().unwrap();
+                            tracker.record_eval_failure();
+                            tracker.should_lower_mode()
+                        };
+                        if let Some(reason) = should_lower {
+                            lower_mode(&orch_server, &reason).await;
+                        }
                         continue;
                     }
                 };
@@ -692,6 +805,10 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                 // In Play mode: act on the decision
                 if mode == server::Mode::Play {
                     if evaluation.approved {
+                        // Track approval (resets rejection counter)
+                        if let Ok(mut tracker) = problem_tracker.lock() {
+                            tracker.record_approval();
+                        }
                         if let Err(e) = orch_server
                             .approve_merge_entry(&entry_id, &evaluation.reasoning)
                             .await
@@ -699,6 +816,15 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                             error!(entry_id = %entry_id, error = %e, "failed to approve merge entry");
                         }
                     } else {
+                        // Track rejection and check for mode lowering
+                        let should_lower = {
+                            let mut tracker = problem_tracker.lock().unwrap();
+                            tracker.record_rejection();
+                            tracker.should_lower_mode()
+                        };
+                        if let Some(reason) = should_lower {
+                            lower_mode(&orch_server, &reason).await;
+                        }
                         if let Err(e) = orch_server
                             .reject_merge_entry(
                                 &entry_id,

--- a/crates/app/src/tui.rs
+++ b/crates/app/src/tui.rs
@@ -11,15 +11,15 @@ use std::time::Duration;
 use crossterm::event::{Event as CtEvent, EventStream, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::execute;
 use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
 use futures::StreamExt;
+use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
-use ratatui::Terminal;
 
 use events::{Event as PlatformEvent, EventBus, EventType};
 use models::merge_queue::MergeStatus;
@@ -143,7 +143,12 @@ async fn refresh_from_server(tui: &mut TuiState, server: &Server) {
     tui.active_sessions = state
         .tasks
         .values()
-        .filter(|t| matches!(t.state, TaskState::Running | TaskState::Question | TaskState::Testing))
+        .filter(|t| {
+            matches!(
+                t.state,
+                TaskState::Running | TaskState::Question | TaskState::Testing
+            )
+        })
         .count();
 
     // Projects
@@ -240,7 +245,7 @@ fn draw(terminal: &mut Terminal<CrosstermBackend<Stdout>>, tui: &mut TuiState) -
             .direction(Direction::Vertical)
             .constraints([
                 Constraint::Length(1), // status bar
-                Constraint::Min(5),   // body
+                Constraint::Min(5),    // body
                 Constraint::Length(1), // keybindings
             ])
             .split(size);
@@ -322,10 +327,7 @@ fn draw_task_list(f: &mut ratatui::Frame, area: Rect, tui: &mut TuiState) {
 
             ListItem::new(Line::from(vec![
                 Span::styled(format!("{icon} "), Style::default().fg(color)),
-                Span::styled(
-                    format!("#{num} "),
-                    Style::default().fg(Color::DarkGray),
-                ),
+                Span::styled(format!("#{num} "), Style::default().fg(Color::DarkGray)),
                 Span::raw(display_title),
             ]))
         })
@@ -359,8 +361,11 @@ fn draw_merge_queue(f: &mut ratatui::Frame, area: Rect, tui: &TuiState) {
         })
         .collect();
 
-    let list = List::new(items)
-        .block(Block::default().borders(Borders::ALL).title(" Merge Queue "));
+    let list = List::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Merge Queue "),
+    );
     f.render_widget(list, area);
 }
 

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -4,28 +4,28 @@
 //! The server serves the built frontend as static files and
 //! exposes API endpoints under `/api/`.
 
-use std::sync::Arc;
 use std::convert::Infallible;
+use std::sync::Arc;
 
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
     http::StatusCode,
     response::{
-        sse::{Event as SseEvent, KeepAlive, Sse},
         IntoResponse, Response,
+        sse::{Event as SseEvent, KeepAlive, Sse},
     },
     routing::{get, post},
 };
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
-use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
+use tokio_stream::wrappers::BroadcastStream;
 use tower_http::cors::CorsLayer;
 
 use events::Actor;
-use server::mode::Mode;
 use server::Server;
+use server::mode::Mode;
 
 /// Shared state for API handlers.
 #[derive(Clone)]
@@ -175,9 +175,7 @@ async fn get_task_events(
 }
 
 /// GET /api/projects — List all projects.
-async fn list_projects(
-    State(state): State<ApiState>,
-) -> Json<Vec<models::project::Project>> {
+async fn list_projects(State(state): State<ApiState>) -> Json<Vec<models::project::Project>> {
     let server_state = state.server.state.read().await;
     Json(server_state.projects.values().cloned().collect())
 }


### PR DESCRIPTION
## Summary

Implements orchestrator mode lowering per spec §6.4. The orchestrator can now detect failure patterns and lower the operating mode from Play to Pause when things go wrong.

- Adds `ProblemTracker` struct to track failure patterns:
  - Consecutive evaluation failures (API errors)
  - Consecutive PR rejections (bad PR pattern)
  - Merge conflicts within a time window
  - Agent errors within a time window  
  - Task failures within a time window
- Wires tracker into the orchestrator loop in `run_loop.rs`
- Subscribes to `AgentError`, `TaskStateFailed`, and `MergeConflict` events
- Calls `server.set_mode(Pause, Actor::Orchestrator)` when thresholds exceeded
- Emits `orchestrator:escalation` event explaining why mode was lowered
- Resets tracker when human raises mode back to Play

Closes #93

## Test plan

- [ ] Manual testing: verify mode lowers after configured number of failures
- [ ] Verify escalation event is emitted with correct reason
- [ ] Verify tracker resets when mode is raised to Play
- [ ] Unit tests pass in `problem_tracker.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)