### PR TITLE
Implement progress detection for retry logic (spec §13.1, §13.2)

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -245,9 +245,13 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // into the server. The session monitor publishes events (e.g.
     // TaskStateAwaitingMerge) but doesn't update server state directly.
     // This loop bridges events → state updates + merge queue entries.
+    //
+    // For TaskStateFailed events from agents, we use progress detection
+    // (spec §13.1, §13.2) to decide whether to retry or mark as failed.
 
     let event_handler_server = server.clone();
     let event_handler_bus = server.event_bus.clone();
+    let event_handler_max_retries = config.max_retries;
 
     let event_handler_handle = tokio::spawn(async move {
         let mut rx = event_handler_bus.subscribe();
@@ -262,6 +266,34 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
             };
 
             let task_id = &event.task;
+
+            // Handle TaskStateFailed specially: use progress detection (spec §13.1)
+            // to determine whether to retry or mark as permanently failed.
+            if event.event_type == EventType::TaskStateFailed
+                && event.actor != events::Actor::Scheduler
+                && event.actor != events::Actor::System
+            {
+                // Extract made_progress from event data (defaults to false)
+                let made_progress = event.data.get("made_progress")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+                if let Err(e) = event_handler_server
+                    .handle_task_failure(task_id, made_progress, event_handler_max_retries)
+                    .await
+                {
+                    if !matches!(e, server::ServerError::TaskNotFound(_)) {
+                        error!(
+                            task_id = %task_id,
+                            made_progress = made_progress,
+                            error = %e,
+                            "failed to handle task failure"
+                        );
+                    }
+                }
+                continue;
+            }
+
             let new_state = match event.event_type {
                 EventType::TaskStateRunning => Some(models::task::TaskState::Running),
                 EventType::TaskStateQuestion => Some(models::task::TaskState::Question),

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -616,6 +616,141 @@ impl Server {
         Ok(())
     }
 
+    // --- Session failure handling (spec §13.1, §13.2) ---
+
+    /// Handle a task failure with progress detection.
+    ///
+    /// Implements spec §13.1 and §13.2:
+    /// - If `made_progress` is true: the agent ran long enough or made changes,
+    ///   so this is considered a transient failure. Reset retry context and
+    ///   transition to Waiting for re-dispatch.
+    /// - If `made_progress` is false: the agent failed quickly without progress.
+    ///   Increment retry_count. If under max_retries, transition to Waiting.
+    ///   If retries exhausted, transition to Failed.
+    ///
+    /// Returns `true` if the task will be retried (transitioned to Waiting),
+    /// `false` if it transitioned to Failed.
+    pub async fn handle_task_failure(
+        &self,
+        task_id: &str,
+        made_progress: bool,
+        max_retries: u32,
+    ) -> Result<bool, ServerError> {
+        let now = chrono::Utc::now();
+
+        let (will_retry, new_state, event_data) = {
+            let mut state = self.state.write().await;
+            let task = state
+                .tasks
+                .get_mut(task_id)
+                .ok_or_else(|| ServerError::TaskNotFound(task_id.to_string()))?;
+
+            if made_progress {
+                // Progress was made — this is a transient failure.
+                // Reset retry context and transition to Waiting.
+                task.retry_count = 0;
+                task.last_failure_at = None;
+                task.session_id = None;
+                task.set_state(TaskState::Waiting);
+
+                // Write-through to store
+                if let Some(ref store) = self.store {
+                    if let Ok(store) = store.lock() {
+                        if let Err(e) = store.save_task(task) {
+                            tracing::error!(
+                                task_id = %task_id,
+                                error = %e,
+                                "failed to persist task retry state to store"
+                            );
+                        }
+                    }
+                }
+
+                (
+                    true,
+                    TaskState::Waiting,
+                    serde_json::json!({
+                        "reason": "session_failure",
+                        "made_progress": true,
+                        "retry_count_reset": true,
+                    }),
+                )
+            } else {
+                // No progress made — increment retry count.
+                task.retry_count += 1;
+                task.last_failure_at = Some(now);
+                task.session_id = None;
+
+                if task.retry_count <= max_retries {
+                    // Under max retries — transition to Waiting.
+                    task.set_state(TaskState::Waiting);
+
+                    // Write-through to store
+                    if let Some(ref store) = self.store {
+                        if let Ok(store) = store.lock() {
+                            if let Err(e) = store.save_task(task) {
+                                tracing::error!(
+                                    task_id = %task_id,
+                                    error = %e,
+                                    "failed to persist task retry state to store"
+                                );
+                            }
+                        }
+                    }
+
+                    (
+                        true,
+                        TaskState::Waiting,
+                        serde_json::json!({
+                            "reason": "session_failure",
+                            "made_progress": false,
+                            "retry_count": task.retry_count,
+                        }),
+                    )
+                } else {
+                    // Retries exhausted — transition to Failed.
+                    task.set_state(TaskState::Failed);
+
+                    // Write-through to store
+                    if let Some(ref store) = self.store {
+                        if let Ok(store) = store.lock() {
+                            if let Err(e) = store.save_task(task) {
+                                tracing::error!(
+                                    task_id = %task_id,
+                                    error = %e,
+                                    "failed to persist task failure to store"
+                                );
+                            }
+                        }
+                    }
+
+                    (
+                        false,
+                        TaskState::Failed,
+                        serde_json::json!({
+                            "reason": "session_failure",
+                            "made_progress": false,
+                            "retries_exhausted": true,
+                            "retry_count": task.retry_count,
+                        }),
+                    )
+                }
+            }
+        };
+
+        // Emit the appropriate event
+        let event_type = match new_state {
+            TaskState::Waiting => EventType::TaskStateWaiting,
+            TaskState::Failed => EventType::TaskStateFailed,
+            _ => unreachable!(),
+        };
+
+        let event = Event::new(event_type, task_id, Actor::System, event_data);
+        self.event_bus.publish(event).await?;
+
+        Ok(will_retry)
+    }
+
     // --- Restart recovery (spec §13.3) ---
 
     /// Apply the results of orphan detection to task state.
@@ -1067,5 +1202,153 @@ mod tests {
         // Task should be back to Waiting for re-dispatch
         let task = server.get_task("task-1").await.unwrap();
         assert_eq!(task.state, TaskState::Waiting);
+    }
+
+    // --- Progress detection tests (spec §13.1, §13.2) ---
+
+    #[tokio::test]
+    async fn handle_task_failure_with_progress_resets_retry_count() {
+        let server = test_server().await;
+
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+
+        // Create a task that's already been retried once
+        let mut task = Task::new("task-1", TaskSource::Internal, "Test task", "proj-1");
+        task.retry_count = 1;
+        task.last_failure_at = Some(chrono::Utc::now());
+        task.set_state(TaskState::Running);
+        server.add_task(task).await.unwrap();
+
+        // Handle failure with progress made
+        let will_retry = server
+            .handle_task_failure("task-1", true, 3)
+            .await
+            .unwrap();
+
+        // Should retry (transition to Waiting)
+        assert!(will_retry);
+
+        // Check task state
+        let task = server.get_task("task-1").await.unwrap();
+        assert_eq!(task.state, TaskState::Waiting);
+        assert_eq!(task.retry_count, 0); // Reset to 0 because progress was made
+        assert!(task.last_failure_at.is_none()); // Cleared because progress was made
+    }
+
+    #[tokio::test]
+    async fn handle_task_failure_without_progress_increments_retry_count() {
+        let server = test_server().await;
+
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+
+        let mut task = Task::new("task-1", TaskSource::Internal, "Test task", "proj-1");
+        task.retry_count = 1;
+        task.set_state(TaskState::Running);
+        server.add_task(task).await.unwrap();
+
+        // Handle failure without progress
+        let will_retry = server
+            .handle_task_failure("task-1", false, 3)
+            .await
+            .unwrap();
+
+        // Should retry (under max_retries)
+        assert!(will_retry);
+
+        // Check task state
+        let task = server.get_task("task-1").await.unwrap();
+        assert_eq!(task.state, TaskState::Waiting);
+        assert_eq!(task.retry_count, 2); // Incremented
+        assert!(task.last_failure_at.is_some()); // Set to now
+    }
+
+    #[tokio::test]
+    async fn handle_task_failure_exhausted_retries_marks_failed() {
+        let server = test_server().await;
+
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+
+        // Task at max retries
+        let mut task = Task::new("task-1", TaskSource::Internal, "Test task", "proj-1");
+        task.retry_count = 3; // Already at max
+        task.set_state(TaskState::Running);
+        server.add_task(task).await.unwrap();
+
+        // Handle failure without progress
+        let will_retry = server
+            .handle_task_failure("task-1", false, 3)
+            .await
+            .unwrap();
+
+        // Should not retry (retries exhausted)
+        assert!(!will_retry);
+
+        // Check task state
+        let task = server.get_task("task-1").await.unwrap();
+        assert_eq!(task.state, TaskState::Failed);
+        assert_eq!(task.retry_count, 4); // Incremented beyond max
+        assert!(task.last_failure_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn handle_task_failure_emits_correct_events() {
+        let server = test_server().await;
+        let mut rx = server.event_bus.subscribe();
+
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+
+        let mut task = Task::new("task-1", TaskSource::Internal, "Test task", "proj-1");
+        task.set_state(TaskState::Running);
+        server.add_task(task).await.unwrap();
+
+        // Drain task-created event
+        while rx.try_recv().is_ok() {}
+
+        // Failure with progress → should emit TaskStateWaiting
+        server.handle_task_failure("task-1", true, 3).await.unwrap();
+
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.event_type, EventType::TaskStateWaiting);
+        assert_eq!(event.data["made_progress"], true);
+        assert_eq!(event.data["retry_count_reset"], true);
+    }
+
+    #[tokio::test]
+    async fn handle_task_failure_exhausted_emits_failed_event() {
+        let server = test_server().await;
+        let mut rx = server.event_bus.subscribe();
+
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+
+        let mut task = Task::new("task-1", TaskSource::Internal, "Test task", "proj-1");
+        task.retry_count = 3; // At max
+        task.set_state(TaskState::Running);
+        server.add_task(task).await.unwrap();
+
+        // Drain task-created event
+        while rx.try_recv().is_ok() {}
+
+        // Failure without progress at max retries → should emit TaskStateFailed
+        server.handle_task_failure("task-1", false, 3).await.unwrap();
+
+        let event = rx.recv().await.unwrap();
+        assert_eq!(event.event_type, EventType::TaskStateFailed);
+        assert_eq!(event.data["retries_exhausted"], true);
+    }
+
+    #[tokio::test]
+    async fn handle_task_failure_nonexistent_task_returns_error() {
+        let server = test_server().await;
+
+        // Try to handle failure for a task that doesn't exist
+        let result = server.handle_task_failure("nonexistent", true, 3).await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ServerError::TaskNotFound(_)));
     }
 }


### PR DESCRIPTION
## Summary

- Add `handle_task_failure` method to `Server` that implements the spec's progress-based retry behavior
- Modify event handler loop to extract `made_progress` flag from `TaskStateFailed` events and use the new method
- Add comprehensive tests for the progress detection logic

## Changes

**Server (`crates/server/src/server.rs`)**:
- New `handle_task_failure(task_id, made_progress, max_retries)` method that:
  - If `made_progress == true`: resets `retry_count` to 0, clears `last_failure_at`, transitions to `Waiting`
  - If `made_progress == false` and under max_retries: increments `retry_count`, sets `last_failure_at`, transitions to `Waiting`
  - If `made_progress == false` and retries exhausted: increments `retry_count`, sets `last_failure_at`, transitions to `Failed`
- Emits appropriate events (`TaskStateWaiting` or `TaskStateFailed`) with detailed metadata

**Run loop (`crates/app/src/run_loop.rs`)**:
- Event handler loop now extracts `made_progress` from `TaskStateFailed` event data
- Calls `handle_task_failure` instead of `apply_task_state` for agent failures
- Passes `max_retries` from config to enforce retry limits

## Spec References

- §13.1: Progress threshold concept — "Making progress" means running for longer than `progress_threshold` (default 60s)
- §13.2: Retry counter increments only for no-progress failures; resets when progress is made

## Test plan

- [x] `handle_task_failure_with_progress_resets_retry_count` - verifies retry_count resets to 0 when progress made
- [x] `handle_task_failure_without_progress_increments_retry_count` - verifies retry_count increments when no progress
- [x] `handle_task_failure_exhausted_retries_marks_failed` - verifies task transitions to Failed when retries exhausted
- [x] `handle_task_failure_emits_correct_events` - verifies correct events emitted for progress case
- [x] `handle_task_failure_exhausted_emits_failed_event` - verifies Failed event emitted when exhausted
- [x] `handle_task_failure_nonexistent_task_returns_error` - verifies error handling

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)