### PR TITLE
Add memory pressure watchdog to prevent OS lockup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ trait-variant = "0.1"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 bytes = "1.11"
 futures = "0.3"
+sysinfo = "0.33"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -30,3 +30,4 @@ tower-http = { version = "0.6", features = ["cors", "fs"] }
 tower = "0.5"
 tokio-stream = { version = "0.1", features = ["sync"] }
 uuid.workspace = true
+sysinfo.workspace = true

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -92,6 +92,12 @@ impl AppConfig {
             .and_then(|s| s.parse().ok())
             .unwrap_or(92u8);
 
+        if !(memory_warn_pct < memory_soft_limit_pct && memory_soft_limit_pct < memory_hard_limit_pct) {
+            return Err(format!(
+                "Memory thresholds must be ordered: warn ({memory_warn_pct}) < soft ({memory_soft_limit_pct}) < hard ({memory_hard_limit_pct})"
+            ));
+        }
+
         Ok(Self {
             data_dir,
             github_token,

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -24,6 +24,12 @@ pub struct AppConfig {
     pub session_soft_limit: Duration,
     /// Session hard time limit (default: 1h15m).
     pub session_hard_limit: Duration,
+    /// Memory usage percentage at which to warn (default: 75%).
+    pub memory_warn_pct: u8,
+    /// Memory usage percentage at which to pause dispatch (default: 85%).
+    pub memory_soft_limit_pct: u8,
+    /// Memory usage percentage at which to emergency-stop sessions (default: 92%).
+    pub memory_hard_limit_pct: u8,
     /// Whether to run the TUI.
     pub tui: bool,
     /// Whether to run the web UI.
@@ -71,6 +77,21 @@ impl AppConfig {
             .and_then(|s| s.parse().ok())
             .unwrap_or(30u64);
 
+        let memory_warn_pct = std::env::var("TASKS_MEMORY_WARN_PCT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(75u8);
+
+        let memory_soft_limit_pct = std::env::var("TASKS_MEMORY_SOFT_LIMIT_PCT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(85u8);
+
+        let memory_hard_limit_pct = std::env::var("TASKS_MEMORY_HARD_LIMIT_PCT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(92u8);
+
         Ok(Self {
             data_dir,
             github_token,
@@ -82,6 +103,9 @@ impl AppConfig {
             container_memory,
             session_soft_limit: Duration::from_secs(3600),
             session_hard_limit: Duration::from_secs(4500),
+            memory_warn_pct,
+            memory_soft_limit_pct,
+            memory_hard_limit_pct,
             tui: false, // set by CLI flag
             web: false, // set by CLI flag
             web_port: std::env::var("TASKS_WEB_PORT")

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -4,6 +4,7 @@
 //! This binary is intentionally thin — logic lives in the library crates.
 
 mod config;
+mod memory;
 mod run_loop;
 mod tui;
 mod web;

--- a/crates/app/src/memory.rs
+++ b/crates/app/src/memory.rs
@@ -1,0 +1,221 @@
+//! Host memory monitoring — prevents OS lockup from container memory pressure.
+//!
+//! Periodically samples system memory usage and emits events / takes action
+//! at configurable thresholds:
+//!
+//! - **Warn** (default 75%): log warning, emit `system:memory:warning`
+//! - **Soft limit** (default 85%): emit `system:memory:pressure`, signal dispatch to pause
+//! - **Hard limit** (default 92%): emit `system:memory:emergency`, stop newest sessions
+
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::Arc;
+
+use sysinfo::System;
+use tracing::{error, info, warn};
+
+use events::{Actor, Event, EventBus, EventType};
+
+/// Memory pressure level observed on the host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MemoryPressure {
+    /// Below warning threshold — all clear.
+    Normal,
+    /// Above warning threshold — log but don't restrict.
+    Warning,
+    /// Above soft limit — pause dispatching new sessions.
+    Pressure,
+    /// Above hard limit — emergency: stop sessions to free memory.
+    Emergency,
+}
+
+/// Snapshot of host memory state.
+#[derive(Debug, Clone)]
+pub struct MemorySnapshot {
+    pub total_bytes: u64,
+    pub used_bytes: u64,
+    pub used_pct: u8,
+    pub pressure: MemoryPressure,
+}
+
+/// Thresholds for memory pressure levels (percentages of total RAM).
+#[derive(Debug, Clone, Copy)]
+pub struct MemoryThresholds {
+    pub warn_pct: u8,
+    pub soft_limit_pct: u8,
+    pub hard_limit_pct: u8,
+}
+
+impl Default for MemoryThresholds {
+    fn default() -> Self {
+        Self {
+            warn_pct: 75,
+            soft_limit_pct: 85,
+            hard_limit_pct: 92,
+        }
+    }
+}
+
+/// Shared state for memory-based dispatch gating.
+///
+/// The watchdog updates this; the dispatch loop reads it.
+pub struct MemoryGate {
+    /// Whether dispatch should be paused due to memory pressure.
+    pub dispatch_paused: AtomicBool,
+    /// Current memory usage percentage (updated by watchdog).
+    pub current_pct: AtomicU8,
+}
+
+impl MemoryGate {
+    pub fn new() -> Self {
+        Self {
+            dispatch_paused: AtomicBool::new(false),
+            current_pct: AtomicU8::new(0),
+        }
+    }
+
+    pub fn is_dispatch_paused(&self) -> bool {
+        self.dispatch_paused.load(Ordering::Relaxed)
+    }
+}
+
+/// Sample current host memory usage.
+pub fn sample_memory(thresholds: &MemoryThresholds) -> MemorySnapshot {
+    let mut sys = System::new();
+    sys.refresh_memory();
+
+    let total = sys.total_memory();
+    let used = sys.used_memory();
+    let pct = if total > 0 {
+        ((used as f64 / total as f64) * 100.0) as u8
+    } else {
+        0
+    };
+
+    let pressure = if pct >= thresholds.hard_limit_pct {
+        MemoryPressure::Emergency
+    } else if pct >= thresholds.soft_limit_pct {
+        MemoryPressure::Pressure
+    } else if pct >= thresholds.warn_pct {
+        MemoryPressure::Warning
+    } else {
+        MemoryPressure::Normal
+    };
+
+    MemorySnapshot {
+        total_bytes: total,
+        used_bytes: used,
+        used_pct: pct,
+        pressure,
+    }
+}
+
+/// Run the memory watchdog loop.
+///
+/// Samples memory every `interval`, updates the `MemoryGate`, emits events,
+/// and triggers emergency session stops when the hard limit is breached.
+pub async fn watchdog_loop(
+    gate: Arc<MemoryGate>,
+    thresholds: MemoryThresholds,
+    event_bus: Arc<EventBus>,
+    session_manager: Arc<tasks_session::SessionManager<runtime::AppleContainerRuntime>>,
+    interval: std::time::Duration,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    let mut last_pressure = MemoryPressure::Normal;
+    let mut emergency_stops: u32 = 0;
+
+    loop {
+        ticker.tick().await;
+
+        let snapshot = sample_memory(&thresholds);
+        gate.current_pct.store(snapshot.used_pct, Ordering::Relaxed);
+
+        match snapshot.pressure {
+            MemoryPressure::Normal => {
+                if last_pressure >= MemoryPressure::Pressure {
+                    info!(
+                        used_pct = snapshot.used_pct,
+                        "memory pressure resolved, resuming dispatch"
+                    );
+                }
+                gate.dispatch_paused.store(false, Ordering::Relaxed);
+            }
+            MemoryPressure::Warning => {
+                if last_pressure < MemoryPressure::Warning {
+                    warn!(
+                        used_pct = snapshot.used_pct,
+                        total_gb = snapshot.total_bytes / (1024 * 1024 * 1024),
+                        used_gb = snapshot.used_bytes / (1024 * 1024 * 1024),
+                        "host memory usage above warning threshold"
+                    );
+                    emit_memory_event(&event_bus, EventType::SystemMemoryWarning, &snapshot).await;
+                }
+                gate.dispatch_paused.store(false, Ordering::Relaxed);
+            }
+            MemoryPressure::Pressure => {
+                if last_pressure < MemoryPressure::Pressure {
+                    warn!(
+                        used_pct = snapshot.used_pct,
+                        threshold = thresholds.soft_limit_pct,
+                        "memory pressure: pausing new session dispatch"
+                    );
+                    emit_memory_event(&event_bus, EventType::SystemMemoryPressure, &snapshot).await;
+                }
+                gate.dispatch_paused.store(true, Ordering::Relaxed);
+            }
+            MemoryPressure::Emergency => {
+                error!(
+                    used_pct = snapshot.used_pct,
+                    threshold = thresholds.hard_limit_pct,
+                    "EMERGENCY: memory critical, stopping sessions to prevent OS lockup"
+                );
+                gate.dispatch_paused.store(true, Ordering::Relaxed);
+                emit_memory_event(&event_bus, EventType::SystemMemoryEmergency, &snapshot).await;
+
+                // Stop the most recently started session to free memory.
+                // We stop one at a time — the next tick will re-evaluate.
+                if let Some(task_id) = pick_session_to_stop(&session_manager).await {
+                    warn!(task_id = %task_id, "emergency-stopping session due to memory pressure");
+                    if let Err(e) = session_manager.stop_session(&task_id).await {
+                        error!(task_id = %task_id, error = %e, "failed to emergency-stop session");
+                    } else {
+                        emergency_stops += 1;
+                        info!(
+                            task_id = %task_id,
+                            total_emergency_stops = emergency_stops,
+                            "session stopped to relieve memory pressure"
+                        );
+                    }
+                }
+            }
+        }
+
+        last_pressure = snapshot.pressure;
+    }
+}
+
+/// Pick the best session to stop under memory pressure.
+///
+/// Strategy: stop the most recently started session (least work invested).
+async fn pick_session_to_stop(
+    session_manager: &tasks_session::SessionManager<runtime::AppleContainerRuntime>,
+) -> Option<String> {
+    session_manager.newest_session().await
+}
+
+/// Emit a memory-related event.
+async fn emit_memory_event(event_bus: &EventBus, event_type: EventType, snapshot: &MemorySnapshot) {
+    let event = Event::new(
+        event_type,
+        "system",
+        Actor::System,
+        serde_json::json!({
+            "used_pct": snapshot.used_pct,
+            "total_bytes": snapshot.total_bytes,
+            "used_bytes": snapshot.used_bytes,
+        }),
+    );
+    if let Err(e) = event_bus.publish(event).await {
+        error!(error = %e, "failed to publish memory event");
+    }
+}

--- a/crates/app/src/memory.rs
+++ b/crates/app/src/memory.rs
@@ -164,13 +164,15 @@ pub async fn watchdog_loop(
                 gate.dispatch_paused.store(true, Ordering::Relaxed);
             }
             MemoryPressure::Emergency => {
-                error!(
-                    used_pct = snapshot.used_pct,
-                    threshold = thresholds.hard_limit_pct,
-                    "EMERGENCY: memory critical, stopping sessions to prevent OS lockup"
-                );
                 gate.dispatch_paused.store(true, Ordering::Relaxed);
-                emit_memory_event(&event_bus, EventType::SystemMemoryEmergency, &snapshot).await;
+                if last_pressure < MemoryPressure::Emergency {
+                    error!(
+                        used_pct = snapshot.used_pct,
+                        threshold = thresholds.hard_limit_pct,
+                        "EMERGENCY: memory critical, stopping sessions to prevent OS lockup"
+                    );
+                    emit_memory_event(&event_bus, EventType::SystemMemoryEmergency, &snapshot).await;
+                }
 
                 // Stop the most recently started session to free memory.
                 // We stop one at a time — the next tick will re-evaluate.

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -403,41 +403,30 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // Check memory pressure before dispatching new work.
-            // When the memory gate is paused, we still allow resume (no new containers)
-            // but skip starting new sessions.
+            // When paused, pass global_max=0 so the dispatcher won't select
+            // new work (which would transition tasks to Running prematurely),
+            // but resumes still go through.
             let memory_paused = dispatch_memory_gate.is_dispatch_paused();
-            if memory_paused {
+            let effective_max = if memory_paused {
                 let pct = dispatch_memory_gate.current_pct.load(std::sync::atomic::Ordering::Relaxed);
                 warn!(
                     used_pct = pct,
-                    "dispatch skipped: host memory pressure too high"
+                    "dispatch: no new sessions due to memory pressure"
                 );
-            }
+                0
+            } else {
+                max_sessions
+            };
 
             // Run dispatch
             let pending_answers: Vec<String> = Vec::new(); // TODO: track pending answers
             match dispatch_server
-                .run_dispatch(&pending_answers, max_sessions)
+                .run_dispatch(&pending_answers, effective_max)
                 .await
             {
                 Ok(plan) => {
-                    // Start new sessions for dispatched tasks (skip if memory-paused)
+                    // Start new sessions for dispatched tasks
                     for task_id in &plan.new_work {
-                        if memory_paused {
-                            info!(task_id = %task_id, "deferring session start due to memory pressure");
-                            // Revert to Waiting so it gets picked up when pressure resolves
-                            if let Err(e) = dispatch_server
-                                .set_task_state(
-                                    task_id,
-                                    models::task::TaskState::Waiting,
-                                    events::Actor::System,
-                                )
-                                .await
-                            {
-                                warn!(task_id = %task_id, error = %e, "failed to revert task to waiting during memory pause");
-                            }
-                            continue;
-                        }
                         if let Some(task) = dispatch_server.get_task(task_id).await {
                             let project = dispatch_server.get_project(&task.project).await;
                             let repo_url = project

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -17,6 +17,7 @@ use tasks_github::poller::RepoPoller;
 use tasks_orchestrator::Orchestrator;
 
 use crate::config::AppConfig;
+use crate::memory::{MemoryGate, MemoryThresholds};
 
 /// Enum wrapper for orchestrator implementations.
 ///
@@ -51,6 +52,9 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         dispatch_interval = ?config.dispatch_interval,
         container_image = %config.container_image,
         container_memory = %config.container_memory,
+        memory_warn_pct = config.memory_warn_pct,
+        memory_soft_limit_pct = config.memory_soft_limit_pct,
+        memory_hard_limit_pct = config.memory_hard_limit_pct,
         "starting tasks platform"
     );
 
@@ -134,6 +138,43 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                 "orchestrator not configured",
             ))
         }
+    });
+
+    // --- 5c. Create memory watchdog ---
+
+    let memory_thresholds = MemoryThresholds {
+        warn_pct: config.memory_warn_pct,
+        soft_limit_pct: config.memory_soft_limit_pct,
+        hard_limit_pct: config.memory_hard_limit_pct,
+    };
+    let memory_gate = Arc::new(MemoryGate::new());
+
+    // Log initial memory state
+    {
+        let snapshot = crate::memory::sample_memory(&memory_thresholds);
+        info!(
+            total_gb = snapshot.total_bytes / (1024 * 1024 * 1024),
+            used_pct = snapshot.used_pct,
+            warn_pct = config.memory_warn_pct,
+            soft_limit_pct = config.memory_soft_limit_pct,
+            hard_limit_pct = config.memory_hard_limit_pct,
+            "memory watchdog configured"
+        );
+    }
+
+    let watchdog_gate = memory_gate.clone();
+    let watchdog_bus = server.event_bus.clone();
+    let watchdog_sessions = session_manager.clone();
+
+    let watchdog_handle = tokio::spawn(async move {
+        crate::memory::watchdog_loop(
+            watchdog_gate,
+            memory_thresholds,
+            watchdog_bus,
+            watchdog_sessions,
+            std::time::Duration::from_secs(10),
+        )
+        .await;
     });
 
     // --- 6. Emit system:started ---
@@ -330,6 +371,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     let dispatch_interval = config.dispatch_interval;
     let max_sessions = config.max_sessions;
     let dispatch_event_bus = server.event_bus.clone();
+    let dispatch_memory_gate = memory_gate.clone();
 
     let dispatch_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(dispatch_interval);
@@ -360,6 +402,18 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                 continue;
             }
 
+            // Check memory pressure before dispatching new work.
+            // When the memory gate is paused, we still allow resume (no new containers)
+            // but skip starting new sessions.
+            let memory_paused = dispatch_memory_gate.is_dispatch_paused();
+            if memory_paused {
+                let pct = dispatch_memory_gate.current_pct.load(std::sync::atomic::Ordering::Relaxed);
+                warn!(
+                    used_pct = pct,
+                    "dispatch skipped: host memory pressure too high"
+                );
+            }
+
             // Run dispatch
             let pending_answers: Vec<String> = Vec::new(); // TODO: track pending answers
             match dispatch_server
@@ -367,8 +421,23 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                 .await
             {
                 Ok(plan) => {
-                    // Start new sessions for dispatched tasks
+                    // Start new sessions for dispatched tasks (skip if memory-paused)
                     for task_id in &plan.new_work {
+                        if memory_paused {
+                            info!(task_id = %task_id, "deferring session start due to memory pressure");
+                            // Revert to Waiting so it gets picked up when pressure resolves
+                            if let Err(e) = dispatch_server
+                                .set_task_state(
+                                    task_id,
+                                    models::task::TaskState::Waiting,
+                                    events::Actor::System,
+                                )
+                                .await
+                            {
+                                warn!(task_id = %task_id, error = %e, "failed to revert task to waiting during memory pause");
+                            }
+                            continue;
+                        }
                         if let Some(task) = dispatch_server.get_task(task_id).await {
                             let project = dispatch_server.get_project(&task.project).await;
                             let repo_url = project
@@ -613,6 +682,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     dispatch_handle.abort();
     event_handler_handle.abort();
     orchestrator_handle.abort();
+    watchdog_handle.abort();
     if let Some(h) = web_handle {
         h.abort();
     }

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -59,6 +59,9 @@ pub enum EventType {
     SystemFlush,
     SystemConfigReloaded,
     SystemSchedulerTick,
+    SystemMemoryWarning,
+    SystemMemoryPressure,
+    SystemMemoryEmergency,
 }
 
 impl EventType {
@@ -93,6 +96,9 @@ impl EventType {
             Self::SystemFlush => "system:flush",
             Self::SystemConfigReloaded => "system:config:reloaded",
             Self::SystemSchedulerTick => "system:scheduler:tick",
+            Self::SystemMemoryWarning => "system:memory:warning",
+            Self::SystemMemoryPressure => "system:memory:pressure",
+            Self::SystemMemoryEmergency => "system:memory:emergency",
         }
     }
 
@@ -156,6 +162,9 @@ impl TryFrom<String> for EventType {
             "system:flush" => Ok(Self::SystemFlush),
             "system:config:reloaded" => Ok(Self::SystemConfigReloaded),
             "system:scheduler:tick" => Ok(Self::SystemSchedulerTick),
+            "system:memory:warning" => Ok(Self::SystemMemoryWarning),
+            "system:memory:pressure" => Ok(Self::SystemMemoryPressure),
+            "system:memory:emergency" => Ok(Self::SystemMemoryEmergency),
             _ => Err(format!("unknown event type: {}", s)),
         }
     }

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -124,6 +124,15 @@ impl<R: ContainerRuntime + Send + Sync + 'static> SessionManager<R> {
         self.sessions.read().await.keys().cloned().collect()
     }
 
+    /// Get the task ID of the most recently started session (for emergency stop).
+    pub async fn newest_session(&self) -> Option<String> {
+        let sessions = self.sessions.read().await;
+        sessions
+            .values()
+            .max_by_key(|h| h.started_at)
+            .map(|h| h.task_id.clone())
+    }
+
     /// Send a chat message to a running session (spec §9.2).
     pub async fn send_chat(&self, task_id: &str, message: String) -> Result<(), SessionManagerError> {
         let sessions = self.sessions.read().await;


### PR DESCRIPTION
## Summary

- Adds a host memory watchdog (`crates/app/src/memory.rs`) that samples RAM every 10s via `sysinfo`
- Three graduated response tiers: warn at 75%, pause dispatch at 85%, emergency-stop sessions at 92%
- Dispatch loop checks a lock-free `MemoryGate` before starting new containers — tasks stay in `Waiting` when paused
- Emergency mode stops the newest session (least work invested), one per tick to avoid over-correction
- Three new event types: `system:memory:warning`, `system:memory:pressure`, `system:memory:emergency`
- Configurable via `TASKS_MEMORY_WARN_PCT`, `TASKS_MEMORY_SOFT_LIMIT_PCT`, `TASKS_MEMORY_HARD_LIMIT_PCT`

Closes #105

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --workspace` — all 180 tests pass
- [ ] Manual: run with `TASKS_MEMORY_SOFT_LIMIT_PCT=10` to verify dispatch pausing triggers
- [ ] Manual: run with `TASKS_MEMORY_HARD_LIMIT_PCT=10` to verify emergency stop triggers
- [ ] Verify memory events appear in SSE stream and logs