### PR TITLE
Implement time limit enforcement for sessions (spec §17.4)

### DIFF
--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -65,6 +65,10 @@ pub enum EventType {
     SystemMemoryWarning,
     SystemMemoryPressure,
     SystemMemoryEmergency,
+    /// Session soft time limit reached (spec §17.4).
+    SystemTimeLimitSoft,
+    /// Session hard time limit reached (spec §17.4).
+    SystemTimeLimitHard,
 }
 
 impl EventType {
@@ -103,6 +107,8 @@ impl EventType {
             Self::SystemMemoryWarning => "system:memory:warning",
             Self::SystemMemoryPressure => "system:memory:pressure",
             Self::SystemMemoryEmergency => "system:memory:emergency",
+            Self::SystemTimeLimitSoft => "system:time_limit:soft",
+            Self::SystemTimeLimitHard => "system:time_limit:hard",
         }
     }
 
@@ -170,6 +176,8 @@ impl TryFrom<String> for EventType {
             "system:memory:warning" => Ok(Self::SystemMemoryWarning),
             "system:memory:pressure" => Ok(Self::SystemMemoryPressure),
             "system:memory:emergency" => Ok(Self::SystemMemoryEmergency),
+            "system:time_limit:soft" => Ok(Self::SystemTimeLimitSoft),
+            "system:time_limit:hard" => Ok(Self::SystemTimeLimitHard),
             _ => Err(format!("unknown event type: {}", s)),
         }
     }
@@ -250,5 +258,62 @@ mod tests {
         );
         let json = serde_json::to_string(&e).unwrap();
         assert!(json.contains("\"type\":\"task:created\""));
+    }
+
+    #[test]
+    fn time_limit_soft_event_serializes() {
+        let e = Event::new(
+            EventType::SystemTimeLimitSoft,
+            "task-123",
+            Actor::System,
+            serde_json::json!({
+                "elapsed_seconds": 3600,
+                "soft_limit_seconds": 3600,
+                "hard_limit_seconds": 4500,
+            }),
+        );
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"type\":\"system:time_limit:soft\""));
+        assert!(json.contains("\"elapsed_seconds\":3600"));
+    }
+
+    #[test]
+    fn time_limit_hard_event_serializes() {
+        let e = Event::new(
+            EventType::SystemTimeLimitHard,
+            "task-123",
+            Actor::System,
+            serde_json::json!({
+                "elapsed_seconds": 4500,
+                "hard_limit_seconds": 4500,
+            }),
+        );
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"type\":\"system:time_limit:hard\""));
+        assert!(json.contains("\"hard_limit_seconds\":4500"));
+    }
+
+    #[test]
+    fn time_limit_soft_deserializes() {
+        let s = "system:time_limit:soft".to_string();
+        let t = EventType::try_from(s).unwrap();
+        assert_eq!(t, EventType::SystemTimeLimitSoft);
+    }
+
+    #[test]
+    fn time_limit_hard_deserializes() {
+        let s = "system:time_limit:hard".to_string();
+        let t = EventType::try_from(s).unwrap();
+        assert_eq!(t, EventType::SystemTimeLimitHard);
+    }
+
+    #[test]
+    fn time_limit_events_match_system_wildcard() {
+        let soft = EventType::SystemTimeLimitSoft;
+        let hard = EventType::SystemTimeLimitHard;
+        assert!(soft.matches("system:*"));
+        assert!(hard.matches("system:*"));
+        assert!(soft.matches("system:time_limit:*"));
+        assert!(hard.matches("system:time_limit:*"));
     }
 }

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -241,6 +241,7 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
 ) {
     let started_at = Instant::now();
     let mut soft_limit_notified = false;
+    let mut hard_limit_triggered = false;
 
     // Wrap session for shared access between blocking recv thread and async command handler
     let session = Arc::new(std::sync::Mutex::new(session));
@@ -302,28 +303,79 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
             else => break, // both channels closed
         }
 
-        // Time limit checks
+        // Time limit checks (spec §17.4)
         let elapsed = started_at.elapsed();
-        if elapsed >= hard_limit {
+        if elapsed >= hard_limit && !hard_limit_triggered {
+            hard_limit_triggered = true;
+            tracing::warn!(task_id = %task_id, elapsed_secs = elapsed.as_secs(), "hard time limit reached, terminating session");
+
+            // Emit system:time_limit:hard event
+            let hard_event = events::Event::new(
+                events::EventType::SystemTimeLimitHard,
+                &task_id,
+                events::Actor::System,
+                serde_json::json!({
+                    "elapsed_seconds": elapsed.as_secs(),
+                    "hard_limit_seconds": hard_limit.as_secs(),
+                }),
+            );
+            if let Err(e) = event_bus.publish(hard_event).await {
+                tracing::error!(task_id = %task_id, error = %e, "failed to publish hard time limit event");
+            }
+
+            // Emit task:state:failed event
+            let failed_event = events::Event::new(
+                events::EventType::TaskStateFailed,
+                &task_id,
+                events::Actor::System,
+                serde_json::json!({
+                    "reason": "hard_time_limit",
+                    "elapsed_seconds": elapsed.as_secs(),
+                    "made_progress": started_at.elapsed() >= progress_threshold,
+                }),
+            );
+            if let Err(e) = event_bus.publish(failed_event).await {
+                tracing::error!(task_id = %task_id, error = %e, "failed to publish failed state event");
+            }
+
+            // Stop the agent
             let mut sess = session_cmd.lock().unwrap();
             if let Err(e) = sess.stop_agent() {
                 tracing::error!(task_id = %task_id, error = %e, "failed to stop agent at hard time limit");
             }
-            // The exit event will come through event_rx
         } else if elapsed >= soft_limit && !soft_limit_notified {
             soft_limit_notified = true;
-            let event = events::Event::new(
-                events::EventType::OrchestratorEscalation,
+            tracing::info!(task_id = %task_id, elapsed_secs = elapsed.as_secs(), "soft time limit reached, notifying orchestrator/human");
+
+            // Emit system:time_limit:soft event
+            let soft_event = events::Event::new(
+                events::EventType::SystemTimeLimitSoft,
                 &task_id,
                 events::Actor::System,
                 serde_json::json!({
-                    "reason": "session_time_limit",
                     "elapsed_seconds": elapsed.as_secs(),
                     "soft_limit_seconds": soft_limit.as_secs(),
+                    "hard_limit_seconds": hard_limit.as_secs(),
                 }),
             );
-            if let Err(e) = event_bus.publish(event).await {
-                tracing::error!(task_id = %task_id, error = %e, "failed to publish escalation event");
+            if let Err(e) = event_bus.publish(soft_event).await {
+                tracing::error!(task_id = %task_id, error = %e, "failed to publish soft time limit event");
+            }
+
+            // Emit task:state:question event to notify human/orchestrator
+            let question_event = events::Event::new(
+                events::EventType::TaskStateQuestion,
+                &task_id,
+                events::Actor::System,
+                serde_json::json!({
+                    "reason": "soft_time_limit",
+                    "message": "Session has reached the soft time limit. The agent will be terminated at the hard limit unless extended or guided.",
+                    "elapsed_seconds": elapsed.as_secs(),
+                    "remaining_seconds": (hard_limit.as_secs().saturating_sub(elapsed.as_secs())),
+                }),
+            );
+            if let Err(e) = event_bus.publish(question_event).await {
+                tracing::error!(task_id = %task_id, error = %e, "failed to publish question state event");
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `system:time_limit:soft` and `system:time_limit:hard` event types to the events crate
- Implement time limit enforcement in the session monitoring task per spec §17.4:
  - **Soft limit** (default 1 hour): Emits `system:time_limit:soft` event and transitions task to `Question` state to notify orchestrator/human
  - **Hard limit** (default soft + 15 min): Emits `system:time_limit:hard` event, transitions task to `Failed` state, and terminates the session
- Add comprehensive tests for new event types (serialization, deserialization, pattern matching)

## Test plan

- [x] All existing tests pass
- [x] New event type tests verify serialization/deserialization
- [x] New event types match `system:*` and `system:time_limit:*` patterns
- [x] Code compiles with no errors

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)