### PR TITLE
Implement agent output interpretation for state detection (spec §9.3)

### DIFF
--- a/crates/session/src/interpreter.rs
+++ b/crates/session/src/interpreter.rs
@@ -1,0 +1,572 @@
+//! Agent output interpreter — spec §9.3.
+//!
+//! Interprets agent output text to infer state transitions and emit appropriate events.
+//! The agent itself does not know about the Tasks event system; this module observes
+//! agent behavior and infers what's happening.
+//!
+//! Design principle: False positives are worse than false negatives. Start conservative
+//! with high-confidence patterns.
+
+use events::{Actor, Event, EventBus, EventType};
+
+/// Result of interpreting agent output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OutputSignal {
+    /// No special signal detected — just a normal message.
+    Message,
+    /// Agent is asking a question and waiting for input.
+    Question { text: String },
+    /// Agent indicates task completion.
+    Completion { text: String },
+    /// Agent indicates failure or being stuck.
+    Failure { text: String },
+}
+
+/// Interpreter for agent output text.
+///
+/// Analyzes agent stdout to detect questions, completion signals, and failure patterns.
+/// Emits appropriate events based on detected patterns.
+pub struct OutputInterpreter {
+    /// Recent output lines for context-aware detection.
+    recent_lines: Vec<String>,
+    /// Maximum number of recent lines to keep.
+    max_recent_lines: usize,
+}
+
+impl Default for OutputInterpreter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OutputInterpreter {
+    /// Create a new output interpreter.
+    pub fn new() -> Self {
+        Self {
+            recent_lines: Vec::new(),
+            max_recent_lines: 20,
+        }
+    }
+
+    /// Set the maximum number of recent lines to track.
+    pub fn with_max_recent_lines(mut self, max: usize) -> Self {
+        self.max_recent_lines = max;
+        self
+    }
+
+    /// Analyze a line of agent output and return the detected signal.
+    pub fn interpret(&mut self, text: &str) -> OutputSignal {
+        // Store for context
+        self.recent_lines.push(text.to_string());
+        if self.recent_lines.len() > self.max_recent_lines {
+            self.recent_lines.remove(0);
+        }
+
+        let trimmed = text.trim();
+
+        // Check for question patterns first (highest priority for blocking)
+        if let Some(signal) = self.detect_question(trimmed) {
+            return signal;
+        }
+
+        // Check for failure patterns
+        if let Some(signal) = self.detect_failure(trimmed) {
+            return signal;
+        }
+
+        // Check for completion patterns
+        if let Some(signal) = self.detect_completion(trimmed) {
+            return signal;
+        }
+
+        OutputSignal::Message
+    }
+
+    /// Detect question patterns in output.
+    ///
+    /// High-confidence patterns that indicate the agent is waiting for human input:
+    /// - Explicit prompts asking for input
+    /// - Multiple choice questions
+    /// - Permission requests
+    fn detect_question(&self, text: &str) -> Option<OutputSignal> {
+        let lower = text.to_lowercase();
+
+        // High-confidence: Explicit input prompts
+        // These are strong indicators the agent is blocked waiting for input
+        let explicit_prompts = [
+            "please provide",
+            "please specify",
+            "please confirm",
+            "please choose",
+            "please select",
+            "which option",
+            "which approach",
+            "which one",
+            "would you like me to",
+            "should i proceed",
+            "should i continue",
+            "do you want me to",
+            "can you provide",
+            "can you clarify",
+            "can you confirm",
+            "i need clarification",
+            "i need more information",
+            "awaiting your input",
+            "waiting for your response",
+            "waiting for your input",
+        ];
+
+        for prompt in explicit_prompts {
+            if lower.contains(prompt) {
+                return Some(OutputSignal::Question {
+                    text: text.to_string(),
+                });
+            }
+        }
+
+        // High-confidence: Questions with specific patterns
+        // Must end with ? AND contain question indicators to reduce false positives
+        if text.ends_with('?') {
+            // Questions that are inherently directed at the user (asking permission/preference)
+            let user_directed_starters = [
+                "should i ",
+                "shall i ",
+                "would you like",
+                "do you want",
+                "can i ",
+                "may i ",
+            ];
+
+            for starter in user_directed_starters {
+                if lower.starts_with(starter) {
+                    return Some(OutputSignal::Question {
+                        text: text.to_string(),
+                    });
+                }
+            }
+
+            // Questions that need "you/your" to confirm they're directed at the user
+            let question_starters = [
+                "what ",
+                "which ",
+                "how ",
+                "where ",
+                "when ",
+                "why ",
+                "would ",
+                "should ",
+                "could ",
+                "can ",
+                "do you ",
+                "does ",
+                "is this ",
+                "are you ",
+            ];
+
+            for starter in question_starters {
+                if lower.starts_with(starter) || lower.contains(&format!(" {}", starter.trim())) {
+                    // Only treat as a blocking question if it seems to be asking the user
+                    // Check for second-person pronouns to indicate it's directed at the user
+                    if lower.contains(" you ") || lower.contains(" your ") || lower.ends_with(" you?")
+                    {
+                        return Some(OutputSignal::Question {
+                            text: text.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Detect failure patterns in output.
+    ///
+    /// High-confidence patterns that indicate the agent has hit a wall:
+    /// - Explicit stuck/blocked statements
+    /// - Inability to proceed
+    /// - Repeated errors (context-aware)
+    fn detect_failure(&self, text: &str) -> Option<OutputSignal> {
+        let lower = text.to_lowercase();
+
+        // High-confidence: Explicit failure/stuck statements
+        let failure_patterns = [
+            "i am stuck",
+            "i'm stuck",
+            "i cannot proceed",
+            "i can't proceed",
+            "i am unable to",
+            "i'm unable to",
+            "unable to continue",
+            "cannot continue",
+            "can't continue",
+            "i've hit a wall",
+            "i have hit a wall",
+            "this is beyond my capabilities",
+            "i need help to proceed",
+            "i cannot resolve this",
+            "i can't resolve this",
+            "i don't know how to proceed",
+            "i'm not sure how to proceed",
+            "this task cannot be completed",
+            "this task can't be completed",
+            "i have failed to",
+            "i've failed to",
+        ];
+
+        for pattern in failure_patterns {
+            if lower.contains(pattern) {
+                return Some(OutputSignal::Failure {
+                    text: text.to_string(),
+                });
+            }
+        }
+
+        // Context-aware: Check for repeated error patterns in recent lines
+        // If we see multiple "error:" or "failed to" in recent output, it might indicate
+        // the agent is in a failure loop
+        if self.detect_error_loop() {
+            // Only signal failure if the current line also mentions error/failure
+            if lower.contains("error") || lower.contains("failed") || lower.contains("failure") {
+                return Some(OutputSignal::Failure {
+                    text: "Repeated errors detected".to_string(),
+                });
+            }
+        }
+
+        None
+    }
+
+    /// Check if there's a pattern of repeated errors in recent lines.
+    fn detect_error_loop(&self) -> bool {
+        if self.recent_lines.len() < 5 {
+            return false;
+        }
+
+        let error_patterns = ["error:", "error!", "failed to", "failure:"];
+        let error_count = self
+            .recent_lines
+            .iter()
+            .rev()
+            .take(10)
+            .filter(|line| {
+                let lower = line.to_lowercase();
+                error_patterns.iter().any(|p| lower.contains(p))
+            })
+            .count();
+
+        // If more than 3 error-like lines in the last 10, consider it a potential loop
+        error_count >= 3
+    }
+
+    /// Detect completion patterns in output.
+    ///
+    /// High-confidence patterns that indicate the agent believes it's done:
+    /// - Explicit completion statements
+    /// - PR creation confirmations
+    /// - Commit/push confirmations
+    fn detect_completion(&self, text: &str) -> Option<OutputSignal> {
+        let lower = text.to_lowercase();
+
+        // High-confidence: Explicit completion statements
+        let completion_patterns = [
+            "task completed",
+            "task complete",
+            "task is complete",
+            "task has been completed",
+            "all changes committed",
+            "changes have been committed",
+            "changes have been pushed",
+            "i have completed the task",
+            "i've completed the task",
+            "the task is finished",
+            "the task is done",
+            "work is complete",
+            "implementation complete",
+            "implementation is complete",
+            "all done",
+            "finished implementing",
+            "successfully completed",
+        ];
+
+        for pattern in completion_patterns {
+            if lower.contains(pattern) {
+                return Some(OutputSignal::Completion {
+                    text: text.to_string(),
+                });
+            }
+        }
+
+        // High-confidence: PR creation confirmations
+        // These indicate the agent has created a PR which signals completion
+        let pr_patterns = [
+            "created pull request",
+            "opened pull request",
+            "pr has been created",
+            "pull request created",
+            "created pr #",
+            "opened pr #",
+        ];
+
+        for pattern in pr_patterns {
+            if lower.contains(pattern) {
+                return Some(OutputSignal::Completion {
+                    text: text.to_string(),
+                });
+            }
+        }
+
+        None
+    }
+
+    /// Clear the recent lines buffer (e.g., on session restart).
+    pub fn clear(&mut self) {
+        self.recent_lines.clear();
+    }
+}
+
+/// Emit events based on the interpreted signal.
+///
+/// This is a helper function that emits the appropriate events to the event bus
+/// based on the detected signal. It handles the logic for which events to emit
+/// for each signal type.
+pub async fn emit_signal_events(
+    task_id: &str,
+    signal: &OutputSignal,
+    event_bus: &EventBus,
+) -> Result<(), events::StoreError> {
+    match signal {
+        OutputSignal::Question { text } => {
+            // Emit agent:question event
+            let question_event = Event::new(
+                EventType::AgentQuestion,
+                task_id,
+                Actor::Agent,
+                serde_json::json!({
+                    "text": text,
+                    "source": "output_interpretation",
+                }),
+            );
+            event_bus.publish(question_event).await?;
+
+            // Emit task:state:question to trigger state transition
+            let state_event = Event::new(
+                EventType::TaskStateQuestion,
+                task_id,
+                Actor::Agent,
+                serde_json::json!({
+                    "reason": "agent_question",
+                    "question": text,
+                }),
+            );
+            event_bus.publish(state_event).await?;
+        }
+        OutputSignal::Failure { text } => {
+            // Emit agent:error event
+            let error_event = Event::new(
+                EventType::AgentError,
+                task_id,
+                Actor::Agent,
+                serde_json::json!({
+                    "text": text,
+                    "source": "output_interpretation",
+                }),
+            );
+            event_bus.publish(error_event).await?;
+
+            // Note: We don't emit task:state:failed here because the agent hasn't
+            // actually exited yet. The orchestrator or session manager should
+            // decide whether to transition to failed state based on this error.
+        }
+        OutputSignal::Completion { text } => {
+            // Emit an orchestrator-informative event
+            // Note: We don't automatically transition to awaiting_merge because
+            // the agent exit handler should still run and verify the exit code.
+            // This is informational for the orchestrator.
+            let completion_hint_event = Event::new(
+                EventType::AgentMessage,
+                task_id,
+                Actor::Agent,
+                serde_json::json!({
+                    "text": text,
+                    "completion_hint": true,
+                    "source": "output_interpretation",
+                }),
+            );
+            event_bus.publish(completion_hint_event).await?;
+        }
+        OutputSignal::Message => {
+            // No special events for regular messages
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_explicit_question_prompts() {
+        let mut interpreter = OutputInterpreter::new();
+
+        let questions = [
+            "Please provide the path to the config file.",
+            "Please specify which database you want to use.",
+            "Please confirm you want to delete these files.",
+            "Which option would you prefer?",
+            "Should I proceed with the refactoring?",
+            "Would you like me to run the tests first?",
+            "Can you provide more context about the bug?",
+            "I need clarification on the expected behavior.",
+        ];
+
+        for q in questions {
+            let signal = interpreter.interpret(q);
+            assert!(
+                matches!(signal, OutputSignal::Question { .. }),
+                "Should detect question: {}",
+                q
+            );
+        }
+    }
+
+    #[test]
+    fn detect_direct_questions_to_user() {
+        let mut interpreter = OutputInterpreter::new();
+
+        // Questions directed at the user (should detect)
+        let signal = interpreter.interpret("What would you like me to do next?");
+        assert!(matches!(signal, OutputSignal::Question { .. }));
+
+        let signal = interpreter.interpret("Should I push your changes to the remote?");
+        assert!(matches!(signal, OutputSignal::Question { .. }));
+
+        // Reset interpreter for clean test
+        interpreter.clear();
+
+        // Questions not directed at user (should NOT detect)
+        let signal = interpreter.interpret("What is the capital of France?");
+        assert!(matches!(signal, OutputSignal::Message));
+
+        let signal = interpreter.interpret("How does this function work?");
+        assert!(matches!(signal, OutputSignal::Message));
+    }
+
+    #[test]
+    fn detect_failure_patterns() {
+        let mut interpreter = OutputInterpreter::new();
+
+        let failures = [
+            "I'm stuck and cannot proceed with this task.",
+            "I cannot proceed without additional information.",
+            "I'm unable to resolve this merge conflict.",
+            "Unable to continue due to missing dependencies.",
+            "I've hit a wall with this approach.",
+            "This is beyond my capabilities.",
+        ];
+
+        for f in failures {
+            let signal = interpreter.interpret(f);
+            assert!(
+                matches!(signal, OutputSignal::Failure { .. }),
+                "Should detect failure: {}",
+                f
+            );
+        }
+    }
+
+    #[test]
+    fn detect_completion_patterns() {
+        let mut interpreter = OutputInterpreter::new();
+
+        let completions = [
+            "Task completed successfully.",
+            "All changes committed and pushed.",
+            "I have completed the task as requested.",
+            "The task is finished.",
+            "Implementation complete.",
+            "Created pull request #42.",
+            "PR has been created and is ready for review.",
+        ];
+
+        for c in completions {
+            let signal = interpreter.interpret(c);
+            assert!(
+                matches!(signal, OutputSignal::Completion { .. }),
+                "Should detect completion: {}",
+                c
+            );
+        }
+    }
+
+    #[test]
+    fn normal_messages_not_detected() {
+        let mut interpreter = OutputInterpreter::new();
+
+        let normal = [
+            "Reading the file...",
+            "I'm analyzing the code structure.",
+            "The function appears to handle user input.",
+            "Let me check the documentation.",
+            "Running the tests now.",
+            "Building the project...",
+        ];
+
+        for n in normal {
+            let signal = interpreter.interpret(n);
+            assert!(
+                matches!(signal, OutputSignal::Message),
+                "Should not detect signal: {}",
+                n
+            );
+        }
+    }
+
+    #[test]
+    fn error_loop_detection() {
+        let mut interpreter = OutputInterpreter::new();
+
+        // Simulate a series of errors
+        interpreter.interpret("Running test...");
+        interpreter.interpret("Error: assertion failed");
+        interpreter.interpret("Retrying...");
+        interpreter.interpret("Error: assertion failed");
+        interpreter.interpret("Trying different approach...");
+        interpreter.interpret("Error: still failing");
+        interpreter.interpret("Error: cannot resolve");
+
+        // The next error line should trigger failure detection
+        let signal = interpreter.interpret("Error: giving up");
+        assert!(matches!(signal, OutputSignal::Failure { .. }));
+    }
+
+    #[test]
+    fn clear_resets_context() {
+        let mut interpreter = OutputInterpreter::new();
+
+        // Add some lines
+        interpreter.interpret("Error: test 1");
+        interpreter.interpret("Error: test 2");
+        interpreter.interpret("Error: test 3");
+        interpreter.interpret("Error: test 4");
+        interpreter.interpret("Error: test 5");
+
+        // Clear should reset
+        interpreter.clear();
+
+        // Now an error line should not trigger error loop detection
+        let signal = interpreter.interpret("Error: single error");
+        assert!(matches!(signal, OutputSignal::Message));
+    }
+
+    #[test]
+    fn question_priority_over_completion() {
+        let mut interpreter = OutputInterpreter::new();
+
+        // A question about completion should be detected as question
+        let signal = interpreter.interpret("Should I mark this task as complete?");
+        assert!(matches!(signal, OutputSignal::Question { .. }));
+    }
+}

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -3,6 +3,8 @@
 //! Manages active container sessions — the bridge between dispatcher
 //! decisions and running agent containers. See spec §9.
 
+mod interpreter;
 mod manager;
 
+pub use interpreter::{OutputInterpreter, OutputSignal, emit_signal_events};
 pub use manager::{SessionManager, SessionManagerError, SessionHandle};

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -14,6 +14,8 @@ use tokio::task::JoinHandle;
 use events::EventBus;
 use runtime::{ContainerConfig, ContainerRuntime};
 
+use crate::interpreter::{emit_signal_events, OutputInterpreter, OutputSignal};
+
 #[derive(Debug, Error)]
 pub enum SessionManagerError {
     #[error("session error: {0}")]
@@ -261,7 +263,8 @@ impl<R: ContainerRuntime + Clone + Send + Sync + 'static> SessionManager<R> {
 ///
 /// Runs for the lifetime of a session. Reads events from the blocking
 /// transport via a dedicated thread, handles commands from the session
-/// manager, and enforces time limits.
+/// manager, and enforces time limits. Includes output interpretation (spec §9.3)
+/// to detect questions, completion signals, and failure patterns.
 async fn monitor_session<R: ContainerRuntime + Send + 'static>(
     task_id: String,
     session: runtime::Session<R>,
@@ -277,6 +280,9 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
     let started_at = Instant::now();
     let mut soft_limit_notified = false;
     let mut hard_limit_triggered = false;
+
+    // Output interpreter for state detection (spec §9.3)
+    let mut interpreter = OutputInterpreter::new();
 
     // Wrap session for shared access between blocking recv thread and async command handler
     let session = Arc::new(std::sync::Mutex::new(session));
@@ -310,8 +316,8 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
     loop {
         tokio::select! {
             Some(supervisor_event) = event_rx.recv() => {
-                // Map and publish platform events
-                handle_supervisor_event(&task_id, &supervisor_event, &event_bus).await;
+                // Map and publish platform events, including output interpretation (spec §9.3)
+                handle_supervisor_event(&task_id, &supervisor_event, &event_bus, &mut interpreter).await;
 
                 // Check for agent exit
                 if let runtime::protocol::Event::AgentExit(ref exit) = supervisor_event {
@@ -442,31 +448,66 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
 }
 
 /// Map a supervisor event to a platform event and publish it.
+///
+/// For stdout events, also runs the output interpreter (spec §9.3) to detect
+/// questions, completion signals, and failure patterns.
 async fn handle_supervisor_event(
     task_id: &str,
     event: &runtime::protocol::Event,
     event_bus: &EventBus,
+    interpreter: &mut OutputInterpreter,
 ) {
-    let (event_type, data) = match event {
-        runtime::protocol::Event::AgentStarted(e) => (
-            events::EventType::TaskStateRunning,
-            serde_json::json!({ "pid": e.pid }),
-        ),
-        runtime::protocol::Event::AgentStdout(e) => (
-            events::EventType::AgentMessage,
-            serde_json::json!({ "text": e.data }),
-        ),
-        runtime::protocol::Event::AgentStderr(e) => (
-            events::EventType::AgentMessage,
-            serde_json::json!({ "text": e.data, "stream": "stderr" }),
-        ),
-        // SystemReady and ExecResult are not mapped to platform events
-        _ => return,
-    };
+    match event {
+        runtime::protocol::Event::AgentStarted(e) => {
+            let platform_event = events::Event::new(
+                events::EventType::TaskStateRunning,
+                task_id,
+                events::Actor::Agent,
+                serde_json::json!({ "pid": e.pid }),
+            );
+            if let Err(e) = event_bus.publish(platform_event).await {
+                tracing::error!(task_id = %task_id, error = %e, "failed to publish agent started event");
+            }
+        }
+        runtime::protocol::Event::AgentStdout(e) => {
+            // Always emit the base agent:message event
+            let message_event = events::Event::new(
+                events::EventType::AgentMessage,
+                task_id,
+                events::Actor::Agent,
+                serde_json::json!({ "text": e.data }),
+            );
+            if let Err(err) = event_bus.publish(message_event).await {
+                tracing::error!(task_id = %task_id, error = %err, "failed to publish agent message event");
+            }
 
-    let platform_event = events::Event::new(event_type, task_id, events::Actor::Agent, data);
-    if let Err(e) = event_bus.publish(platform_event).await {
-        tracing::error!(task_id = %task_id, error = %e, "failed to publish supervisor event");
+            // Interpret the output for state signals (spec §9.3)
+            let signal = interpreter.interpret(&e.data);
+            if !matches!(signal, OutputSignal::Message) {
+                tracing::debug!(
+                    task_id = %task_id,
+                    signal = ?signal,
+                    "output interpreter detected signal"
+                );
+
+                if let Err(err) = emit_signal_events(task_id, &signal, event_bus).await {
+                    tracing::error!(task_id = %task_id, error = %err, "failed to emit signal events");
+                }
+            }
+        }
+        runtime::protocol::Event::AgentStderr(e) => {
+            let platform_event = events::Event::new(
+                events::EventType::AgentMessage,
+                task_id,
+                events::Actor::Agent,
+                serde_json::json!({ "text": e.data, "stream": "stderr" }),
+            );
+            if let Err(e) = event_bus.publish(platform_event).await {
+                tracing::error!(task_id = %task_id, error = %e, "failed to publish agent stderr event");
+            }
+        }
+        // SystemReady and ExecResult are not mapped to platform events
+        _ => {}
     }
 }
 
@@ -522,11 +563,12 @@ mod tests {
     #[tokio::test]
     async fn agent_started_maps_to_running() {
         let (bus, mut rx) = test_event_bus().await;
+        let mut interpreter = OutputInterpreter::new();
         let event = runtime::protocol::Event::AgentStarted(
             runtime::protocol::AgentStartedEvent { pid: 42 },
         );
 
-        handle_supervisor_event("task-1", &event, &bus).await;
+        handle_supervisor_event("task-1", &event, &bus, &mut interpreter).await;
 
         let received = rx.recv().await.unwrap();
         assert_eq!(received.event_type, events::EventType::TaskStateRunning);
@@ -537,13 +579,14 @@ mod tests {
     #[tokio::test]
     async fn agent_stdout_maps_to_message() {
         let (bus, mut rx) = test_event_bus().await;
+        let mut interpreter = OutputInterpreter::new();
         let event = runtime::protocol::Event::AgentStdout(
             runtime::protocol::AgentStdoutEvent {
                 data: "hello world".to_string(),
             },
         );
 
-        handle_supervisor_event("task-1", &event, &bus).await;
+        handle_supervisor_event("task-1", &event, &bus, &mut interpreter).await;
 
         let received = rx.recv().await.unwrap();
         assert_eq!(received.event_type, events::EventType::AgentMessage);
@@ -553,13 +596,14 @@ mod tests {
     #[tokio::test]
     async fn agent_stderr_maps_to_message() {
         let (bus, mut rx) = test_event_bus().await;
+        let mut interpreter = OutputInterpreter::new();
         let event = runtime::protocol::Event::AgentStderr(
             runtime::protocol::AgentStderrEvent {
                 data: "error output".to_string(),
             },
         );
 
-        handle_supervisor_event("task-1", &event, &bus).await;
+        handle_supervisor_event("task-1", &event, &bus, &mut interpreter).await;
 
         let received = rx.recv().await.unwrap();
         assert_eq!(received.event_type, events::EventType::AgentMessage);
@@ -570,11 +614,12 @@ mod tests {
     #[tokio::test]
     async fn system_ready_not_mapped() {
         let (bus, mut rx) = test_event_bus().await;
+        let mut interpreter = OutputInterpreter::new();
         let event = runtime::protocol::Event::SystemReady(
             runtime::protocol::SystemReadyEvent {},
         );
 
-        handle_supervisor_event("task-1", &event, &bus).await;
+        handle_supervisor_event("task-1", &event, &bus, &mut interpreter).await;
 
         // No event should have been published — try_recv should fail
         assert!(rx.try_recv().is_err());
@@ -640,5 +685,105 @@ mod tests {
 
         let received = rx.recv().await.unwrap();
         assert_eq!(received.actor, events::Actor::Agent);
+    }
+
+    #[tokio::test]
+    async fn stdout_question_emits_question_events() {
+        // When agent output contains a question pattern, we should emit
+        // agent:question and task:state:question events (spec §9.3).
+        let (bus, mut rx) = test_event_bus().await;
+        let mut interpreter = OutputInterpreter::new();
+        let event = runtime::protocol::Event::AgentStdout(
+            runtime::protocol::AgentStdoutEvent {
+                data: "Please provide the database connection string.".to_string(),
+            },
+        );
+
+        handle_supervisor_event("task-1", &event, &bus, &mut interpreter).await;
+
+        // First event is the base agent:message
+        let msg_event = rx.recv().await.unwrap();
+        assert_eq!(msg_event.event_type, events::EventType::AgentMessage);
+
+        // Second event is agent:question
+        let question_event = rx.recv().await.unwrap();
+        assert_eq!(question_event.event_type, events::EventType::AgentQuestion);
+        assert_eq!(question_event.data["source"], "output_interpretation");
+
+        // Third event is task:state:question
+        let state_event = rx.recv().await.unwrap();
+        assert_eq!(state_event.event_type, events::EventType::TaskStateQuestion);
+        assert_eq!(state_event.data["reason"], "agent_question");
+    }
+
+    #[tokio::test]
+    async fn stdout_failure_emits_error_event() {
+        // When agent output contains failure patterns, we should emit
+        // an agent:error event (spec §9.3).
+        let (bus, mut rx) = test_event_bus().await;
+        let mut interpreter = OutputInterpreter::new();
+        let event = runtime::protocol::Event::AgentStdout(
+            runtime::protocol::AgentStdoutEvent {
+                data: "I'm stuck and cannot proceed with this task.".to_string(),
+            },
+        );
+
+        handle_supervisor_event("task-1", &event, &bus, &mut interpreter).await;
+
+        // First event is the base agent:message
+        let msg_event = rx.recv().await.unwrap();
+        assert_eq!(msg_event.event_type, events::EventType::AgentMessage);
+
+        // Second event is agent:error
+        let error_event = rx.recv().await.unwrap();
+        assert_eq!(error_event.event_type, events::EventType::AgentError);
+        assert_eq!(error_event.data["source"], "output_interpretation");
+    }
+
+    #[tokio::test]
+    async fn stdout_completion_emits_completion_hint() {
+        // When agent output contains completion patterns, we emit an
+        // agent:message with completion_hint=true (spec §9.3).
+        let (bus, mut rx) = test_event_bus().await;
+        let mut interpreter = OutputInterpreter::new();
+        let event = runtime::protocol::Event::AgentStdout(
+            runtime::protocol::AgentStdoutEvent {
+                data: "Task completed successfully.".to_string(),
+            },
+        );
+
+        handle_supervisor_event("task-1", &event, &bus, &mut interpreter).await;
+
+        // First event is the base agent:message
+        let msg_event = rx.recv().await.unwrap();
+        assert_eq!(msg_event.event_type, events::EventType::AgentMessage);
+        assert_eq!(msg_event.data["text"], "Task completed successfully.");
+
+        // Second event is agent:message with completion_hint
+        let hint_event = rx.recv().await.unwrap();
+        assert_eq!(hint_event.event_type, events::EventType::AgentMessage);
+        assert_eq!(hint_event.data["completion_hint"], true);
+    }
+
+    #[tokio::test]
+    async fn stdout_normal_message_no_extra_events() {
+        // Normal agent output should only emit the base agent:message,
+        // no additional signal events.
+        let (bus, mut rx) = test_event_bus().await;
+        let mut interpreter = OutputInterpreter::new();
+        let event = runtime::protocol::Event::AgentStdout(
+            runtime::protocol::AgentStdoutEvent {
+                data: "Reading the configuration file...".to_string(),
+            },
+        );
+
+        handle_supervisor_event("task-1", &event, &bus, &mut interpreter).await;
+
+        // Should receive the base agent:message
+        let msg_event = rx.recv().await.unwrap();
+        assert_eq!(msg_event.event_type, events::EventType::AgentMessage);
+
+        // No additional events - try_recv should fail
+        assert!(rx.try_recv().is_err());
     }
 }


### PR DESCRIPTION
## Summary

Implements agent output interpretation for state detection per spec §9.3. The session wrapper now observes agent behavior patterns and emits appropriate events.

**Key changes:**
- Add `OutputInterpreter` module in `crates/session/src/interpreter.rs`
- Integrate interpreter with session manager's `handle_supervisor_event` function
- Detect question patterns → emit `agent:question` + `task:state:question` events
- Detect failure patterns → emit `agent:error` event
- Detect completion patterns → emit `agent:message` with `completion_hint: true`

**Detection patterns:**
- **Questions**: Explicit prompts ("please provide", "please confirm"), user-directed questions ("should I", "would you like"), questions with second-person pronouns
- **Failures**: Stuck/blocked statements ("I'm stuck", "cannot proceed"), repeated error patterns in recent output
- **Completions**: Task completed statements, PR creation confirmations, commit/push confirmations

**Design principle**: False positives are worse than false negatives. Patterns are conservative and high-confidence.

**Note on completion detection**: The interpreter doesn't automatically transition to `awaiting_merge` state—the exit handler still runs and verifies exit code. Completion detection provides an early hint to the orchestrator.

## Test plan

- [x] Unit tests for question detection patterns
- [x] Unit tests for failure detection patterns  
- [x] Unit tests for completion detection patterns
- [x] Unit tests for normal messages (no false positives)
- [x] Unit tests for error loop detection
- [x] Integration tests in manager for event emission
- [x] All existing tests pass

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)