### PR TITLE
Wire progress_threshold to SessionManager (spec §13.1)

### DIFF
--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -24,6 +24,8 @@ pub struct AppConfig {
     pub session_soft_limit: Duration,
     /// Session hard time limit (default: 1h15m).
     pub session_hard_limit: Duration,
+    /// Minimum session duration to count as "progress" (default: 60s, spec §13.1).
+    pub progress_threshold: Duration,
     /// Memory usage percentage at which to warn (default: 75%).
     pub memory_warn_pct: u8,
     /// Memory usage percentage at which to pause dispatch (default: 85%).
@@ -77,6 +79,11 @@ impl AppConfig {
             .and_then(|s| s.parse().ok())
             .unwrap_or(30u64);
 
+        let progress_threshold_secs = std::env::var("TASKS_PROGRESS_THRESHOLD")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(60u64);
+
         let memory_warn_pct = std::env::var("TASKS_MEMORY_WARN_PCT")
             .ok()
             .and_then(|s| s.parse().ok())
@@ -109,6 +116,7 @@ impl AppConfig {
             container_memory,
             session_soft_limit: Duration::from_secs(3600),
             session_hard_limit: Duration::from_secs(4500),
+            progress_threshold: Duration::from_secs(progress_threshold_secs),
             memory_warn_pct,
             memory_soft_limit_pct,
             memory_hard_limit_pct,

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -52,6 +52,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         dispatch_interval = ?config.dispatch_interval,
         container_image = %config.container_image,
         container_memory = %config.container_memory,
+        progress_threshold = ?config.progress_threshold,
         memory_warn_pct = config.memory_warn_pct,
         memory_soft_limit_pct = config.memory_soft_limit_pct,
         memory_hard_limit_pct = config.memory_hard_limit_pct,
@@ -122,7 +123,8 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
             default_container_config,
         )
         .with_soft_time_limit(config.session_soft_limit)
-        .with_hard_time_limit(config.session_hard_limit),
+        .with_hard_time_limit(config.session_hard_limit)
+        .with_progress_threshold(config.progress_threshold),
     );
 
     // --- 5b. Create orchestrator ---


### PR DESCRIPTION
## Summary

- Add `progress_threshold` field to `AppConfig` with `TASKS_PROGRESS_THRESHOLD` env var support (default: 60s)
- Wire `progress_threshold` to `SessionManager` via `.with_progress_threshold()` in `run_loop.rs`
- Add logging for `progress_threshold` at startup

This allows customizing the minimum session duration that counts as "progress" for retry logic (spec §13.1, §13.2).

## Test plan

- [x] `cargo check --package tasks-app` passes
- [x] `cargo test --package tasks-session --package server` passes (87 tests)
- [x] Verified env var parsing follows existing patterns

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)