### PR TITLE
Cross-compile supervisor on host instead of in container

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,10 +41,19 @@ A human-in-the-loop platform that orchestrates coding agents to get project work
 ## Building the container image
 
 ```sh
-container build --dns 8.8.8.8 -f src/runtime/Dockerfile -t tasks-agent:latest .
+make container-image   # cross-compile supervisor + build image
 ```
 
-The Dockerfile uses a multi-stage build: Rust compilation in `rust:1.85-slim`, runtime on `ubuntu:24.04`. The supervisor binary (`crates/supervisor/`) is compiled in the builder stage and copied into the final image.
+The supervisor binary is cross-compiled on the host for `aarch64-unknown-linux-gnu` and copied into the container image. This is faster than building inside Docker.
+
+**Prerequisites** (run `make check-linker` to verify):
+- Cross-linker: `brew install messense/macos-cross-toolchains/aarch64-unknown-linux-gnu` (macOS) or `apt install gcc-aarch64-linux-gnu` (Linux)
+- Rust target: `rustup target add aarch64-unknown-linux-gnu`
+
+**Individual targets:**
+- `make supervisor` — build the supervisor binary only
+- `make container-image` — build supervisor + container image
+- `make check-linker` — verify cross-compilation toolchain is installed
 
 ## Running
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# Cross-compilation and container image build targets
+
+# Target triple for Linux ARM64 (container runtime)
+TARGET := aarch64-unknown-linux-gnu
+
+# Cross-linker binary name (installed via brew on macOS or apt on Linux)
+LINKER := $(TARGET)-gcc
+
+# Output paths
+SUPERVISOR_BIN := target/$(TARGET)/release/tasks-supervisor
+CONTAINER_IMAGE := tasks-agent:latest
+
+.PHONY: all check-linker supervisor container-image clean
+
+all: container-image
+
+# Verify the cross-compilation toolchain is available
+check-linker:
+	@which $(LINKER) > /dev/null 2>&1 || { \
+		echo ""; \
+		echo "ERROR: Cross-linker '$(LINKER)' not found in PATH"; \
+		echo ""; \
+		echo "Install the cross-compilation toolchain:"; \
+		echo ""; \
+		echo "  macOS (Homebrew):"; \
+		echo "    brew tap messense/macos-cross-toolchains"; \
+		echo "    brew install $(TARGET)"; \
+		echo ""; \
+		echo "  Ubuntu/Debian:"; \
+		echo "    sudo apt-get install gcc-aarch64-linux-gnu"; \
+		echo ""; \
+		echo "Then ensure rustup has the target:"; \
+		echo "    rustup target add $(TARGET)"; \
+		echo ""; \
+		exit 1; \
+	}
+	@echo "Cross-linker '$(LINKER)' found: $$(which $(LINKER))"
+
+# Build the supervisor binary for Linux ARM64
+supervisor: check-linker
+	CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$(LINKER) \
+		cargo build -p tasks-supervisor --release --target $(TARGET)
+	@echo "Built: $(SUPERVISOR_BIN)"
+
+# Build the container image (requires supervisor binary)
+container-image: supervisor
+	@test -f $(SUPERVISOR_BIN) || { echo "ERROR: $(SUPERVISOR_BIN) not found"; exit 1; }
+	container build --dns 8.8.8.8 -f src/runtime/Dockerfile -t $(CONTAINER_IMAGE) .
+	@echo "Built container image: $(CONTAINER_IMAGE)"
+
+# Clean build artifacts
+clean:
+	cargo clean
+	@echo "Cleaned build artifacts"

--- a/src/runtime/Dockerfile
+++ b/src/runtime/Dockerfile
@@ -1,42 +1,5 @@
-# Stage 1: Build the supervisor binary
-FROM rust:1.85-slim AS builder
-
-WORKDIR /build
-
-# Copy workspace manifests.
-COPY Cargo.toml Cargo.lock* ./
-
-# Copy all crate Cargo.toml files (workspace glob requires them to exist).
-COPY crates/agent/Cargo.toml crates/agent/Cargo.toml
-COPY crates/app/Cargo.toml crates/app/Cargo.toml
-COPY crates/events/Cargo.toml crates/events/Cargo.toml
-COPY crates/github/Cargo.toml crates/github/Cargo.toml
-COPY crates/models/Cargo.toml crates/models/Cargo.toml
-COPY crates/orchestrator/Cargo.toml crates/orchestrator/Cargo.toml
-COPY crates/runtime/Cargo.toml crates/runtime/Cargo.toml
-COPY crates/server/Cargo.toml crates/server/Cargo.toml
-COPY crates/session/Cargo.toml crates/session/Cargo.toml
-COPY crates/store/Cargo.toml crates/store/Cargo.toml
-COPY crates/supervisor/Cargo.toml crates/supervisor/Cargo.toml
-
-# Create dummy lib/main files so cargo can resolve the workspace and cache deps.
-RUN for dir in crates/*/; do \
-      mkdir -p "$dir/src"; \
-      name=$(basename "$dir"); \
-      if [ "$name" = "app" ] || [ "$name" = "supervisor" ]; then \
-        echo 'fn main() {}' > "$dir/src/main.rs"; \
-      else \
-        echo '' > "$dir/src/lib.rs"; \
-      fi; \
-    done
-
-RUN cargo build -p tasks-supervisor --release 2>/dev/null || true
-
-# Copy real supervisor source and rebuild (remove cached dummy binary to force recompile).
-COPY crates/supervisor/src crates/supervisor/src
-RUN touch crates/supervisor/src/main.rs && cargo build -p tasks-supervisor --release
-
-# Stage 2: Runtime image
+# Single-stage runtime image
+# The supervisor binary is cross-compiled on the host via `make supervisor`
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -74,12 +37,12 @@ RUN useradd -m -s /bin/bash agent && \
     echo 'Defaults env_keep += "ANTHROPIC_API_KEY GITHUB_TOKEN AGENT_CMD AGENT_ARGS"' >> /etc/sudoers && \
     echo 'Defaults secure_path="/home/agent/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' >> /etc/sudoers
 
-# Rust (minimal profile — for Rust-based projects the agent works on)
+# Rust (minimal profile - for Rust-based projects the agent works on)
 RUN su agent -c 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal'
 ENV PATH="/home/agent/.cargo/bin:${PATH}"
 
-# Supervisor binary from build stage (runs as root PID 1, spawns agent as non-root).
-COPY --from=builder /build/target/release/tasks-supervisor /usr/local/bin/supervisor
+# Supervisor binary (cross-compiled on host, runs as root PID 1, spawns agent as non-root)
+COPY target/aarch64-unknown-linux-gnu/release/tasks-supervisor /usr/local/bin/supervisor
 
 # Pre-accept Claude Code ToS so it doesn't hang on first run
 RUN mkdir -p /home/agent/.claude && \


### PR DESCRIPTION
## Summary

- Add Makefile with cross-compilation targets for `aarch64-unknown-linux-gnu`
- `check-linker` target verifies the cross-toolchain is on `$PATH` with helpful install instructions
- `supervisor` target builds the binary with linker set via `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER` env var
- `container-image` target runs the full flow: build supervisor + container image
- Simplify Dockerfile from multi-stage to single-stage (just COPY the pre-built binary)
- Update CLAUDE.md with new build instructions and prerequisites

This addresses the issues from the previous attempt (PR #70):
1. Linker is set via env var in Makefile, not commented `.cargo/config.toml` lines
2. `check-linker` target provides clear install instructions for macOS and Linux
3. No dead code or unnecessary OS/arch detection branches

Fixes #16

## Test plan

- [ ] Run `make check-linker` - should show helpful error if toolchain missing, or success message if found
- [ ] Run `make supervisor` on macOS with toolchain installed - should produce `target/aarch64-unknown-linux-gnu/release/tasks-supervisor`
- [ ] Run `make container-image` - should build working container image
- [ ] Verify container starts and supervisor runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)