### PR TITLE
Fix retry logic: use Agent actor for exit events

### DIFF
--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -440,7 +440,10 @@ async fn handle_exit(
         )
     };
 
-    let event = events::Event::new(event_type, task_id, events::Actor::System, data);
+    // Use Actor::Agent since this event represents the agent exiting.
+    // This allows the run_loop event handler to process it through
+    // handle_task_failure() for retry logic (spec §13.1, §13.2, §18.2).
+    let event = events::Event::new(event_type, task_id, events::Actor::Agent, data);
     if let Err(e) = event_bus.publish(event).await {
         tracing::error!(task_id = %task_id, error = %e, "failed to publish agent exit event");
     }
@@ -565,5 +568,22 @@ mod tests {
         let received = rx.recv().await.unwrap();
         assert_eq!(received.event_type, events::EventType::TaskStateFailed);
         assert_eq!(received.data["made_progress"], true);
+    }
+
+    #[tokio::test]
+    async fn exit_event_uses_agent_actor() {
+        // The exit event must use Actor::Agent so run_loop's event handler
+        // processes it through handle_task_failure() for retry logic.
+        // See spec §13.1, §13.2, §18.2.
+        let (bus, mut rx) = test_event_bus().await;
+        let exit = runtime::protocol::AgentExitEvent {
+            code: Some(1),
+            signal: None,
+        };
+
+        handle_exit("task-1", &exit, false, &bus).await;
+
+        let received = rx.recv().await.unwrap();
+        assert_eq!(received.actor, events::Actor::Agent);
     }
 }


### PR DESCRIPTION
## Summary

- Fixed the retry logic for failed agent sessions (spec §18.2)
- Changed `handle_exit()` to emit events with `Actor::Agent` instead of `Actor::System`
- Added regression test to verify the actor type

## Problem

The `handle_exit()` function was emitting `TaskStateFailed` events with `Actor::System`, but the run_loop event handler explicitly filters out `Actor::System` events to prevent infinite loops. This meant the retry logic in `handle_task_failure()` was never triggered for agent exits.

## Fix

Changed the actor from `Actor::System` to `Actor::Agent` since the exit event represents the agent exiting (semantically correct). The event handler now correctly processes it through `handle_task_failure()`, which:

1. Increments `task.retry_count`
2. Sets `task.last_failure_at = now()`
3. If `retry_count >= max_retries`: transitions to `Failed`
4. Else: transitions to `Waiting` — dispatcher picks up after backoff

## Test plan

- [x] All existing tests pass
- [x] Added `exit_event_uses_agent_actor` test to prevent regression
- [x] Verified retry logic in `handle_task_failure()` is correctly triggered

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)