### PR TITLE
Destroy containers when sessions end to prevent disk leak

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -952,8 +952,8 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     }
     info!("shutting down");
 
-    // Stop all sessions
-    session_manager.stop_all().await;
+    // Stop all sessions and destroy their containers
+    session_manager.destroy_all().await;
 
     // Cancel the loops
     poll_handle.abort();

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -162,6 +162,31 @@ impl<R: ContainerRuntime + Send + Sync + 'static> SessionManager<R> {
             }
         }
     }
+
+    /// Stop all sessions and destroy their containers (for clean shutdown).
+    pub async fn destroy_all(&self) {
+        let mut sessions = self.sessions.write().await;
+        for handle in sessions.values() {
+            // Best-effort stop command to the agent
+            let _ = handle.command_tx.send(SessionCommand::Stop).await;
+            // Destroy the container (stop + rm)
+            if let Err(e) = self.runtime.destroy(&handle.container_id).await {
+                tracing::error!(
+                    task_id = %handle.task_id,
+                    container_id = %handle.container_id,
+                    error = %e,
+                    "failed to destroy container during shutdown"
+                );
+            } else {
+                tracing::info!(
+                    task_id = %handle.task_id,
+                    container_id = %handle.container_id,
+                    "destroyed container during shutdown"
+                );
+            }
+        }
+        sessions.clear();
+    }
 }
 
 /// Methods that require `Clone` on the runtime (needed to create `runtime::Session`).
@@ -205,6 +230,8 @@ impl<R: ContainerRuntime + Clone + Send + Sync + 'static> SessionManager<R> {
             command_rx,
             self.event_bus.clone(),
             self.sessions.clone(),
+            self.runtime.clone(),
+            container_id.clone(),
             self.soft_time_limit,
             self.hard_time_limit,
             self.progress_threshold,
@@ -235,6 +262,8 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
     mut command_rx: tokio::sync::mpsc::Receiver<SessionCommand>,
     event_bus: Arc<EventBus>,
     sessions: Arc<RwLock<HashMap<String, SessionHandle>>>,
+    runtime: Arc<R>,
+    container_id: String,
     soft_limit: Duration,
     hard_limit: Duration,
     progress_threshold: Duration,
@@ -384,6 +413,22 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
     sessions.write().await.remove(&task_id);
     // Abort the reader thread
     reader.abort();
+
+    // Destroy the container to reclaim disk and memory
+    if let Err(e) = runtime.destroy(&container_id).await {
+        tracing::error!(
+            task_id = %task_id,
+            container_id = %container_id,
+            error = %e,
+            "failed to destroy container after session ended"
+        );
+    } else {
+        tracing::info!(
+            task_id = %task_id,
+            container_id = %container_id,
+            "destroyed container after session ended"
+        );
+    }
 }
 
 /// Map a supervisor event to a platform event and publish it.

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -153,39 +153,38 @@ impl<R: ContainerRuntime + Send + Sync + 'static> SessionManager<R> {
         Ok(())
     }
 
-    /// Stop all active sessions (for shutdown).
-    pub async fn stop_all(&self) {
-        let sessions = self.sessions.read().await;
-        for handle in sessions.values() {
-            if let Err(e) = handle.command_tx.send(SessionCommand::Stop).await {
-                tracing::warn!(task_id = %handle.task_id, error = %e, "failed to send stop command during shutdown");
-            }
-        }
-    }
-
     /// Stop all sessions and destroy their containers (for clean shutdown).
+    ///
+    /// Drains the sessions map under a brief write lock, then aborts monitor
+    /// tasks and destroys containers without holding the lock.
     pub async fn destroy_all(&self) {
-        let mut sessions = self.sessions.write().await;
-        for handle in sessions.values() {
-            // Best-effort stop command to the agent
-            let _ = handle.command_tx.send(SessionCommand::Stop).await;
-            // Destroy the container (stop + rm)
-            if let Err(e) = self.runtime.destroy(&handle.container_id).await {
+        let entries: Vec<(String, String, JoinHandle<()>)> = {
+            let mut sessions = self.sessions.write().await;
+            sessions
+                .drain()
+                .map(|(_, h)| (h.task_id, h.container_id, h.monitor_handle))
+                .collect()
+        };
+
+        for (task_id, container_id, monitor_handle) in entries {
+            // Abort the monitor task so it doesn't double-destroy
+            monitor_handle.abort();
+
+            if let Err(e) = self.runtime.destroy(&container_id).await {
                 tracing::error!(
-                    task_id = %handle.task_id,
-                    container_id = %handle.container_id,
+                    task_id = %task_id,
+                    container_id = %container_id,
                     error = %e,
                     "failed to destroy container during shutdown"
                 );
             } else {
                 tracing::info!(
-                    task_id = %handle.task_id,
-                    container_id = %handle.container_id,
+                    task_id = %task_id,
+                    container_id = %container_id,
                     "destroyed container during shutdown"
                 );
             }
         }
-        sessions.clear();
     }
 }
 
@@ -414,20 +413,24 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
     // Abort the reader thread
     reader.abort();
 
-    // Destroy the container to reclaim disk and memory
-    if let Err(e) = runtime.destroy(&container_id).await {
-        tracing::error!(
-            task_id = %task_id,
-            container_id = %container_id,
-            error = %e,
-            "failed to destroy container after session ended"
-        );
-    } else {
-        tracing::info!(
-            task_id = %task_id,
-            container_id = %container_id,
-            "destroyed container after session ended"
-        );
+    // Destroy the container to reclaim disk and memory.
+    // Log at debug on failure — the container may already be gone if destroy_all ran first.
+    match runtime.destroy(&container_id).await {
+        Ok(()) => {
+            tracing::info!(
+                task_id = %task_id,
+                container_id = %container_id,
+                "destroyed container after session ended"
+            );
+        }
+        Err(e) => {
+            tracing::debug!(
+                task_id = %task_id,
+                container_id = %container_id,
+                error = %e,
+                "container destroy failed (may already be cleaned up)"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Containers were never destroyed after sessions ended — `monitor_session` removed the handle from the sessions map but never called `container stop` + `container rm`. `StdioTransport::Drop` killed the attach process but left the VM and its disk layer running.
- This caused ~2GB per session to accumulate indefinitely (found 157 zombie containers using 318GB on disk).

**Fix:**
- Pass `runtime` + `container_id` into `monitor_session`, call `runtime.destroy()` after the monitoring loop exits
- Add `destroy_all()` to `SessionManager` for clean shutdown (stops agents + destroys containers)
- Use `destroy_all()` instead of `stop_all()` in the shutdown path

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p tasks-session` — all 7 tests pass
- [x] Manually cleaned up 157 stale containers, reclaiming ~300GB