### PR TITLE
Add issue creation from web UI

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -47,6 +47,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/projects", get(list_projects))
         .route("/projects", post(add_project))
         .route("/projects/{id}", axum::routing::delete(delete_project))
+        .route("/issues", post(create_issue))
         .route("/merge-queue", get(list_merge_queue))
         .route("/merge-queue/flush", post(flush_merge_queue))
         .route("/merge-queue/{id}/approve", post(approve_merge))
@@ -97,6 +98,22 @@ struct AddProjectRequest {
 #[derive(Deserialize)]
 struct ChatRequest {
     message: String,
+}
+
+#[derive(Deserialize)]
+struct CreateIssueRequest {
+    /// Repository in "owner/repo" format.
+    repo: String,
+    /// Issue title.
+    title: String,
+    /// Issue body (markdown).
+    body: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CreateIssueResponse {
+    number: u64,
+    url: String,
 }
 
 #[derive(Deserialize)]
@@ -209,6 +226,43 @@ async fn delete_project(
     } else {
         Err(ApiError::BadRequest(format!("Project not found: {id}")))
     }
+}
+
+/// POST /api/issues — Create a GitHub issue.
+///
+/// Creates a new issue in the specified repository via the GitHub API.
+/// The poller will pick up the new issue on its next cycle and create a task.
+async fn create_issue(
+    Json(req): Json<CreateIssueRequest>,
+) -> Result<Json<CreateIssueResponse>, ApiError> {
+    let parts: Vec<&str> = req.repo.split('/').collect();
+    if parts.len() != 2 {
+        return Err(ApiError::BadRequest(format!(
+            "Invalid repo format: {} (expected owner/repo)",
+            req.repo
+        )));
+    }
+    let owner = parts[0];
+    let repo = parts[1];
+
+    if req.title.trim().is_empty() {
+        return Err(ApiError::BadRequest("Issue title cannot be empty".to_string()));
+    }
+
+    let github_token = std::env::var("GITHUB_TOKEN").map_err(|_| {
+        ApiError::BadRequest("GITHUB_TOKEN not configured".to_string())
+    })?;
+
+    let client = tasks_github::GitHubClient::new(&github_token);
+    let created = client
+        .create_issue(owner, repo, &req.title, req.body.as_deref())
+        .await
+        .map_err(|e| ApiError::GitHub(e.to_string()))?;
+
+    Ok(Json(CreateIssueResponse {
+        number: created.number,
+        url: created.url,
+    }))
 }
 
 /// GET /api/merge-queue — List merge queue entries.
@@ -397,6 +451,7 @@ enum ApiError {
     BadRequest(String),
     MergeQueue(String),
     SessionManager(String),
+    GitHub(String),
 }
 
 impl IntoResponse for ApiError {
@@ -406,6 +461,7 @@ impl IntoResponse for ApiError {
             ApiError::BadRequest(e) => (StatusCode::BAD_REQUEST, e),
             ApiError::MergeQueue(e) => (StatusCode::BAD_REQUEST, e),
             ApiError::SessionManager(e) => (StatusCode::BAD_REQUEST, e),
+            ApiError::GitHub(e) => (StatusCode::BAD_GATEWAY, e),
         };
         (status, Json(serde_json::json!({ "error": message }))).into_response()
     }

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -215,6 +215,58 @@ impl GitHubClient {
         Ok(issue)
     }
 
+    /// Create a new issue in a repository.
+    ///
+    /// Returns the created issue with its number, node ID, title, and URL.
+    pub async fn create_issue(
+        &self,
+        owner: &str,
+        repo: &str,
+        title: &str,
+        body: Option<&str>,
+    ) -> Result<crate::model::CreatedIssue, GitHubError> {
+        // First, get the repository ID (required for mutations).
+        let repo_id = self.get_repository_id(owner, repo).await?;
+
+        let query = queries::create_issue_mutation();
+        let variables = json!({
+            "repositoryId": repo_id,
+            "title": title,
+            "body": body,
+        });
+
+        let resp: GraphQLResponse<CreateIssueData> = self.execute(&query, variables).await?;
+        let data = self.unwrap_data(resp)?;
+
+        let issue = data
+            .create_issue
+            .and_then(|p| p.issue)
+            .ok_or_else(|| GitHubError::Decode("createIssue returned no issue".to_string()))?;
+
+        Ok(crate::model::CreatedIssue {
+            number: issue.number,
+            node_id: issue.id,
+            title: issue.title,
+            url: issue.url,
+        })
+    }
+
+    /// Get the GraphQL node ID for a repository.
+    async fn get_repository_id(&self, owner: &str, repo: &str) -> Result<String, GitHubError> {
+        let query = queries::get_repository_id_query();
+        let variables = json!({
+            "owner": owner,
+            "name": repo,
+        });
+
+        let resp: GraphQLResponse<GetRepositoryIdData> = self.execute(&query, variables).await?;
+        let data = self.unwrap_data(resp)?;
+
+        data.repository
+            .map(|r| r.id)
+            .ok_or_else(|| GitHubError::NotFound(format!("{owner}/{repo}")))
+    }
+
     // -----------------------------------------------------------------------
     // Pull Requests (spec github.md §4.2)
     // -----------------------------------------------------------------------

--- a/crates/github/src/model.rs
+++ b/crates/github/src/model.rs
@@ -196,6 +196,19 @@ pub struct LinkedIssueRef {
 }
 
 // ---------------------------------------------------------------------------
+// Created issue (returned from create mutation)
+// ---------------------------------------------------------------------------
+
+/// A newly created issue, returned from the createIssue mutation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreatedIssue {
+    pub number: u64,
+    pub node_id: String,
+    pub title: String,
+    pub url: String,
+}
+
+// ---------------------------------------------------------------------------
 // Filters (spec github.md §4.3)
 // ---------------------------------------------------------------------------
 

--- a/crates/github/src/queries.rs
+++ b/crates/github/src/queries.rs
@@ -240,3 +240,31 @@ pub fn pr_reviews_query() -> &'static str {
   }
 }"#
 }
+
+/// Mutation to create a new issue in a repository.
+pub fn create_issue_mutation() -> &'static str {
+    r#"mutation CreateIssue($repositoryId: ID!, $title: String!, $body: String, $labelIds: [ID!]) {
+  createIssue(input: {
+    repositoryId: $repositoryId
+    title: $title
+    body: $body
+    labelIds: $labelIds
+  }) {
+    issue {
+      number
+      id
+      title
+      url
+    }
+  }
+}"#
+}
+
+/// Query to get a repository's node ID (needed for mutations).
+pub fn get_repository_id_query() -> &'static str {
+    r#"query GetRepositoryId($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    id
+  }
+}"#
+}

--- a/crates/github/src/response.rs
+++ b/crates/github/src/response.rs
@@ -541,6 +541,43 @@ pub(crate) struct PrReviewsNode {
 }
 
 // ---------------------------------------------------------------------------
+// Create issue mutation response
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CreateIssueData {
+    #[serde(rename = "createIssue")]
+    pub create_issue: Option<CreateIssuePayload>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CreateIssuePayload {
+    pub issue: Option<CreatedIssue>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CreatedIssue {
+    pub number: u64,
+    pub id: String,
+    pub title: String,
+    pub url: String,
+}
+
+// ---------------------------------------------------------------------------
+// Repository ID query response
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GetRepositoryIdData {
+    pub repository: Option<RepositoryIdNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RepositoryIdNode {
+    pub id: String,
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/web/src/components/create-issue-dialog.tsx
+++ b/web/src/components/create-issue-dialog.tsx
@@ -1,0 +1,212 @@
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { useAppState } from "@/hooks/use-app-state";
+import { createIssue } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export function CreateIssueDialog() {
+  const { snapshot, selectedProject } = useAppState();
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [repo, setRepo] = useState<string>("");
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<{ number: number; url: string } | null>(null);
+
+  const projects = snapshot?.projects ?? [];
+
+  // Set default repo when dialog opens
+  const handleOpenChange = (newOpen: boolean) => {
+    if (newOpen) {
+      // If a project is selected, use it as default
+      if (selectedProject) {
+        const project = projects.find((p) => p.id === selectedProject);
+        if (project) {
+          setRepo(project.repo);
+        }
+      } else if (projects.length === 1 && projects[0]) {
+        // If only one project, use it
+        setRepo(projects[0].repo);
+      }
+    } else {
+      // Reset form when closing
+      setTitle("");
+      setBody("");
+      setRepo("");
+      setError(null);
+      setSuccess(null);
+    }
+    setOpen(newOpen);
+  };
+
+  const handleCreate = async () => {
+    if (!repo) {
+      setError("Please select a project");
+      return;
+    }
+    if (!title.trim()) {
+      setError("Title is required");
+      return;
+    }
+
+    setCreating(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const result = await createIssue({
+        repo,
+        title: title.trim(),
+        body: body.trim() || undefined,
+      });
+      setSuccess(result);
+      // Reset form fields but keep success message
+      setTitle("");
+      setBody("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create issue");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const hasProjects = projects.length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="sm" disabled={!hasProjects}>
+          <Plus className="h-4 w-4 mr-1" />
+          New Task
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create New Task</DialogTitle>
+          <DialogDescription>
+            Create a GitHub issue that will be picked up as a task.
+          </DialogDescription>
+        </DialogHeader>
+
+        {success ? (
+          <div className="space-y-4 py-4">
+            <div className="rounded-lg border border-green-500/50 bg-green-500/10 p-4">
+              <p className="text-sm text-green-400">
+                Issue #{success.number} created successfully!
+              </p>
+              <a
+                href={success.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-blue-400 hover:underline mt-1 block"
+              >
+                View on GitHub
+              </a>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              The poller will pick up the new issue on its next cycle and create
+              a task from it.
+            </p>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setOpen(false)}>
+                Close
+              </Button>
+              <Button onClick={() => setSuccess(null)}>Create Another</Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleCreate();
+            }}
+          >
+            <div className="space-y-4 py-4">
+              {/* Project selector */}
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Project</label>
+                <Select value={repo} onValueChange={setRepo}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select a project" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {projects.map((project) => (
+                      <SelectItem key={project.id} value={project.repo}>
+                        {project.repo}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Title input */}
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Title</label>
+                <Input
+                  placeholder="Issue title"
+                  value={title}
+                  onChange={(e) => {
+                    setTitle(e.target.value);
+                    setError(null);
+                  }}
+                  disabled={creating}
+                  autoFocus
+                />
+              </div>
+
+              {/* Body textarea */}
+              <div className="space-y-2">
+                <label className="text-sm font-medium">
+                  Description{" "}
+                  <span className="text-muted-foreground font-normal">
+                    (optional, markdown supported)
+                  </span>
+                </label>
+                <textarea
+                  className="flex min-h-[120px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+                  placeholder="Describe the task..."
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  disabled={creating}
+                />
+              </div>
+
+              {error && <p className="text-sm text-red-400">{error}</p>}
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={creating || !title.trim() || !repo}>
+                {creating ? "Creating..." : "Create Issue"}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -94,6 +94,25 @@ export function cancelTask(taskId: string): Promise<void> {
   return requestVoid(`/api/tasks/${taskId}/cancel`, { method: "POST" });
 }
 
+export interface CreateIssueRequest {
+  repo: string;
+  title: string;
+  body?: string;
+}
+
+export interface CreateIssueResponse {
+  number: number;
+  url: string;
+}
+
+export function createIssue(req: CreateIssueRequest): Promise<CreateIssueResponse> {
+  return request<CreateIssueResponse>("/api/issues", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(req),
+  });
+}
+
 export function subscribeEvents(opts?: {
   pattern?: string;
   task_id?: string;

--- a/web/src/pages/tasks/page.tsx
+++ b/web/src/pages/tasks/page.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useAppState } from "@/hooks/use-app-state";
+import { CreateIssueDialog } from "@/components/create-issue-dialog";
 import { columns } from "./columns";
 import { DataTable } from "./data-table";
 
@@ -23,13 +24,16 @@ export function TasksPage() {
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 md:p-8">
-      <div>
-        <h2 className="text-base font-bold tracking-tight">Tasks</h2>
-        <p className="text-muted-foreground">
-          {selectedProjectName
-            ? `Tasks for ${selectedProjectName}`
-            : "Manage and monitor your coding tasks."}
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-base font-bold tracking-tight">Tasks</h2>
+          <p className="text-muted-foreground">
+            {selectedProjectName
+              ? `Tasks for ${selectedProjectName}`
+              : "Manage and monitor your coding tasks."}
+          </p>
+        </div>
+        <CreateIssueDialog />
       </div>
       <DataTable columns={columns} data={filteredTasks} hideProjectColumn={!!selectedProject} projectIdToRepo={projectIdToRepo} />
     </div>


### PR DESCRIPTION
## Summary
- Adds a "New Task" button to the tasks page that opens a dialog for creating GitHub issues
- Issues are created via the GitHub GraphQL API and the poller picks them up as tasks
- Dialog includes project selector, title input, and markdown body textarea
- Success state shows the issue number with a link to view on GitHub

## Implementation
**Backend (Rust):**
- Added GraphQL mutation for creating issues in `tasks-github` crate
- Added `POST /api/issues` endpoint that accepts `{ repo, title, body? }`
- Returns `{ number, url }` on success

**Frontend (React):**
- Created `CreateIssueDialog` component with form validation
- Added to tasks page header
- Auto-selects current project when one is selected

## Test plan
- [ ] Build passes (`cargo check` and `npm run build`)
- [ ] Create an issue from the UI and verify it appears on GitHub
- [ ] Verify the poller picks up the new issue and creates a task
- [ ] Test with no projects (button should be disabled)
- [ ] Test with a single project (auto-selected in form)
- [ ] Test error handling (invalid repo format, empty title)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)