### PR TITLE
Wire event-driven dispatch triggers (spec §12.1)

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -424,7 +424,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // - task:created — new work available
     // - task:state:completed/failed/cancelled — slot freed up
     // - task:state:waiting — task became unblocked
-    // - human:message — answer provided to Question-state task
+    // - human:message or orchestrator:feedback — answer provided to Question-state task
     // - system:mode:pause/play — mode changed
     //
     // Plus a reconciliation tick to catch missed events (spec §12.1).
@@ -443,9 +443,23 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
 
     let dispatch_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(dispatch_interval);
-        let mut event_rx = dispatch_event_bus.subscribe();
 
-        // Track pending answers: task IDs that received HumanMessage while in Question state
+        // Subscribe to dispatch-triggering events only (spec §12.1).
+        // Pattern-based subscription filters out irrelevant events at the receiver level.
+        let mut event_rx = dispatch_event_bus.subscribe_with_patterns(&[
+            "task:created",
+            "task:state:completed",
+            "task:state:failed",
+            "task:state:cancelled",
+            "task:state:waiting",
+            "human:message",
+            "orchestrator:feedback",
+            "system:mode:pause",
+            "system:mode:play",
+        ]);
+
+        // Track pending answers: task IDs that received a message while in Question state.
+        // Per spec §12.1, both human and orchestrator messages can answer agent questions.
         let mut pending_answers: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         // GitHub client for fetching comments at dispatch time (spec §15.2)
@@ -467,37 +481,26 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                 }
             };
 
-            // Check if this is a dispatch-triggering event
-            let should_dispatch = match &trigger_event {
-                None => true, // reconciliation tick
-                Some(event) => {
-                    // Track HumanMessage for Question-state tasks (spec §12.1)
-                    if event.event_type == EventType::HumanMessage {
-                        // Check if task is in Question state
-                        if let Some(task) = dispatch_server.get_task(&event.task).await {
-                            if task.state == models::task::TaskState::Question {
-                                pending_answers.insert(event.task.clone());
-                                info!(task_id = %event.task, "tracking pending answer for dispatch");
-                            }
+            // Track answer events for Question-state tasks (spec §12.1).
+            // All events from pattern subscription trigger dispatch; we just need
+            // to track HumanMessage and OrchestratorFeedback for pending answers.
+            if let Some(ref event) = trigger_event {
+                if matches!(
+                    event.event_type,
+                    EventType::HumanMessage | EventType::OrchestratorFeedback
+                ) {
+                    // Check if task is in Question state
+                    if let Some(task) = dispatch_server.get_task(&event.task).await {
+                        if task.state == models::task::TaskState::Question {
+                            pending_answers.insert(event.task.clone());
+                            info!(
+                                task_id = %event.task,
+                                event_type = %event.event_type.as_str(),
+                                "tracking pending answer for dispatch"
+                            );
                         }
-                        true // trigger dispatch to process the answer
-                    } else {
-                        matches!(
-                            event.event_type,
-                            EventType::TaskCreated
-                            | EventType::TaskStateCompleted
-                            | EventType::TaskStateFailed
-                            | EventType::TaskStateCancelled
-                            | EventType::TaskStateWaiting
-                            | EventType::SystemModePause
-                            | EventType::SystemModePlay
-                        )
                     }
                 }
-            };
-
-            if !should_dispatch {
-                continue;
             }
 
             // Debounce: wait briefly to coalesce rapid events (spec §12.1)
@@ -508,8 +511,11 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     _ = tokio::time::sleep_until(debounce_deadline) => break,
                     result = event_rx.recv() => {
                         if let Ok(event) = result {
-                            // Track additional HumanMessage events during debounce
-                            if event.event_type == EventType::HumanMessage {
+                            // Track additional answer events during debounce
+                            if matches!(
+                                event.event_type,
+                                EventType::HumanMessage | EventType::OrchestratorFeedback
+                            ) {
                                 if let Some(task) = dispatch_server.get_task(&event.task).await {
                                     if task.state == models::task::TaskState::Question {
                                         pending_answers.insert(event.task.clone());

--- a/crates/events/src/bus.rs
+++ b/crates/events/src/bus.rs
@@ -8,6 +8,34 @@ use tokio::sync::broadcast;
 
 use crate::{Event, EventStore, store::StoreError};
 
+/// A pattern-filtered event subscriber (spec §12.1).
+///
+/// Wraps a broadcast receiver and filters events based on patterns.
+/// Created via [`EventBus::subscribe_with_patterns`].
+pub struct PatternSubscriber {
+    receiver: broadcast::Receiver<Arc<Event>>,
+    patterns: Vec<String>,
+}
+
+impl PatternSubscriber {
+    /// Receive the next event that matches any of the patterns.
+    ///
+    /// Blocks until a matching event is available or the channel is closed.
+    pub async fn recv(&mut self) -> Result<Arc<Event>, broadcast::error::RecvError> {
+        loop {
+            let event = self.receiver.recv().await?;
+            if self.matches(&event) {
+                return Ok(event);
+            }
+        }
+    }
+
+    /// Check if an event matches any of the configured patterns.
+    fn matches(&self, event: &Event) -> bool {
+        self.patterns.iter().any(|p| event.event_type.matches(p))
+    }
+}
+
 /// Event bus combining storage with live pub/sub.
 ///
 /// Events are persisted to the store and broadcast to subscribers.
@@ -41,6 +69,27 @@ impl EventBus {
     /// Use `subscribe_with_replay` to also get historical events.
     pub fn subscribe(&self) -> broadcast::Receiver<Arc<Event>> {
         self.sender.subscribe()
+    }
+
+    /// Subscribe to events matching specific patterns (spec §12.1).
+    ///
+    /// Returns a [`PatternSubscriber`] that filters events based on the given patterns.
+    /// Patterns support wildcards: `task:*` matches all task events,
+    /// `task:state:*` matches all state changes.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let mut sub = event_bus.subscribe_with_patterns(&["task:created", "task:state:*"]);
+    /// while let Ok(event) = sub.recv().await {
+    ///     // Only receives task:created and task:state:* events
+    /// }
+    /// ```
+    pub fn subscribe_with_patterns(&self, patterns: &[&str]) -> PatternSubscriber {
+        PatternSubscriber {
+            receiver: self.sender.subscribe(),
+            patterns: patterns.iter().map(|s| s.to_string()).collect(),
+        }
     }
 
     /// Subscribe to events for a specific task, replaying history first.
@@ -164,5 +213,51 @@ mod tests {
 
         assert!(matches_task(&event, "task-1"));
         assert!(!matches_task(&event, "task-2"));
+    }
+
+    #[tokio::test]
+    async fn subscribe_with_patterns_filters_events() {
+        let dir = tempdir().unwrap();
+        let store = EventStore::new(dir.path());
+        let bus = EventBus::new(store, 16);
+
+        // Subscribe only to task:created and task:state:* events
+        let mut sub = bus.subscribe_with_patterns(&["task:created", "task:state:*"]);
+
+        // Publish events of different types
+        let task_created = Event::new(
+            EventType::TaskCreated,
+            "task-1",
+            Actor::System,
+            serde_json::json!({}),
+        );
+        let task_created_id = task_created.id;
+
+        let agent_message = Event::new(
+            EventType::AgentMessage,
+            "task-1",
+            Actor::Agent,
+            serde_json::json!({}),
+        );
+
+        let task_running = Event::new(
+            EventType::TaskStateRunning,
+            "task-1",
+            Actor::System,
+            serde_json::json!({}),
+        );
+        let task_running_id = task_running.id;
+
+        bus.publish(task_created).await.unwrap();
+        bus.publish(agent_message).await.unwrap();
+        bus.publish(task_running).await.unwrap();
+
+        // Should receive task:created (matches exact pattern)
+        let received = sub.recv().await.unwrap();
+        assert_eq!(received.id, task_created_id);
+
+        // Should skip agent:message and receive task:state:running (matches task:state:*)
+        let received = sub.recv().await.unwrap();
+        assert_eq!(received.id, task_running_id);
     }
 }

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -9,4 +9,4 @@ mod bus;
 
 pub use event::{Event, EventType, Actor};
 pub use store::{EventStore, StoreError};
-pub use bus::{EventBus, matches_pattern, matches_task};
+pub use bus::{EventBus, PatternSubscriber, matches_pattern, matches_task};


### PR DESCRIPTION
## Summary

- Add `subscribe_with_patterns` to EventBus for filtered event subscriptions
- Add `PatternSubscriber` wrapper that filters events by pattern at receive time
- Update dispatch loop to use pattern subscription with explicit trigger list
- Track both `HumanMessage` and `OrchestratorFeedback` as potential answers for Question-state tasks

Per spec §12.1, dispatch should be triggered by specific events:
- `task:created` — new task is available
- `task:state:completed/failed/cancelled` — a slot freed up
- `task:state:waiting` — a blocked task became unblocked  
- `human:message` or `orchestrator:feedback` — answer provided to Question-state task
- `system:mode:pause/play` — mode changed to one that allows dispatch

The dispatch loop now explicitly subscribes to only these events using `subscribe_with_patterns`, making the trigger sources clear and the code more maintainable.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p events` passes (includes new test for `subscribe_with_patterns`)
- [x] `cargo test -p server` passes
- [x] `cargo test -p tasks-app` passes

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)