### PR TITLE
Add general purpose completions endpoint using Haiku 4.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,11 @@ bun web dev                    # dev mode (proxies /api to localhost:4800)
 - `POST /api/merge-queue/flush` — Flush approved entries (Pause mode only)
 - `POST /api/tasks/:id/chat` — Send chat message to agent session `{ message: string }`
 - `GET /api/events` — SSE live event stream (optional `?pattern=&task_id=` filters)
+
+#### Completions (fast mode LLM service using claude-haiku-4-5)
+
+- `POST /api/completions` — General-purpose completion `{ prompt, system?, temperature?, max_tokens? }`
+- `POST /api/completions/name` — Generate a name `{ context: string }`
+- `POST /api/completions/describe` — Generate a description `{ context: string }`
+- `POST /api/completions/brainstorm` — Brainstorm ideas `{ context: string, count?: number }`
+- `POST /api/completions/summarize` — Summarize text `{ context: string }`

--- a/crates/agent/src/completions.rs
+++ b/crates/agent/src/completions.rs
@@ -1,0 +1,187 @@
+//! Fast completions service for general-purpose LLM utilities.
+//!
+//! Provides a lightweight service using claude-haiku-4-5 for quick tasks like:
+//! - Naming threads
+//! - Generating descriptions
+//! - Brainstorming names
+//! - Other general-purpose text generation
+
+use crate::error::AgentError;
+use crate::message::{Message, Response};
+use crate::provider::{CompletionConfig, CompletionRequest, Provider};
+use crate::providers::AnthropicProvider;
+
+/// Default model for fast completions (Haiku for speed).
+pub const FAST_MODEL: &str = "claude-haiku-4-5-20251001";
+
+/// Default max tokens for completions (conservative for fast responses).
+const DEFAULT_MAX_TOKENS: u32 = 1024;
+
+/// Service for fast, general-purpose LLM completions.
+///
+/// Uses claude-haiku-4-5 by default for quick responses. Designed for
+/// utility tasks that don't require the full capabilities of larger models.
+#[derive(Debug, Clone)]
+pub struct CompletionsService {
+    provider: AnthropicProvider,
+    model: String,
+    max_tokens: u32,
+}
+
+impl CompletionsService {
+    /// Create a new completions service with the given provider.
+    pub fn new(provider: AnthropicProvider) -> Self {
+        Self {
+            provider,
+            model: FAST_MODEL.to_string(),
+            max_tokens: DEFAULT_MAX_TOKENS,
+        }
+    }
+
+    /// Create from environment variables (ANTHROPIC_API_KEY).
+    pub fn from_env() -> Result<Self, AgentError> {
+        let provider = AnthropicProvider::from_env()?;
+        Ok(Self::new(provider))
+    }
+
+    /// Set a custom model (default is claude-haiku-4-5).
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    /// Set custom max tokens (default is 1024).
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Generate a simple text completion.
+    ///
+    /// # Arguments
+    /// * `prompt` - The user prompt to complete
+    ///
+    /// # Returns
+    /// The generated text response
+    pub async fn complete(&self, prompt: &str) -> Result<String, AgentError> {
+        let config = CompletionConfig::new(&self.model).with_max_tokens(self.max_tokens);
+        let request = CompletionRequest::new(config, vec![Message::user(prompt)]);
+        let response = self.provider.complete(request).await?;
+        Ok(response.text())
+    }
+
+    /// Generate a completion with a system prompt.
+    ///
+    /// # Arguments
+    /// * `system` - The system prompt providing context/instructions
+    /// * `prompt` - The user prompt to complete
+    ///
+    /// # Returns
+    /// The generated text response
+    pub async fn complete_with_system(
+        &self,
+        system: &str,
+        prompt: &str,
+    ) -> Result<String, AgentError> {
+        let config = CompletionConfig::new(&self.model).with_max_tokens(self.max_tokens);
+        let request = CompletionRequest::new(config, vec![Message::user(prompt)])
+            .with_system(system);
+        let response = self.provider.complete(request).await?;
+        Ok(response.text())
+    }
+
+    /// Generate a completion with full control over parameters.
+    ///
+    /// # Arguments
+    /// * `system` - Optional system prompt
+    /// * `messages` - Conversation messages
+    /// * `temperature` - Optional temperature for sampling
+    /// * `max_tokens` - Optional max tokens override
+    ///
+    /// # Returns
+    /// The full response including usage information
+    pub async fn complete_advanced(
+        &self,
+        system: Option<&str>,
+        messages: Vec<Message>,
+        temperature: Option<f32>,
+        max_tokens: Option<u32>,
+    ) -> Result<Response, AgentError> {
+        let mut config = CompletionConfig::new(&self.model)
+            .with_max_tokens(max_tokens.unwrap_or(self.max_tokens));
+        if let Some(temp) = temperature {
+            config = config.with_temperature(temp);
+        }
+        let mut request = CompletionRequest::new(config, messages);
+        if let Some(sys) = system {
+            request = request.with_system(sys);
+        }
+        self.provider.complete(request).await
+    }
+
+    /// Generate a name for something.
+    ///
+    /// Utility method that uses a tailored system prompt for naming tasks.
+    pub async fn generate_name(&self, context: &str) -> Result<String, AgentError> {
+        let system = "You are a naming assistant. Generate a single, concise name based on the context provided. \
+                      Return only the name with no explanation or additional text.";
+        self.complete_with_system(system, context).await
+    }
+
+    /// Generate a short description.
+    ///
+    /// Utility method that uses a tailored system prompt for descriptions.
+    pub async fn generate_description(&self, context: &str) -> Result<String, AgentError> {
+        let system = "You are a description writer. Generate a clear, concise description (1-2 sentences) \
+                      based on the context provided. Return only the description with no additional formatting.";
+        self.complete_with_system(system, context).await
+    }
+
+    /// Brainstorm names or ideas.
+    ///
+    /// Utility method that returns multiple suggestions.
+    ///
+    /// # Arguments
+    /// * `context` - What to brainstorm about
+    /// * `count` - Number of suggestions to generate (default 5)
+    pub async fn brainstorm(&self, context: &str, count: Option<u32>) -> Result<String, AgentError> {
+        let n = count.unwrap_or(5);
+        let system = format!(
+            "You are a creative brainstorming assistant. Generate exactly {} unique suggestions \
+             based on the context provided. Format as a numbered list, one per line. \
+             Be creative but relevant.",
+            n
+        );
+        self.complete_with_system(&system, context).await
+    }
+
+    /// Summarize text content.
+    ///
+    /// Utility method for quick summarization.
+    pub async fn summarize(&self, content: &str) -> Result<String, AgentError> {
+        let system = "You are a summarization assistant. Provide a clear, concise summary \
+                      of the content provided. Focus on the key points and keep it brief.";
+        self.complete_with_system(system, content).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_service_creation() {
+        // Test that service can be configured
+        let provider = AnthropicProvider::new("test-key");
+        let service = CompletionsService::new(provider)
+            .with_model("claude-haiku-4-5-20251001")
+            .with_max_tokens(512);
+        assert_eq!(service.model, "claude-haiku-4-5-20251001");
+        assert_eq!(service.max_tokens, 512);
+    }
+
+    #[test]
+    fn test_default_model() {
+        assert_eq!(FAST_MODEL, "claude-haiku-4-5-20251001");
+    }
+}

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -4,12 +4,14 @@
 //! Lifted and adapted from agent-foundry.
 
 pub mod chain;
+pub mod completions;
 pub mod error;
 pub mod message;
 pub mod provider;
 pub mod providers;
 pub mod session;
 
+pub use completions::{CompletionsService, FAST_MODEL};
 pub use error::AgentError;
 pub use message::{Content, Message, Response, Role, StopReason, Tool, ToolCall, ToolResult, Usage};
 pub use provider::{

--- a/crates/agent/src/providers/anthropic.rs
+++ b/crates/agent/src/providers/anthropic.rs
@@ -405,6 +405,7 @@ impl Provider for AnthropicProvider {
         &[
             "claude-sonnet-4-20250514",
             "claude-opus-4-0-20250514",
+            "claude-haiku-4-5-20251001",
             "claude-3-5-haiku-20241022",
         ]
     }

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -14,6 +14,7 @@ tasks-session = { path = "../session" }
 tasks-github = { path = "../github" }
 tasks-store = { path = "../store" }
 tasks-orchestrator = { path = "../orchestrator" }
+tasks-agent = { path = "../agent" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -981,10 +981,16 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // --- 9. Optionally spawn web server ---
 
     let web_handle = if config.web {
+        // Initialize the completions service for fast LLM utilities
+        let completions_service = tasks_agent::CompletionsService::from_env()
+            .ok()
+            .map(|s| std::sync::Arc::new(tokio::sync::RwLock::new(s)));
+
         let api_state = crate::web::ApiState {
             server: server.clone(),
             max_sessions: config.max_sessions,
             session_manager: Some(session_manager.clone()),
+            completions_service,
         };
         let web_port = config.web_port;
 

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -19,6 +19,7 @@ use axum::{
 };
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 use tower_http::cors::CorsLayer;
@@ -26,6 +27,7 @@ use tower_http::cors::CorsLayer;
 use events::Actor;
 use server::Server;
 use server::mode::Mode;
+use tasks_agent::CompletionsService;
 
 /// Shared state for API handlers.
 #[derive(Clone)]
@@ -33,6 +35,7 @@ pub struct ApiState {
     pub server: Arc<Server>,
     pub max_sessions: u32,
     pub session_manager: Option<Arc<tasks_session::SessionManager<runtime::AppleContainerRuntime>>>,
+    pub completions_service: Option<Arc<RwLock<CompletionsService>>>,
 }
 
 /// Build the API router.
@@ -53,7 +56,13 @@ pub fn router(state: ApiState) -> Router {
         .route("/merge-queue/{id}/reject", post(reject_merge))
         .route("/mode", get(get_mode))
         .route("/mode", post(set_mode))
-        .route("/events", get(event_stream));
+        .route("/events", get(event_stream))
+        // Completions endpoints (fast mode LLM service)
+        .route("/completions", post(completions))
+        .route("/completions/name", post(completions_name))
+        .route("/completions/describe", post(completions_describe))
+        .route("/completions/brainstorm", post(completions_brainstorm))
+        .route("/completions/summarize", post(completions_summarize));
 
     Router::new()
         .nest("/api", api)
@@ -105,6 +114,48 @@ struct EventStreamQuery {
     pattern: Option<String>,
     /// Optional task ID filter.
     task_id: Option<String>,
+}
+
+// --- Completions request/response types ---
+
+#[derive(Deserialize)]
+struct CompletionsRequest {
+    /// The prompt to complete.
+    prompt: String,
+    /// Optional system prompt.
+    system: Option<String>,
+    /// Optional temperature (0.0-1.0).
+    temperature: Option<f32>,
+    /// Optional max tokens override.
+    max_tokens: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct CompletionsResponse {
+    /// The generated text.
+    text: String,
+    /// Token usage information.
+    usage: Option<CompletionsUsage>,
+}
+
+#[derive(Serialize)]
+struct CompletionsUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+}
+
+#[derive(Deserialize)]
+struct ContextRequest {
+    /// The context to use for generation.
+    context: String,
+}
+
+#[derive(Deserialize)]
+struct BrainstormRequest {
+    /// The context to brainstorm about.
+    context: String,
+    /// Number of suggestions to generate (default 5).
+    count: Option<u32>,
 }
 
 // --- Handlers ---
@@ -390,6 +441,130 @@ async fn event_stream(
     Sse::new(stream).keep_alive(KeepAlive::default())
 }
 
+// --- Completions handlers ---
+
+/// POST /api/completions — General-purpose text completion.
+///
+/// Uses claude-haiku-4-5 for fast responses. Supports optional system prompt,
+/// temperature, and max_tokens parameters.
+async fn completions(
+    State(state): State<ApiState>,
+    Json(req): Json<CompletionsRequest>,
+) -> Result<Json<CompletionsResponse>, ApiError> {
+    let service_arc = state
+        .completions_service
+        .as_ref()
+        .ok_or_else(|| ApiError::Completions("completions service not available".into()))?;
+
+    // Clone the service to avoid holding lock across await
+    let service: CompletionsService = service_arc.read().await.clone();
+    let response = service
+        .complete_advanced(
+            req.system.as_deref(),
+            vec![tasks_agent::Message::user(&req.prompt)],
+            req.temperature,
+            req.max_tokens,
+        )
+        .await
+        .map_err(|e: tasks_agent::AgentError| ApiError::Completions(e.to_string()))?;
+
+    Ok(Json(CompletionsResponse {
+        text: response.text(),
+        usage: response.usage.map(|u| CompletionsUsage {
+            input_tokens: u.input_tokens,
+            output_tokens: u.output_tokens,
+        }),
+    }))
+}
+
+/// POST /api/completions/name — Generate a name.
+///
+/// Utility endpoint that generates a single, concise name based on context.
+async fn completions_name(
+    State(state): State<ApiState>,
+    Json(req): Json<ContextRequest>,
+) -> Result<Json<CompletionsResponse>, ApiError> {
+    let service_arc = state
+        .completions_service
+        .as_ref()
+        .ok_or_else(|| ApiError::Completions("completions service not available".into()))?;
+
+    // Clone the service to avoid holding lock across await
+    let service: CompletionsService = service_arc.read().await.clone();
+    let text = service
+        .generate_name(&req.context)
+        .await
+        .map_err(|e: tasks_agent::AgentError| ApiError::Completions(e.to_string()))?;
+
+    Ok(Json(CompletionsResponse { text, usage: None }))
+}
+
+/// POST /api/completions/describe — Generate a description.
+///
+/// Utility endpoint that generates a clear, concise description (1-2 sentences).
+async fn completions_describe(
+    State(state): State<ApiState>,
+    Json(req): Json<ContextRequest>,
+) -> Result<Json<CompletionsResponse>, ApiError> {
+    let service_arc = state
+        .completions_service
+        .as_ref()
+        .ok_or_else(|| ApiError::Completions("completions service not available".into()))?;
+
+    // Clone the service to avoid holding lock across await
+    let service: CompletionsService = service_arc.read().await.clone();
+    let text = service
+        .generate_description(&req.context)
+        .await
+        .map_err(|e: tasks_agent::AgentError| ApiError::Completions(e.to_string()))?;
+
+    Ok(Json(CompletionsResponse { text, usage: None }))
+}
+
+/// POST /api/completions/brainstorm — Brainstorm names or ideas.
+///
+/// Utility endpoint that generates multiple suggestions based on context.
+async fn completions_brainstorm(
+    State(state): State<ApiState>,
+    Json(req): Json<BrainstormRequest>,
+) -> Result<Json<CompletionsResponse>, ApiError> {
+    let service_arc = state
+        .completions_service
+        .as_ref()
+        .ok_or_else(|| ApiError::Completions("completions service not available".into()))?;
+
+    // Clone the service to avoid holding lock across await
+    let service: CompletionsService = service_arc.read().await.clone();
+    let text = service
+        .brainstorm(&req.context, req.count)
+        .await
+        .map_err(|e: tasks_agent::AgentError| ApiError::Completions(e.to_string()))?;
+
+    Ok(Json(CompletionsResponse { text, usage: None }))
+}
+
+/// POST /api/completions/summarize — Summarize text content.
+///
+/// Utility endpoint that provides a clear, concise summary.
+async fn completions_summarize(
+    State(state): State<ApiState>,
+    Json(req): Json<ContextRequest>,
+) -> Result<Json<CompletionsResponse>, ApiError> {
+    let service_arc = state
+        .completions_service
+        .as_ref()
+        .ok_or_else(|| ApiError::Completions("completions service not available".into()))?;
+
+    // Clone the service to avoid holding lock across await
+    let service: CompletionsService = service_arc.read().await.clone();
+    let text = service
+        .summarize(&req.context)
+        .await
+        .map_err(|e: tasks_agent::AgentError| ApiError::Completions(e.to_string()))?;
+
+    Ok(Json(CompletionsResponse { text, usage: None }))
+}
+
 // --- Error handling ---
 
 enum ApiError {
@@ -397,6 +572,7 @@ enum ApiError {
     BadRequest(String),
     MergeQueue(String),
     SessionManager(String),
+    Completions(String),
 }
 
 impl IntoResponse for ApiError {
@@ -406,6 +582,7 @@ impl IntoResponse for ApiError {
             ApiError::BadRequest(e) => (StatusCode::BAD_REQUEST, e),
             ApiError::MergeQueue(e) => (StatusCode::BAD_REQUEST, e),
             ApiError::SessionManager(e) => (StatusCode::BAD_REQUEST, e),
+            ApiError::Completions(e) => (StatusCode::INTERNAL_SERVER_ERROR, e),
         };
         (status, Json(serde_json::json!({ "error": message }))).into_response()
     }


### PR DESCRIPTION
## Summary

- Adds a new `/api/completions` endpoint for fast LLM completions using `claude-haiku-4-5`
- Creates `CompletionService` in `crates/agent` with sensible defaults for quick utility tasks
- Supports optional parameters: `system` prompt, `max_tokens`, and `temperature`

This endpoint can be used for naming threads, generating descriptions, brainstorming names, and other general purpose utilities that need quick LLM responses.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test --workspace` passes (22 tests in agent crate, including 2 new tests for completions)
- [ ] Manual test: `curl -X POST localhost:4800/api/completions -H "Content-Type: application/json" -d '{"prompt": "Suggest 3 names for a task management app"}'`

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)