### PR TITLE
Implement merge execution for approved PRs (spec §7.1)

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -670,6 +670,8 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     let orch_server = server.clone();
     let orch = orchestrator.clone();
     let orch_event_bus = server.event_bus.clone();
+    let orch_github_token = config.github_token.clone();
+
     let orchestrator_interval = config.dispatch_interval; // reuse dispatch interval for now
 
     // Problem tracker for mode lowering (spec §6.4)
@@ -678,7 +680,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     let orchestrator_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(orchestrator_interval);
         let mut event_rx = orch_event_bus.subscribe();
-
+        let merge_github = GitHubClient::new(&orch_github_token);
         loop {
             // Tick on interval or on relevant events
             let event_opt = tokio::select! {
@@ -775,7 +777,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     .collect()
             };
 
-            for (entry_id, task_id, _pr_url) in pending {
+            for (entry_id, task_id, pr_url) in pending {
                 // Build evaluation context
                 let (task, project) = {
                     let state = orch_server.state.read().await;
@@ -858,6 +860,29 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                             .await
                         {
                             error!(entry_id = %entry_id, error = %e, "failed to approve merge entry");
+                        }
+
+                        // Execute the merge on GitHub (Play mode = continuous merge authority)
+                        if let Some((owner, repo, number)) = tasks_orchestrator::parse_pr_url(&pr_url) {
+                            match merge_github.merge_pull_request(&owner, &repo, number).await {
+                                Ok(true) => {
+                                    info!(entry_id = %entry_id, pr_url = %pr_url, "PR merged successfully");
+                                    if let Err(e) = orch_server.mark_entry_merged(&entry_id, &pr_url).await {
+                                        error!(entry_id = %entry_id, error = %e, "failed to mark entry as merged");
+                                    }
+                                }
+                                Ok(false) => {
+                                    warn!(entry_id = %entry_id, pr_url = %pr_url, "PR not mergeable (conflicts or checks failing)");
+                                    if let Err(e) = orch_server.mark_entry_conflict(&entry_id, &pr_url).await {
+                                        error!(entry_id = %entry_id, error = %e, "failed to mark entry as conflict");
+                                    }
+                                }
+                                Err(e) => {
+                                    error!(entry_id = %entry_id, pr_url = %pr_url, error = %e, "failed to merge PR on GitHub");
+                                }
+                            }
+                        } else {
+                            warn!(entry_id = %entry_id, pr_url = %pr_url, "could not parse PR URL for merge execution");
                         }
                     } else {
                         // Track rejection and check for mode lowering

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -220,13 +220,44 @@ async fn list_merge_queue(
 }
 
 /// POST /api/merge-queue/flush — Flush approved entries (Pause mode only).
+///
+/// Flushes approved entries and executes the actual GitHub merges.
 async fn flush_merge_queue(State(state): State<ApiState>) -> Result<Json<Vec<String>>, ApiError> {
-    state
+    let flushed_entries = state
         .server
         .flush_merge_queue()
         .await
-        .map(Json)
-        .map_err(ApiError::Server)
+        .map_err(ApiError::Server)?;
+
+    // Execute GitHub merges for each flushed entry
+    let github_token = std::env::var("GITHUB_TOKEN").unwrap_or_default();
+    if !github_token.is_empty() {
+        let client = tasks_github::client::GitHubClient::new(&github_token);
+        for (entry_id, pr_url) in &flushed_entries {
+            if let Some((owner, repo, number)) = tasks_orchestrator::parse_pr_url(pr_url) {
+                match client.merge_pull_request(&owner, &repo, number).await {
+                    Ok(true) => {
+                        tracing::info!(entry_id = %entry_id, pr_url = %pr_url, "PR merged via flush");
+                        if let Err(e) = state.server.mark_entry_merged(entry_id, pr_url).await {
+                            tracing::error!(entry_id = %entry_id, error = %e, "failed to mark entry merged after flush");
+                        }
+                    }
+                    Ok(false) => {
+                        tracing::warn!(entry_id = %entry_id, pr_url = %pr_url, "PR not mergeable during flush");
+                        if let Err(e) = state.server.mark_entry_conflict(entry_id, pr_url).await {
+                            tracing::error!(entry_id = %entry_id, error = %e, "failed to mark entry conflict after flush");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(entry_id = %entry_id, pr_url = %pr_url, error = %e, "failed to merge PR during flush");
+                    }
+                }
+            }
+        }
+    }
+
+    let ids: Vec<String> = flushed_entries.into_iter().map(|(id, _)| id).collect();
+    Ok(Json(ids))
 }
 
 /// POST /api/merge-queue/:id/approve — Approve a merge queue entry.

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -433,6 +433,65 @@ impl GitHubClient {
     }
 
     // -----------------------------------------------------------------------
+    // PR merge (spec §7.1)
+    // -----------------------------------------------------------------------
+
+    /// Merge a pull request via the GitHub REST API.
+    ///
+    /// Uses squash merge by default. Returns `Ok(true)` if merged successfully,
+    /// `Ok(false)` if the PR is not mergeable (conflicts, checks failing, etc.).
+    pub async fn merge_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+    ) -> Result<bool, GitHubError> {
+        self.wait_for_rate_limit().await;
+
+        let url = format!(
+            "{}/repos/{}/{}/pulls/{}/merge",
+            self.base_url, owner, repo, number
+        );
+
+        let body = json!({
+            "merge_method": "squash",
+        });
+
+        let response = self.http.put(&url).json(&body).send().await?;
+        self.update_rate_limit(&response);
+
+        let status = response.status();
+
+        if status.is_success() {
+            return Ok(true);
+        }
+
+        // 405 = not mergeable (conflicts, checks required, etc.)
+        // 409 = merge conflict
+        if status == reqwest::StatusCode::METHOD_NOT_ALLOWED
+            || status == reqwest::StatusCode::CONFLICT
+        {
+            return Ok(false);
+        }
+
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(GitHubError::NotFound(format!(
+                "{owner}/{repo}#{number}"
+            )));
+        }
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        let text = response.text().await.unwrap_or_default();
+        Err(GitHubError::Decode(format!(
+            "unexpected merge status {status}: {text}"
+        )))
+    }
+
+    // -----------------------------------------------------------------------
     // PR discovery
     // -----------------------------------------------------------------------
 

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -500,29 +500,40 @@ impl Server {
 
     /// Flush the merge queue (spec Section 6.2).
     ///
-    /// Only valid in Pause mode.
-    pub async fn flush_merge_queue(&self) -> Result<Vec<String>, ServerError> {
-        let mut state = self.state.write().await;
-        let mode = state.mode;
-        let flushed = state
-            .merge_queue
-            .flush(mode)
-            .map_err(|e| ServerError::EventStore(events::StoreError::Io(
-                std::io::Error::other(e.to_string()),
-            )))?;
+    /// Only valid in Pause mode. Returns (entry_id, pr_url) pairs for
+    /// the caller to execute the actual GitHub merges.
+    pub async fn flush_merge_queue(&self) -> Result<Vec<(String, String)>, ServerError> {
+        let flushed_entries = {
+            let mut state = self.state.write().await;
+            let mode = state.mode;
+            // Collect entry details before flushing
+            let entries: Vec<(String, String)> = state
+                .merge_queue
+                .approved()
+                .iter()
+                .map(|e| (e.id.clone(), e.pr_url.clone()))
+                .collect();
+            state
+                .merge_queue
+                .flush(mode)
+                .map_err(|e| ServerError::EventStore(events::StoreError::Io(
+                    std::io::Error::other(e.to_string()),
+                )))?;
+            entries
+        };
 
-        drop(state);
+        let ids: Vec<String> = flushed_entries.iter().map(|(id, _)| id.clone()).collect();
 
         // Emit flush event
         let event = Event::new(
             EventType::SystemFlush,
             "system",
             Actor::Human,
-            serde_json::json!({ "flushed": flushed }),
+            serde_json::json!({ "flushed": ids }),
         );
         self.event_bus.publish(event).await?;
 
-        Ok(flushed)
+        Ok(flushed_entries)
     }
 
     /// Approve a merge queue entry and emit a `merge:approved` event.
@@ -552,6 +563,69 @@ impl Server {
             serde_json::json!({ "entry_id": entry_id, "reasoning": reasoning }),
         );
         self.event_bus.publish(event).await?;
+        Ok(())
+    }
+
+    /// Mark a merge queue entry as merged and transition the linked task
+    /// to Completed. Emits `merge:completed` and `task:state:completed`.
+    pub async fn mark_entry_merged(
+        &self,
+        entry_id: &str,
+        pr_url: &str,
+    ) -> Result<(), ServerError> {
+        let task_id = {
+            let mut state = self.state.write().await;
+            state
+                .merge_queue
+                .mark_merged(entry_id)
+                .map_err(|e| ServerError::StoreError(e.to_string()))?;
+            let entry = state.merge_queue.get(entry_id)
+                .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
+            entry.task_id.clone()
+        };
+
+        let event = Event::new(
+            EventType::MergeCompleted,
+            &task_id,
+            Actor::System,
+            serde_json::json!({ "entry_id": entry_id, "pr_url": pr_url }),
+        );
+        self.event_bus.publish(event).await?;
+
+        // Transition linked task to Completed (if task_id is non-empty)
+        if !task_id.is_empty() {
+            self.set_task_state(&task_id, TaskState::Completed, Actor::System)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Mark a merge queue entry as conflicted. Emits `merge:conflict`.
+    pub async fn mark_entry_conflict(
+        &self,
+        entry_id: &str,
+        pr_url: &str,
+    ) -> Result<(), ServerError> {
+        let task_id = {
+            let mut state = self.state.write().await;
+            state
+                .merge_queue
+                .mark_conflict(entry_id)
+                .map_err(|e| ServerError::StoreError(e.to_string()))?;
+            let entry = state.merge_queue.get(entry_id)
+                .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
+            entry.task_id.clone()
+        };
+
+        let event = Event::new(
+            EventType::MergeConflict,
+            &task_id,
+            Actor::System,
+            serde_json::json!({ "entry_id": entry_id, "pr_url": pr_url }),
+        );
+        self.event_bus.publish(event).await?;
+
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

The merge queue infrastructure existed (approve, reject, status tracking, events) but **nothing actually merged PRs on GitHub**. The orchestrator would approve entries but they'd just sit in Approved status forever.

- Add `merge_pull_request()` to `GitHubClient` — REST API squash merge, returns `Ok(true)` on success, `Ok(false)` if not mergeable (conflicts/checks)
- Add `mark_entry_merged()` / `mark_entry_conflict()` to `Server` — emit `merge:completed` / `merge:conflict` events and transition linked tasks to `Completed`
- **Play mode**: after orchestrator approval, immediately merge on GitHub
- **Pause mode**: `flush` endpoint now executes actual GitHub merges for each approved entry

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --workspace` — all tests pass
- [ ] Manual test: run in Play mode, verify approved PRs get merged and tasks transition to Completed