### PR TITLE
Populate merge queue from open PRs (spec §7)

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -310,6 +310,11 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                         // If a PR's branch matches the `tasks/{task_id}` pattern, we
                         // link it to that task. Otherwise, we use an empty task_id.
                         for pr in &result.pull_requests {
+                            // Skip draft PRs — they aren't merge-ready
+                            if pr.is_draft {
+                                continue;
+                            }
+
                             let pr_url = format!(
                                 "https://github.com/{}/{}/pull/{}",
                                 pr.owner, pr.repo, pr.number

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -12,6 +12,7 @@ use tracing::{error, info, warn};
 use events::{Actor, Event, EventBus, EventStore, EventType};
 use runtime::{AppleContainerRuntime, ContainerConfig};
 use server::Server;
+use server::model::merge_queue::MergeQueueEntry;
 use server::model::task::TaskSource;
 use tasks_github::client::GitHubClient;
 use tasks_github::poller::RepoPoller;
@@ -300,17 +301,55 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             }
                         }
-                        // TODO: Re-enable PR task creation and merge queue population
-                        // once the core spec is more complete. Currently causes loops
-                        // where agent-created PRs get picked up as new tasks, which
-                        // then create more PRs, etc.
+                        // Add open PRs to the merge queue (spec §7).
                         //
-                        // for pr in &result.pull_requests {
-                        //     let source = TaskSource::GithubPr { ... };
-                        //     // Create tasks for new PRs
-                        //     // Add open PRs to the merge queue
-                        // }
-                        let _ = &result.pull_requests; // suppress unused warning
+                        // We don't create tasks for PRs here — that would cause loops
+                        // where agent-created PRs get picked up as new tasks. Instead,
+                        // we only add PRs to the merge queue, which is PR-centric.
+                        //
+                        // If a PR's branch matches the `tasks/{task_id}` pattern, we
+                        // link it to that task. Otherwise, we use an empty task_id.
+                        for pr in &result.pull_requests {
+                            let pr_url = format!(
+                                "https://github.com/{}/{}/pull/{}",
+                                pr.owner, pr.repo, pr.number
+                            );
+
+                            // Skip if already in merge queue
+                            if poll_server.has_merge_entry_for_pr(&pr_url).await {
+                                continue;
+                            }
+
+                            // Try to find a linked task by branch name
+                            let task_id = poll_server
+                                .find_task_by_branch(&pr.head_ref)
+                                .await
+                                .unwrap_or_default();
+
+                            // Create merge queue entry
+                            let entry_id = format!("mq-{}-{}-pr-{}", pr.owner, pr.repo, pr.number);
+                            let entry = MergeQueueEntry::new(
+                                entry_id.clone(),
+                                task_id.clone(),
+                                &pr_url,
+                            );
+
+                            if let Err(e) = poll_server.add_to_merge_queue(entry).await {
+                                warn!(
+                                    project = %project_id,
+                                    pr = pr.number,
+                                    error = %e,
+                                    "failed to add PR to merge queue"
+                                );
+                            } else {
+                                info!(
+                                    project = %project_id,
+                                    pr = pr.number,
+                                    task_id = %task_id,
+                                    "added PR to merge queue"
+                                );
+                            }
+                        }
                     }
                     Err(e) => {
                         error!(project = %project_id, error = %e, "poll failed");

--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -57,6 +57,11 @@ impl MergeQueue {
         self.entries.iter().find(|e| e.task_id == task_id)
     }
 
+    /// Get an entry by PR URL.
+    pub fn get_by_pr_url(&self, pr_url: &str) -> Option<&MergeQueueEntry> {
+        self.entries.iter().find(|e| e.pr_url == pr_url)
+    }
+
     /// Get all pending entries (eligible for merge in Play mode).
     pub fn pending(&self) -> Vec<&MergeQueueEntry> {
         self.entries

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -332,10 +332,16 @@ impl Server {
     ) -> Result<(), ServerError> {
         let task_id = entry.task_id.clone();
         let entry_id = entry.id.clone();
+        let pr_url = entry.pr_url.clone();
         {
             let mut state = self.state.write().await;
-            if state.merge_queue.get_by_task(&task_id).is_some() {
-                return Ok(()); // Already queued
+            // Dedup by PR URL first (handles unlinked PRs where task_id is empty)
+            if state.merge_queue.get_by_pr_url(&pr_url).is_some() {
+                return Ok(());
+            }
+            // Dedup by task_id for linked PRs
+            if !task_id.is_empty() && state.merge_queue.get_by_task(&task_id).is_some() {
+                return Ok(());
             }
             if let Some(ref store) = self.store {
                 if let Ok(store) = store.lock() {

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -373,6 +373,27 @@ impl Server {
             .map(|t| t.id.clone())
     }
 
+    /// Check if a PR URL is already in the merge queue.
+    pub async fn has_merge_entry_for_pr(&self, pr_url: &str) -> bool {
+        let state = self.state.read().await;
+        state.merge_queue.get_by_pr_url(pr_url).is_some()
+    }
+
+    /// Find a task ID by its branch name.
+    ///
+    /// Tasks use branches named `tasks/{task_id}`, so we extract the task ID
+    /// from the branch name and look it up.
+    pub async fn find_task_by_branch(&self, branch: &str) -> Option<String> {
+        // Tasks use branches like "tasks/gh-owner-repo-issue-123"
+        let task_id = branch.strip_prefix("tasks/")?;
+        let state = self.state.read().await;
+        if state.tasks.contains_key(task_id) {
+            Some(task_id.to_string())
+        } else {
+            None
+        }
+    }
+
     /// Get the effective session limit for a project.
     /// Returns the project's configured limit, or the global default.
     pub async fn project_session_limit(&self, project_id: &str, global_max: u32) -> u32 {


### PR DESCRIPTION
## Summary

- Fix merge queue not being populated by open PRs
- Add `get_by_pr_url` method to MergeQueue for dedup checking  
- Add `has_merge_entry_for_pr` and `find_task_by_branch` methods to Server
- Implement PR-to-merge-queue population in the GitHub poll loop

The original code had PR processing disabled due to concerns about loops where agent-created PRs would be picked up as new tasks. The fix adds PRs directly to the merge queue without creating tasks for them, which follows the spec (§7) stating the merge queue is PR-centric and operates independently of tasks.

When a PR's branch matches `tasks/{task_id}`, it's linked to that task. Otherwise, the entry has an empty `task_id`.

## Test plan

- [x] Code compiles with `cargo check`
- [x] All existing tests pass with `cargo test`
- [x] Server tests pass (83 tests)

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)