### PR TITLE
Load system_prompt from workflow config at dispatch time

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -384,6 +384,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     let max_sessions = config.max_sessions;
     let dispatch_event_bus = server.event_bus.clone();
     let dispatch_memory_gate = memory_gate.clone();
+    let dispatch_github_token = config.github_token.clone();
 
     // Debounce interval to coalesce rapid events (100ms)
     let debounce_duration = std::time::Duration::from_millis(100);
@@ -498,7 +499,18 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 .unwrap_or_default();
                             let branch = format!("tasks/{}", task.id);
 
-                            let prompt = server::prompt::build_prompt_for_task(&task, &branch);
+                            // Load system prompt from workflow config (spec §14, §15)
+                            let system_prompt = load_system_prompt_for_project(
+                                project.as_ref(),
+                                &dispatch_github_token,
+                            )
+                            .await;
+
+                            let prompt = server::prompt::build_prompt_for_task(
+                                &task,
+                                &branch,
+                                system_prompt.as_deref(),
+                            );
 
                             if let Err(e) = dispatch_session_mgr
                                 .start_session(
@@ -748,4 +760,102 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
 
     info!("shutdown complete");
     Ok(())
+}
+
+/// Load system prompt content for a project at dispatch time (spec §14, §15).
+///
+/// 1. Fetches `workflow.toml` from the repository root
+/// 2. Parses the workflow config to get the system_prompt path
+/// 3. Fetches the system prompt file if configured
+/// 4. Returns the content, or None if not configured or unavailable
+///
+/// Errors are logged but don't fail dispatch — the session continues with
+/// the default prompt (no project-level system prompt).
+async fn load_system_prompt_for_project(
+    project: Option<&models::project::Project>,
+    github_token: &str,
+) -> Option<String> {
+    let project = project?;
+
+    // Parse owner/repo
+    let parts: Vec<&str> = project.repo.split('/').collect();
+    if parts.len() != 2 {
+        warn!(repo = %project.repo, "invalid repo format, cannot load workflow config");
+        return None;
+    }
+    let (owner, repo) = (parts[0], parts[1]);
+
+    // Create GitHub client
+    let client = GitHubClient::new(github_token);
+
+    // Fetch workflow.toml
+    let workflow_content = match client.get_file_content(owner, repo, "workflow.toml").await {
+        Ok(Some(content)) => content,
+        Ok(None) => {
+            // No workflow.toml — that's fine, use defaults
+            return None;
+        }
+        Err(e) => {
+            warn!(
+                project_id = %project.id,
+                error = %e,
+                "failed to fetch workflow.toml, using default prompt"
+            );
+            return None;
+        }
+    };
+
+    // Parse workflow config
+    let workflow_config = match server::workflow::WorkflowConfig::parse(&workflow_content) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            warn!(
+                project_id = %project.id,
+                error = %e,
+                "failed to parse workflow.toml, using default prompt"
+            );
+            return None;
+        }
+    };
+
+    // Get system_prompt path from config
+    let system_prompt_path = match &workflow_config.prompt.system_prompt {
+        Some(path) => path,
+        None => {
+            // No system_prompt configured
+            return None;
+        }
+    };
+
+    // Fetch the system prompt file
+    match client
+        .get_file_content(owner, repo, system_prompt_path)
+        .await
+    {
+        Ok(Some(content)) => {
+            info!(
+                project_id = %project.id,
+                path = %system_prompt_path,
+                "loaded system prompt from workflow config"
+            );
+            Some(content)
+        }
+        Ok(None) => {
+            warn!(
+                project_id = %project.id,
+                path = %system_prompt_path,
+                "system_prompt file not found in repository"
+            );
+            None
+        }
+        Err(e) => {
+            warn!(
+                project_id = %project.id,
+                path = %system_prompt_path,
+                error = %e,
+                "failed to fetch system_prompt file"
+            );
+            None
+        }
+    }
 }

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -361,6 +361,78 @@ impl GitHubClient {
     }
 
     // -----------------------------------------------------------------------
+    // File content (spec §14 — workflow config loading)
+    // -----------------------------------------------------------------------
+
+    /// Fetch file content from a repository at a given path.
+    ///
+    /// Uses the GitHub REST API contents endpoint. Returns the file's decoded
+    /// content as a string. The path should be relative to the repo root
+    /// (e.g., "workflow.toml" or ".tasks/prompt.md").
+    ///
+    /// Returns `Ok(None)` if the file doesn't exist (404). Returns an error
+    /// for other failures (network, auth, etc.).
+    pub async fn get_file_content(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+    ) -> Result<Option<String>, GitHubError> {
+        self.wait_for_rate_limit().await;
+
+        let url = format!(
+            "{}/repos/{}/{}/contents/{}",
+            self.base_url, owner, repo, path
+        );
+
+        let response = self
+            .http
+            .get(&url)
+            .header("Accept", "application/vnd.github.raw+json")
+            .send()
+            .await?;
+
+        // Update rate limit state from headers.
+        self.update_rate_limit(&response);
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::FORBIDDEN {
+            if let Some(rl) = self.rate_limit() {
+                if rl.remaining == 0 {
+                    return Err(GitHubError::RateLimited {
+                        reset_at: rl.reset_at,
+                    });
+                }
+            }
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Decode(format!(
+                "unexpected status {status}: {text}"
+            )));
+        }
+
+        let content = response.text().await.map_err(|e| {
+            GitHubError::Decode(format!("failed to read response body: {e}"))
+        })?;
+
+        Ok(Some(content))
+    }
+
+    // -----------------------------------------------------------------------
     // PR discovery
     // -----------------------------------------------------------------------
 

--- a/crates/github/tests/client_tests.rs
+++ b/crates/github/tests/client_tests.rs
@@ -647,3 +647,89 @@ async fn pr_since_filter_stops_at_cutoff() {
     assert_eq!(prs.len(), 1);
     assert_eq!(prs[0].number, 10);
 }
+
+// ---------------------------------------------------------------------------
+// File content tests (spec §14 — workflow config loading)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_file_content_returns_raw_content() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/contents/workflow.toml"))
+        .and(header("accept", "application/vnd.github.raw+json"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string("[prompt]\nsystem_prompt = \"prompt.md\""),
+        )
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let content = client
+        .get_file_content("owner", "repo", "workflow.toml")
+        .await
+        .unwrap();
+
+    assert!(content.is_some());
+    assert!(content.as_ref().unwrap().contains("system_prompt"));
+}
+
+#[tokio::test]
+async fn get_file_content_returns_none_for_404() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/contents/nonexistent.toml"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Not found"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let content = client
+        .get_file_content("owner", "repo", "nonexistent.toml")
+        .await
+        .unwrap();
+
+    assert!(content.is_none());
+}
+
+#[tokio::test]
+async fn get_file_content_auth_error_on_401() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/contents/workflow.toml"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Bad credentials"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let result = client
+        .get_file_content("owner", "repo", "workflow.toml")
+        .await;
+
+    assert!(matches!(result, Err(GitHubError::Auth(_))));
+}
+
+#[tokio::test]
+async fn get_file_content_fetches_nested_path() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/contents/.tasks/prompt.md"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string("# System Prompt\n\nUse conventional commits."),
+        )
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let content = client
+        .get_file_content("owner", "repo", ".tasks/prompt.md")
+        .await
+        .unwrap();
+
+    assert!(content.is_some());
+    assert!(content.as_ref().unwrap().contains("conventional commits"));
+}

--- a/crates/server/src/prompt.rs
+++ b/crates/server/src/prompt.rs
@@ -124,7 +124,15 @@ pub fn build_prompt(params: &PromptParams) -> String {
 /// Extracts the issue/PR number from the task source and builds retry
 /// context from the task's retry state. This keeps domain logic in the
 /// server crate rather than in the app's run loop.
-pub fn build_prompt_for_task(task: &crate::model::task::Task, branch: &str) -> String {
+///
+/// The `system_prompt` parameter should contain the loaded contents of the
+/// project's system prompt file (from workflow.toml `[prompt].system_prompt`).
+/// If the file doesn't exist or couldn't be loaded, pass `None`.
+pub fn build_prompt_for_task(
+    task: &crate::model::task::Task,
+    branch: &str,
+    system_prompt: Option<&str>,
+) -> String {
     let number = match &task.source {
         crate::model::task::TaskSource::GithubIssue { number, .. } => Some(*number),
         crate::model::task::TaskSource::GithubPr { number, .. } => Some(*number),
@@ -144,7 +152,7 @@ pub fn build_prompt_for_task(task: &crate::model::task::Task, branch: &str) -> S
     };
 
     let params = PromptParams {
-        system_prompt: None, // TODO: load from workflow.toml
+        system_prompt,
         number,
         title: &task.title,
         body: task.description.as_deref(),


### PR DESCRIPTION
## Summary

- Implements spec §14 (Workflow Configuration) and §15 (Prompt Construction) for system_prompt loading
- At dispatch time, fetches `workflow.toml` from the project repository via GitHub API
- If `[prompt].system_prompt` is configured, fetches that file and passes content to the prompt builder
- Handles missing files gracefully (warns and continues with default prompt)

### Changes

1. **crates/github/src/client.rs**: Added `get_file_content()` method using GitHub REST API to fetch raw file contents
2. **crates/server/src/prompt.rs**: Updated `build_prompt_for_task()` to accept optional `system_prompt` parameter
3. **crates/app/src/run_loop.rs**: Added `load_system_prompt_for_project()` helper that fetches workflow config and system prompt at dispatch time
4. **Cargo.toml**: Switched reqwest to `rustls-tls` to avoid OpenSSL build dependency

## Test plan

- [x] Added tests for `get_file_content()` (success, 404, auth error, nested paths)
- [x] All existing prompt tests pass
- [x] Full workspace test suite passes

Closes #38

---
Generated with [Claude Code](https://claude.com/claude-code)