### PR TITLE
Fetch GitHub comments for prompt construction (spec §15.2)

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -9,8 +9,8 @@ use tracing::{error, info, warn};
 
 use events::{Actor, Event, EventBus, EventStore, EventType};
 use runtime::{AppleContainerRuntime, ContainerConfig};
-use server::model::task::TaskSource;
 use server::Server;
+use server::model::task::TaskSource;
 use tasks_github::client::GitHubClient;
 use tasks_github::poller::RepoPoller;
 
@@ -205,11 +205,16 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
             // Sync pollers with live project list
             let projects: Vec<(String, String)> = {
                 let state = poll_server.state.read().await;
-                state.projects.iter().map(|(id, p)| (id.clone(), p.repo.clone())).collect()
+                state
+                    .projects
+                    .iter()
+                    .map(|(id, p)| (id.clone(), p.repo.clone()))
+                    .collect()
             };
 
             // Remove pollers for deleted projects
-            let active_ids: std::collections::HashSet<&str> = projects.iter().map(|(id, _)| id.as_str()).collect();
+            let active_ids: std::collections::HashSet<&str> =
+                projects.iter().map(|(id, _)| id.as_str()).collect();
             pollers.retain(|id, _| active_ids.contains(id.as_str()));
 
             // Add pollers for new projects
@@ -302,7 +307,10 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
             let event = match rx.recv().await {
                 Ok(e) => e,
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(skipped = n, "event handler lagged, some events may not update state");
+                    warn!(
+                        skipped = n,
+                        "event handler lagged, some events may not update state"
+                    );
                     continue;
                 }
                 Err(_) => break,
@@ -395,6 +403,9 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
 
         // Track pending answers: task IDs that received HumanMessage while in Question state
         let mut pending_answers: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        // GitHub client for fetching comments at dispatch time (spec §15.2)
+        let github_client = GitHubClient::new(&dispatch_github_token);
 
         loop {
             // Wait for either the tick or a dispatch-triggering event
@@ -506,20 +517,22 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                             )
                             .await;
 
+                            // Fetch comments from GitHub at dispatch time (spec §15.2)
+                            let comments = server::prompt::fetch_comments_for_task(
+                                &github_client,
+                                &task.source,
+                            )
+                            .await;
+
                             let prompt = server::prompt::build_prompt_for_task(
                                 &task,
                                 &branch,
                                 system_prompt.as_deref(),
+                                &comments,
                             );
 
                             if let Err(e) = dispatch_session_mgr
-                                .start_session(
-                                    task_id.clone(),
-                                    repo_url,
-                                    branch,
-                                    prompt,
-                                    None,
-                                )
+                                .start_session(task_id.clone(), repo_url, branch, prompt, None)
                                 .await
                             {
                                 error!(task_id = %task_id, error = %e, "failed to start session");
@@ -606,9 +619,18 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
             // Snapshot pending merge queue entries with their tasks and projects
             let pending: Vec<(String, String, String)> = {
                 let state = orch_server.state.read().await;
-                state.merge_queue.pending().iter().map(|entry| {
-                    (entry.id.clone(), entry.task_id.clone(), entry.pr_url.clone())
-                }).collect()
+                state
+                    .merge_queue
+                    .pending()
+                    .iter()
+                    .map(|entry| {
+                        (
+                            entry.id.clone(),
+                            entry.task_id.clone(),
+                            entry.pr_url.clone(),
+                        )
+                    })
+                    .collect()
             };
 
             for (entry_id, task_id, _pr_url) in pending {
@@ -655,27 +677,36 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                 };
 
                 // Always emit a decision event (audit trail)
-                if let Err(e) = orch_server.emit_orchestrator_decision(
-                    &task_id,
-                    &entry_id,
-                    evaluation.approved,
-                    &evaluation.reasoning,
-                ).await {
+                if let Err(e) = orch_server
+                    .emit_orchestrator_decision(
+                        &task_id,
+                        &entry_id,
+                        evaluation.approved,
+                        &evaluation.reasoning,
+                    )
+                    .await
+                {
                     error!(error = %e, "failed to emit orchestrator decision event");
                 }
 
                 // In Play mode: act on the decision
                 if mode == server::Mode::Play {
                     if evaluation.approved {
-                        if let Err(e) = orch_server.approve_merge_entry(&entry_id, &evaluation.reasoning).await {
+                        if let Err(e) = orch_server
+                            .approve_merge_entry(&entry_id, &evaluation.reasoning)
+                            .await
+                        {
                             error!(entry_id = %entry_id, error = %e, "failed to approve merge entry");
                         }
                     } else {
-                        if let Err(e) = orch_server.reject_merge_entry(
-                            &entry_id,
-                            &evaluation.reasoning,
-                            evaluation.feedback.as_deref(),
-                        ).await {
+                        if let Err(e) = orch_server
+                            .reject_merge_entry(
+                                &entry_id,
+                                &evaluation.reasoning,
+                                evaluation.feedback.as_deref(),
+                            )
+                            .await
+                        {
                             error!(entry_id = %entry_id, error = %e, "failed to reject merge entry");
                         }
                         // Emit orchestrator:feedback event when feedback is provided
@@ -719,8 +750,9 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                 .join("web")
                 .join("build");
             if web_dir.exists() {
-                let serve = tower_http::services::ServeDir::new(&web_dir)
-                    .fallback(tower_http::services::ServeFile::new(web_dir.join("index.html")));
+                let serve = tower_http::services::ServeDir::new(&web_dir).fallback(
+                    tower_http::services::ServeFile::new(web_dir.join("index.html")),
+                );
                 api_router.fallback_service(serve)
             } else {
                 api_router
@@ -739,7 +771,12 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // --- 10. Wait for shutdown (TUI or headless) ---
 
     if config.tui {
-        crate::tui::run_tui(server.clone(), server.event_bus.clone(), config.max_sessions).await?;
+        crate::tui::run_tui(
+            server.clone(),
+            server.event_bus.clone(),
+            config.max_sessions,
+        )
+        .await?;
     } else {
         tokio::signal::ctrl_c().await?;
     }

--- a/crates/server/src/prompt.rs
+++ b/crates/server/src/prompt.rs
@@ -86,6 +86,68 @@ const TAIL_COMMENTS: usize = 10;
 const TRUNCATION_THRESHOLD: usize = HEAD_COMMENTS + TAIL_COMMENTS;
 
 // ---------------------------------------------------------------------------
+// GitHub comment conversion (spec §15.2)
+// ---------------------------------------------------------------------------
+
+/// Convert a GitHub comment to the prompt's `CommentInfo` format.
+pub fn github_comment_to_info(comment: &tasks_github::model::Comment) -> CommentInfo {
+    CommentInfo {
+        author: comment.author.login.clone(),
+        timestamp: comment.created_at.to_rfc3339(),
+        body: comment.body.clone(),
+    }
+}
+
+/// Fetch comments for a task from GitHub (spec §11, §15.2).
+///
+/// Returns an empty vec for internal tasks or on error (graceful degradation).
+/// Errors are logged but do not prevent prompt construction.
+pub async fn fetch_comments_for_task(
+    client: &tasks_github::client::GitHubClient,
+    source: &crate::model::task::TaskSource,
+) -> Vec<CommentInfo> {
+    use crate::model::task::TaskSource;
+
+    match source {
+        TaskSource::GithubIssue {
+            owner,
+            repo,
+            number,
+        } => match client.get_issue(owner, repo, *number).await {
+            Ok(issue) => issue.comments.iter().map(github_comment_to_info).collect(),
+            Err(e) => {
+                tracing::warn!(
+                    owner = %owner,
+                    repo = %repo,
+                    number = %number,
+                    error = %e,
+                    "failed to fetch issue comments for prompt"
+                );
+                Vec::new()
+            }
+        },
+        TaskSource::GithubPr {
+            owner,
+            repo,
+            number,
+        } => match client.get_pull_request(owner, repo, *number).await {
+            Ok(pr) => pr.comments.iter().map(github_comment_to_info).collect(),
+            Err(e) => {
+                tracing::warn!(
+                    owner = %owner,
+                    repo = %repo,
+                    number = %number,
+                    error = %e,
+                    "failed to fetch PR comments for prompt"
+                );
+                Vec::new()
+            }
+        },
+        TaskSource::Internal => Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -119,7 +181,7 @@ pub fn build_prompt(params: &PromptParams) -> String {
     out
 }
 
-/// Build a prompt directly from a Task and branch name.
+/// Build a prompt directly from a Task and branch name, with comments.
 ///
 /// Extracts the issue/PR number from the task source and builds retry
 /// context from the task's retry state. This keeps domain logic in the
@@ -128,10 +190,14 @@ pub fn build_prompt(params: &PromptParams) -> String {
 /// The `system_prompt` parameter should contain the loaded contents of the
 /// project's system prompt file (from workflow.toml `[prompt].system_prompt`).
 /// If the file doesn't exist or couldn't be loaded, pass `None`.
+///
+/// Comments should be fetched from GitHub at dispatch time using
+/// [`fetch_comments_for_task`] and passed here.
 pub fn build_prompt_for_task(
     task: &crate::model::task::Task,
     branch: &str,
     system_prompt: Option<&str>,
+    comments: &[CommentInfo],
 ) -> String {
     let number = match &task.source {
         crate::model::task::TaskSource::GithubIssue { number, .. } => Some(*number),
@@ -156,7 +222,7 @@ pub fn build_prompt_for_task(
         number,
         title: &task.title,
         body: task.description.as_deref(),
-        comments: &[],      // TODO: fetch from GitHub at dispatch time
+        comments,
         labels: &task.labels,
         assignees: &[],
         sub_issues: &[],
@@ -190,7 +256,11 @@ fn render_retry(out: &mut String, retry: &RetryContext) {
         )
         .unwrap();
     }
-    writeln!(out, "Try a different approach if the previous one failed.\n").unwrap();
+    writeln!(
+        out,
+        "Try a different approach if the previous one failed.\n"
+    )
+    .unwrap();
 }
 
 fn render_task(out: &mut String, params: &PromptParams) {
@@ -292,22 +362,42 @@ fn render_context(out: &mut String, params: &PromptParams) {
 fn render_instructions(out: &mut String, branch: &str, issue_number: Option<u64>) {
     writeln!(out, "## Instructions\n").unwrap();
     writeln!(out, "- Work on the branch `{branch}`.").unwrap();
-    writeln!(out, "- If you are stuck or the task is ambiguous, describe the problem clearly.").unwrap();
+    writeln!(
+        out,
+        "- If you are stuck or the task is ambiguous, describe the problem clearly."
+    )
+    .unwrap();
 
     writeln!(out).unwrap();
     writeln!(out, "### Valid outputs\n").unwrap();
     writeln!(out, "Your work can produce any of the following outputs:\n").unwrap();
     writeln!(out, "- **Code changes**: New features, bug fixes, refactoring, tests, or documentation committed to the branch.").unwrap();
-    writeln!(out, "- **Pull requests**: Open a PR when code changes are ready for review.").unwrap();
+    writeln!(
+        out,
+        "- **Pull requests**: Open a PR when code changes are ready for review."
+    )
+    .unwrap();
     writeln!(out, "- **Issue comments**: Progress updates, research findings, questions, or analysis posted to the issue.").unwrap();
     writeln!(out, "- **New issues**: Create issues for bugs found, follow-up work, or tasks discovered during implementation.").unwrap();
     writeln!(out, "- **Plans or proposals**: Architecture decisions, implementation approaches, or design documents.").unwrap();
-    writeln!(out, "- **Questions**: Ask for clarification when requirements are unclear or you need guidance.").unwrap();
-    writeln!(out, "- **Error reports**: If something is broken or blocked, describe what went wrong clearly.").unwrap();
+    writeln!(
+        out,
+        "- **Questions**: Ask for clarification when requirements are unclear or you need guidance."
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "- **Error reports**: If something is broken or blocked, describe what went wrong clearly."
+    )
+    .unwrap();
 
     writeln!(out).unwrap();
     writeln!(out, "### Delivering your work\n").unwrap();
-    writeln!(out, "When your task is finished, deliver your output using the GitHub CLI (`gh`).").unwrap();
+    writeln!(
+        out,
+        "When your task is finished, deliver your output using the GitHub CLI (`gh`)."
+    )
+    .unwrap();
     writeln!(out, "Choose the approach that fits what you produced:\n").unwrap();
     writeln!(
         out,
@@ -566,7 +656,9 @@ mod tests {
         };
         let prompt = build_prompt(&params);
 
-        assert!(prompt.contains("Sub-issues: #100 — Sub-issue A (open), #101 — Sub-issue B (closed)"));
+        assert!(
+            prompt.contains("Sub-issues: #100 — Sub-issue A (open), #101 — Sub-issue B (closed)")
+        );
         assert!(prompt.contains("Linked: #200 — Related PR (merged)"));
     }
 }


### PR DESCRIPTION
## Summary

Implements GitHub issue/PR comment fetching at task dispatch time per spec §15 (Prompt Construction).

- Adds `fetch_comments_for_task()` async function to fetch comments from GitHub using the existing GraphQL client
- Adds `github_comment_to_info()` converter from GitHub comment format to prompt `CommentInfo`
- Updates `build_prompt_for_task()` to accept a comments parameter
- Updates dispatch loop to fetch comments before building prompts
- Errors are logged but don't block dispatch (graceful degradation)

The truncation logic (first 10 + last 10 comments with omission note) was already implemented in `prompt.rs` — this PR wires up the actual comment fetching.

Also switches reqwest to use `rustls-tls` instead of `native-tls` for better build portability (no OpenSSL dependency).

## Test plan

- [x] Existing prompt tests pass (`cargo test --package server prompt::tests`)
- [x] Server and app crates compile
- [ ] Manual test: Dispatch a task from a GitHub issue with comments and verify they appear in the agent prompt

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)