### PR TITLE
Implement failure diagnosis and surfacing

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -481,8 +481,12 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
 
+                // Extract failure_info from event data for diagnosis (spec §13.4)
+                let failure_info = event.data.get("failure_info")
+                    .and_then(|v| serde_json::from_value(v.clone()).ok());
+
                 if let Err(e) = event_handler_server
-                    .handle_task_failure(task_id, made_progress, event_handler_max_retries)
+                    .handle_task_failure(task_id, made_progress, event_handler_max_retries, failure_info)
                     .await
                 {
                     if !matches!(e, server::ServerError::TaskNotFound(_)) {
@@ -705,7 +709,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 // Treat as a failure with no progress so backoff kicks in.
                                 // This prevents tight retry loops when containers can't start.
                                 if let Err(e2) = dispatch_server
-                                    .handle_task_failure(task_id, false, max_retries)
+                                    .handle_task_failure(task_id, false, max_retries, None)
                                     .await
                                 {
                                     warn!(task_id = %task_id, error = %e2, "failed to handle session start failure");

--- a/crates/models/src/task.rs
+++ b/crates/models/src/task.rs
@@ -3,6 +3,39 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Failure classification — spec Section 13.1.
+///
+/// The system categorizes failures to determine the appropriate response:
+/// - Transient: temporary problems likely to resolve on retry
+/// - Deterministic: problems that will recur with the same inputs
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureType {
+    /// Temporary problems: rate limits, network issues, resource exhaustion, OOM kills.
+    Transient,
+    /// Persistent problems: code errors, invalid config, missing dependencies.
+    Deterministic,
+}
+
+/// Detailed failure information — spec Section 13.4.
+///
+/// Captured when a session fails to provide context for debugging and retries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailureInfo {
+    /// Exit code from the agent process, if available.
+    pub exit_code: Option<i32>,
+    /// Signal that terminated the process, if applicable (e.g., "9" or "SIGKILL").
+    pub signal: Option<String>,
+    /// How long the session ran before failing (seconds).
+    pub duration_secs: u64,
+    /// Last lines of stderr output (rolling buffer, max 50 lines).
+    pub stderr_tail: Vec<String>,
+    /// Classification of the failure.
+    pub failure_type: FailureType,
+    /// Human-readable summary of the failure.
+    pub summary: String,
+}
+
 /// Origin reference for a task (spec Section 5.1 `source` field).
 ///
 /// A task may originate from a GitHub issue, a GitHub PR, or be created
@@ -89,6 +122,8 @@ pub struct Task {
     pub retry_count: u32,
     /// When the most recent failure occurred (spec §13.2).
     pub last_failure_at: Option<DateTime<Utc>>,
+    /// Detailed information about the last failure (spec §13.4).
+    pub last_failure: Option<FailureInfo>,
     /// When the source (GitHub issue/PR) was created. Used for dispatch ordering.
     pub source_created_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
@@ -119,6 +154,7 @@ impl Task {
             workspace_id: None,
             retry_count: 0,
             last_failure_at: None,
+            last_failure: None,
             source_created_at: None,
             created_at: now,
             updated_at: now,
@@ -129,5 +165,138 @@ impl Task {
     pub fn set_state(&mut self, state: TaskState) {
         self.state = state;
         self.updated_at = Utc::now();
+    }
+}
+
+impl FailureInfo {
+    /// Classify a session failure based on exit code, signal, and duration.
+    ///
+    /// Per spec §13.1:
+    /// - Transient: rate limits, network issues, resource exhaustion, OOM kills (signal 9)
+    /// - Deterministic: code errors, invalid config, missing dependencies
+    /// - "Making progress" = agent ran >= progress_threshold_secs
+    pub fn classify(
+        exit_code: Option<i32>,
+        signal: Option<String>,
+        duration_secs: u64,
+        progress_threshold_secs: u64,
+        stderr_tail: Vec<String>,
+    ) -> Self {
+        let made_progress = duration_secs >= progress_threshold_secs;
+
+        // Parse signal string to number if possible
+        let signal_num = signal.as_ref().and_then(|s| {
+            s.parse::<i32>().ok().or_else(|| {
+                // Try to parse common signal names
+                match s.to_uppercase().as_str() {
+                    "SIGKILL" | "KILL" => Some(9),
+                    "SIGTERM" | "TERM" => Some(15),
+                    "SIGINT" | "INT" => Some(2),
+                    "SIGSEGV" | "SEGV" => Some(11),
+                    "SIGABRT" | "ABRT" => Some(6),
+                    _ => None,
+                }
+            })
+        });
+
+        // Determine failure type based on exit code, signal, and progress
+        let (failure_type, summary) = match (exit_code, signal_num) {
+            // OOM kill (signal 9) is transient
+            (_, Some(9)) => (
+                FailureType::Transient,
+                "Process killed by OOM killer (signal 9)".to_string(),
+            ),
+            // SIGTERM (15) from timeout is transient
+            (_, Some(15)) => (
+                FailureType::Transient,
+                "Process terminated by signal 15 (SIGTERM)".to_string(),
+            ),
+            // If progress was made, treat as transient (may have hit edge case)
+            _ if made_progress => (
+                FailureType::Transient,
+                format!("Session ran for {duration_secs}s before failing"),
+            ),
+            // Exit code 1 without progress is likely a code error
+            (Some(1), _) => (
+                FailureType::Deterministic,
+                "Process exited with code 1 (error)".to_string(),
+            ),
+            // Exit code 2 is often invalid arguments/config
+            (Some(2), _) => (
+                FailureType::Deterministic,
+                "Process exited with code 2 (invalid arguments)".to_string(),
+            ),
+            // Exit code 127 is command not found
+            (Some(127), _) => (
+                FailureType::Deterministic,
+                "Process exited with code 127 (command not found)".to_string(),
+            ),
+            // Exit code 126 is permission denied
+            (Some(126), _) => (
+                FailureType::Deterministic,
+                "Process exited with code 126 (permission denied)".to_string(),
+            ),
+            // Other non-zero exits without progress are deterministic
+            (Some(code), _) if code != 0 => (
+                FailureType::Deterministic,
+                format!("Process exited with code {code}"),
+            ),
+            // Unknown failure
+            _ => (
+                FailureType::Transient,
+                "Unknown failure (no exit code or signal)".to_string(),
+            ),
+        };
+
+        Self {
+            exit_code,
+            signal,
+            duration_secs,
+            stderr_tail,
+            failure_type,
+            summary,
+        }
+    }
+
+    /// Check for transient patterns in stderr (rate limits, network errors).
+    ///
+    /// Call this after initial classification to potentially upgrade
+    /// a deterministic failure to transient if stderr indicates a
+    /// recoverable issue.
+    pub fn check_stderr_for_transient_patterns(&mut self) {
+        let stderr_text = self.stderr_tail.join("\n").to_lowercase();
+
+        // Patterns that indicate transient failures
+        let transient_patterns = [
+            "rate limit",
+            "rate_limit",
+            "too many requests",
+            "429",
+            "timeout",
+            "timed out",
+            "connection refused",
+            "connection reset",
+            "network unreachable",
+            "dns",
+            "econnrefused",
+            "econnreset",
+            "etimedout",
+            "resource temporarily unavailable",
+            "out of memory",
+            "oom",
+            "no space left on device",
+            "disk quota exceeded",
+        ];
+
+        for pattern in transient_patterns {
+            if stderr_text.contains(pattern) {
+                self.failure_type = FailureType::Transient;
+                self.summary = format!(
+                    "{} (detected transient pattern: {})",
+                    self.summary, pattern
+                );
+                return;
+            }
+        }
     }
 }

--- a/crates/server/src/prompt.rs
+++ b/crates/server/src/prompt.rs
@@ -72,6 +72,24 @@ pub struct RetryContext {
     pub attempt: u32,
     pub previous_failure: String,
     pub has_prior_commits: bool,
+    /// Detailed failure information from the previous session (spec §13.4).
+    pub failure_details: Option<RetryFailureDetails>,
+}
+
+/// Detailed failure context for the retry prompt (spec §15.2).
+pub struct RetryFailureDetails {
+    /// Exit code from the previous session, if available.
+    pub exit_code: Option<i32>,
+    /// Signal that terminated the previous session, if any.
+    pub signal: Option<String>,
+    /// How long the previous session ran (seconds).
+    pub duration_secs: u64,
+    /// Failure type classification.
+    pub failure_type: String,
+    /// Human-readable failure summary.
+    pub summary: String,
+    /// Last lines of stderr from the previous session.
+    pub stderr_tail: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -206,12 +224,29 @@ pub fn build_prompt_for_task(
     };
 
     let retry = if task.retry_count > 0 {
+        // Build detailed failure context from last_failure if available (spec §13.4, §15.2)
+        let failure_details = task.last_failure.as_ref().map(|f| RetryFailureDetails {
+            exit_code: f.exit_code,
+            signal: f.signal.clone(),
+            duration_secs: f.duration_secs,
+            failure_type: format!("{:?}", f.failure_type).to_lowercase(),
+            summary: f.summary.clone(),
+            stderr_tail: f.stderr_tail.clone(),
+        });
+
+        let previous_failure = task
+            .last_failure
+            .as_ref()
+            .map(|f| f.summary.clone())
+            .unwrap_or_else(|| "Previous session failed".to_string());
+
         Some(RetryContext {
             attempt: task.retry_count + 1,
-            previous_failure: "Previous session failed".to_string(),
+            previous_failure,
             // Conservative: only claim prior commits exist after the first retry,
             // since the first attempt may have crashed before committing.
             has_prior_commits: task.retry_count > 1,
+            failure_details,
         })
     } else {
         None
@@ -258,9 +293,37 @@ fn render_retry(out: &mut String, retry: &RetryContext) {
     }
     writeln!(
         out,
-        "Try a different approach if the previous one failed.\n"
+        "Try a different approach if the previous one failed."
     )
     .unwrap();
+
+    // Include detailed failure context if available (spec §13.4, §15.2)
+    if let Some(details) = &retry.failure_details {
+        writeln!(out).unwrap();
+        writeln!(out, "## Previous Session Details\n").unwrap();
+        writeln!(out, "- **Failure type**: {}", details.failure_type).unwrap();
+        writeln!(out, "- **Duration**: {}s", details.duration_secs).unwrap();
+        if let Some(code) = details.exit_code {
+            writeln!(out, "- **Exit code**: {}", code).unwrap();
+        }
+        if let Some(ref signal) = details.signal {
+            writeln!(out, "- **Signal**: {}", signal).unwrap();
+        }
+
+        // Include last few lines of stderr if available
+        if !details.stderr_tail.is_empty() {
+            writeln!(out).unwrap();
+            writeln!(out, "### Last stderr output\n").unwrap();
+            writeln!(out, "```").unwrap();
+            // Show at most the last 10 lines to keep the prompt concise
+            let lines_to_show = details.stderr_tail.len().min(10);
+            for line in details.stderr_tail.iter().rev().take(lines_to_show).rev() {
+                writeln!(out, "{}", line).unwrap();
+            }
+            writeln!(out, "```").unwrap();
+        }
+    }
+    writeln!(out).unwrap();
 }
 
 fn render_task(out: &mut String, params: &PromptParams) {
@@ -595,6 +658,7 @@ mod tests {
             attempt: 3,
             previous_failure: "Timeout after 600s".to_string(),
             has_prior_commits: true,
+            failure_details: None,
         };
         let params = PromptParams {
             retry: Some(&retry),
@@ -612,6 +676,39 @@ mod tests {
         let retry_pos = prompt.find("# Retry Information").unwrap();
         let task_pos = prompt.find("# Task").unwrap();
         assert!(retry_pos < task_pos);
+    }
+
+    #[test]
+    fn retry_context_with_failure_details() {
+        let retry = RetryContext {
+            attempt: 2,
+            previous_failure: "Process exited with code 1 (error)".to_string(),
+            has_prior_commits: false,
+            failure_details: Some(RetryFailureDetails {
+                exit_code: Some(1),
+                signal: None,
+                duration_secs: 45,
+                failure_type: "deterministic".to_string(),
+                summary: "Process exited with code 1 (error)".to_string(),
+                stderr_tail: vec![
+                    "Error: Failed to compile".to_string(),
+                    "  at src/main.rs:42".to_string(),
+                ],
+            }),
+        };
+        let params = PromptParams {
+            retry: Some(&retry),
+            ..minimal_params()
+        };
+        let prompt = build_prompt(&params);
+
+        assert!(prompt.contains("## Previous Session Details"));
+        assert!(prompt.contains("**Failure type**: deterministic"));
+        assert!(prompt.contains("**Duration**: 45s"));
+        assert!(prompt.contains("**Exit code**: 1"));
+        assert!(prompt.contains("### Last stderr output"));
+        assert!(prompt.contains("Error: Failed to compile"));
+        assert!(prompt.contains("at src/main.rs:42"));
     }
 
     #[test]

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -15,7 +15,7 @@ use events::{Actor, Event, EventBus, EventType};
 use crate::merge_queue::MergeQueue;
 use crate::mode::{Mode, ModeTransitionError};
 use crate::model::project::Project;
-use crate::model::task::{Task, TaskSource, TaskState};
+use crate::model::task::{FailureInfo, Task, TaskSource, TaskState};
 use crate::dispatcher::{self, DispatchPlan};
 use crate::presence::PresenceTracker;
 
@@ -844,11 +844,16 @@ impl Server {
     ///
     /// Returns `true` if the task will be retried (transitioned to Waiting),
     /// `false` if it transitioned to Failed.
+    ///
+    /// The optional `failure_info` parameter contains detailed diagnosis from
+    /// the session (spec §13.4). When provided, it is stored with the task for
+    /// surfacing in the UI and retry prompt context.
     pub async fn handle_task_failure(
         &self,
         task_id: &str,
         made_progress: bool,
         max_retries: u32,
+        failure_info: Option<FailureInfo>,
     ) -> Result<bool, ServerError> {
         let now = chrono::Utc::now();
 
@@ -858,6 +863,9 @@ impl Server {
                 .tasks
                 .get_mut(task_id)
                 .ok_or_else(|| ServerError::TaskNotFound(task_id.to_string()))?;
+
+            // Store failure info for UI and retry context (spec §13.4)
+            task.last_failure = failure_info.clone();
 
             if made_progress {
                 // Progress was made — this is a transient failure.
@@ -887,6 +895,7 @@ impl Server {
                         "reason": "session_failure",
                         "made_progress": true,
                         "retry_count_reset": true,
+                        "failure_info": failure_info,
                     }),
                 )
             } else {
@@ -919,6 +928,7 @@ impl Server {
                             "reason": "session_failure",
                             "made_progress": false,
                             "retry_count": task.retry_count,
+                            "failure_info": failure_info,
                         }),
                     )
                 } else {
@@ -946,6 +956,7 @@ impl Server {
                             "made_progress": false,
                             "retries_exhausted": true,
                             "retry_count": task.retry_count,
+                            "failure_info": failure_info,
                         }),
                     )
                 }
@@ -1436,7 +1447,7 @@ mod tests {
 
         // Handle failure with progress made
         let will_retry = server
-            .handle_task_failure("task-1", true, 3)
+            .handle_task_failure("task-1", true, 3, None)
             .await
             .unwrap();
 
@@ -1464,7 +1475,7 @@ mod tests {
 
         // Handle failure without progress
         let will_retry = server
-            .handle_task_failure("task-1", false, 3)
+            .handle_task_failure("task-1", false, 3, None)
             .await
             .unwrap();
 
@@ -1493,7 +1504,7 @@ mod tests {
 
         // Handle failure without progress
         let will_retry = server
-            .handle_task_failure("task-1", false, 3)
+            .handle_task_failure("task-1", false, 3, None)
             .await
             .unwrap();
 
@@ -1523,7 +1534,7 @@ mod tests {
         while rx.try_recv().is_ok() {}
 
         // Failure with progress → should emit TaskStateWaiting
-        server.handle_task_failure("task-1", true, 3).await.unwrap();
+        server.handle_task_failure("task-1", true, 3, None).await.unwrap();
 
         let event = rx.recv().await.unwrap();
         assert_eq!(event.event_type, EventType::TaskStateWaiting);
@@ -1548,7 +1559,7 @@ mod tests {
         while rx.try_recv().is_ok() {}
 
         // Failure without progress at max retries → should emit TaskStateFailed
-        server.handle_task_failure("task-1", false, 3).await.unwrap();
+        server.handle_task_failure("task-1", false, 3, None).await.unwrap();
 
         let event = rx.recv().await.unwrap();
         assert_eq!(event.event_type, EventType::TaskStateFailed);
@@ -1560,7 +1571,7 @@ mod tests {
         let server = test_server().await;
 
         // Try to handle failure for a task that doesn't exist
-        let result = server.handle_task_failure("nonexistent", true, 3).await;
+        let result = server.handle_task_failure("nonexistent", true, 3, None).await;
 
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), ServerError::TaskNotFound(_)));

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 
 [dependencies]
 events = { path = "../events" }
+models = { path = "../models" }
 runtime = { path = "../runtime" }
 server = { path = "../server" }
 serde.workspace = true

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -3,7 +3,7 @@
 //! Manages active container sessions. Spawns containers, monitors agent
 //! output, maps supervisor events to platform events, and enforces time limits.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -12,7 +12,11 @@ use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 
 use events::EventBus;
+use models::task::FailureInfo;
 use runtime::{ContainerConfig, ContainerRuntime};
+
+/// Maximum number of stderr lines to keep in the rolling buffer.
+const MAX_STDERR_LINES: usize = 50;
 
 use crate::interpreter::{emit_signal_events, OutputInterpreter, OutputSignal};
 
@@ -284,6 +288,9 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
     // Output interpreter for state detection (spec §9.3)
     let mut interpreter = OutputInterpreter::new();
 
+    // Rolling stderr buffer for failure diagnosis (spec §13.4)
+    let mut stderr_buffer: VecDeque<String> = VecDeque::with_capacity(MAX_STDERR_LINES);
+
     // Wrap session for shared access between blocking recv thread and async command handler
     let session = Arc::new(std::sync::Mutex::new(session));
     let session_recv = session.clone();
@@ -316,13 +323,25 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
     loop {
         tokio::select! {
             Some(supervisor_event) = event_rx.recv() => {
+                // Capture stderr into rolling buffer for failure diagnosis (spec §13.4)
+                if let runtime::protocol::Event::AgentStderr(ref stderr) = supervisor_event {
+                    for line in stderr.data.lines() {
+                        if stderr_buffer.len() >= MAX_STDERR_LINES {
+                            stderr_buffer.pop_front();
+                        }
+                        stderr_buffer.push_back(line.to_string());
+                    }
+                }
+
                 // Map and publish platform events, including output interpretation (spec §9.3)
                 handle_supervisor_event(&task_id, &supervisor_event, &event_bus, &mut interpreter).await;
 
                 // Check for agent exit
                 if let runtime::protocol::Event::AgentExit(ref exit) = supervisor_event {
-                    let ran_long_enough = started_at.elapsed() >= progress_threshold;
-                    handle_exit(&task_id, exit, ran_long_enough, &event_bus).await;
+                    let duration_secs = started_at.elapsed().as_secs();
+                    let progress_threshold_secs = progress_threshold.as_secs();
+                    let stderr_tail: Vec<String> = stderr_buffer.iter().cloned().collect();
+                    handle_exit(&task_id, exit, duration_secs, progress_threshold_secs, stderr_tail, &event_bus).await;
                     break;
                 }
             }
@@ -511,14 +530,17 @@ async fn handle_supervisor_event(
     }
 }
 
-/// Handle an agent exit event — publish success or failure.
+/// Handle an agent exit event — publish success or failure with diagnosis (spec §13.4).
 async fn handle_exit(
     task_id: &str,
     exit: &runtime::protocol::AgentExitEvent,
-    made_progress: bool,
+    duration_secs: u64,
+    progress_threshold_secs: u64,
+    stderr_tail: Vec<String>,
     event_bus: &EventBus,
 ) {
     let success = exit.code == Some(0);
+    let made_progress = duration_secs >= progress_threshold_secs;
 
     let (event_type, data) = if success {
         (
@@ -526,12 +548,26 @@ async fn handle_exit(
             serde_json::json!({ "exit_code": 0 }),
         )
     } else {
+        // Classify the failure and include diagnosis info (spec §13.1, §13.4)
+        let mut failure_info = FailureInfo::classify(
+            exit.code,
+            exit.signal.clone(),
+            duration_secs,
+            progress_threshold_secs,
+            stderr_tail,
+        );
+
+        // Check stderr for transient patterns (rate limits, network errors)
+        failure_info.check_stderr_for_transient_patterns();
+
         (
             events::EventType::TaskStateFailed,
             serde_json::json!({
                 "exit_code": exit.code,
                 "signal": exit.signal,
                 "made_progress": made_progress,
+                "duration_secs": duration_secs,
+                "failure_info": failure_info,
             }),
         )
     };
@@ -633,7 +669,7 @@ mod tests {
             signal: None,
         };
 
-        handle_exit("task-1", &exit, false, &bus).await;
+        handle_exit("task-1", &exit, 120, 60, vec![], &bus).await;
 
         let received = rx.recv().await.unwrap();
         assert_eq!(received.event_type, events::EventType::TaskStateAwaitingMerge);
@@ -648,7 +684,8 @@ mod tests {
             signal: None,
         };
 
-        handle_exit("task-1", &exit, false, &bus).await;
+        // Short duration (30s) below progress threshold (60s) -> no progress
+        handle_exit("task-1", &exit, 30, 60, vec![], &bus).await;
 
         let received = rx.recv().await.unwrap();
         assert_eq!(received.event_type, events::EventType::TaskStateFailed);
@@ -663,7 +700,8 @@ mod tests {
             signal: None,
         };
 
-        handle_exit("task-1", &exit, true, &bus).await;
+        // Duration (120s) >= progress threshold (60s) -> made progress
+        handle_exit("task-1", &exit, 120, 60, vec![], &bus).await;
 
         let received = rx.recv().await.unwrap();
         assert_eq!(received.event_type, events::EventType::TaskStateFailed);
@@ -681,10 +719,65 @@ mod tests {
             signal: None,
         };
 
-        handle_exit("task-1", &exit, false, &bus).await;
+        handle_exit("task-1", &exit, 30, 60, vec![], &bus).await;
 
         let received = rx.recv().await.unwrap();
         assert_eq!(received.actor, events::Actor::Agent);
+    }
+
+    #[tokio::test]
+    async fn exit_includes_failure_info() {
+        let (bus, mut rx) = test_event_bus().await;
+        let exit = runtime::protocol::AgentExitEvent {
+            code: Some(1),
+            signal: None,
+        };
+        let stderr = vec!["error: something went wrong".to_string()];
+
+        handle_exit("task-1", &exit, 30, 60, stderr, &bus).await;
+
+        let received = rx.recv().await.unwrap();
+        assert_eq!(received.event_type, events::EventType::TaskStateFailed);
+
+        // Check failure_info is present
+        let failure_info = &received.data["failure_info"];
+        assert_eq!(failure_info["exit_code"], 1);
+        assert_eq!(failure_info["duration_secs"], 30);
+        assert_eq!(failure_info["failure_type"], "deterministic");
+        assert_eq!(failure_info["stderr_tail"][0], "error: something went wrong");
+    }
+
+    #[tokio::test]
+    async fn exit_detects_transient_rate_limit() {
+        let (bus, mut rx) = test_event_bus().await;
+        let exit = runtime::protocol::AgentExitEvent {
+            code: Some(1),
+            signal: None,
+        };
+        let stderr = vec!["API error: rate limit exceeded (429)".to_string()];
+
+        handle_exit("task-1", &exit, 30, 60, stderr, &bus).await;
+
+        let received = rx.recv().await.unwrap();
+        let failure_info = &received.data["failure_info"];
+        // Should be upgraded to transient due to rate limit pattern in stderr
+        assert_eq!(failure_info["failure_type"], "transient");
+    }
+
+    #[tokio::test]
+    async fn exit_oom_is_transient() {
+        let (bus, mut rx) = test_event_bus().await;
+        let exit = runtime::protocol::AgentExitEvent {
+            code: None,
+            signal: Some("9".to_string()),
+        };
+
+        handle_exit("task-1", &exit, 30, 60, vec![], &bus).await;
+
+        let received = rx.recv().await.unwrap();
+        let failure_info = &received.data["failure_info"];
+        assert_eq!(failure_info["failure_type"], "transient");
+        assert!(failure_info["summary"].as_str().unwrap().contains("OOM"));
     }
 
     #[tokio::test]

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -12,3 +12,4 @@ serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
 thiserror.workspace = true
+tracing.workspace = true

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
 use models::merge_queue::{MergeQueueEntry, MergeStatus};
 use models::project::Project;
-use models::task::{Task, TaskSource, TaskState};
+use models::task::{FailureInfo, Task, TaskSource, TaskState};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -223,6 +223,11 @@ impl Store {
         let blocked_by_json = serde_json::to_string(&task.blocked_by)?;
         let labels_json = serde_json::to_string(&task.labels)?;
         let last_failure_at = task.last_failure_at.map(|dt| dt.to_rfc3339());
+        let last_failure_json = task
+            .last_failure
+            .as_ref()
+            .map(|f| serde_json::to_string(f))
+            .transpose()?;
         let source_created_at = task.source_created_at.map(|dt| dt.to_rfc3339());
         let created_at = task.created_at.to_rfc3339();
         let updated_at = task.updated_at.to_rfc3339();
@@ -232,12 +237,12 @@ impl Store {
                 id, source_json, title, description, state,
                 parent_id, blocked_by_json, project, labels_json, priority,
                 session_id, workspace_id, retry_count, last_failure_at,
-                source_created_at, created_at, updated_at
+                last_failure_json, source_created_at, created_at, updated_at
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5,
                 ?6, ?7, ?8, ?9, ?10,
                 ?11, ?12, ?13, ?14,
-                ?15, ?16, ?17
+                ?15, ?16, ?17, ?18
             )",
             params![
                 task.id,
@@ -254,6 +259,7 @@ impl Store {
                 task.workspace_id,
                 task.retry_count,
                 last_failure_at,
+                last_failure_json,
                 source_created_at,
                 created_at,
                 updated_at,
@@ -268,7 +274,7 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    source_created_at, created_at, updated_at
+                    last_failure_json, source_created_at, created_at, updated_at
              FROM tasks WHERE id = ?1",
         )?;
         let mut rows = stmt.query_map(params![id], row_to_task)?;
@@ -287,7 +293,7 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    source_created_at, created_at, updated_at
+                    last_failure_json, source_created_at, created_at, updated_at
              FROM tasks",
         )?;
         let rows = stmt.query_map([], row_to_task)?;
@@ -304,7 +310,7 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    source_created_at, created_at, updated_at
+                    last_failure_json, source_created_at, created_at, updated_at
              FROM tasks WHERE project = ?1",
         )?;
         let rows = stmt.query_map(params![project], row_to_task)?;
@@ -322,7 +328,7 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    source_created_at, created_at, updated_at
+                    last_failure_json, source_created_at, created_at, updated_at
              FROM tasks WHERE state = ?1",
         )?;
         let rows = stmt.query_map(params![state_json], row_to_task)?;
@@ -358,9 +364,10 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
     let workspace_id: Option<String> = row.get(11)?;
     let retry_count: u32 = row.get(12)?;
     let last_failure_at_str: Option<String> = row.get(13)?;
-    let source_created_at_str: Option<String> = row.get(14)?;
-    let created_at_str: String = row.get(15)?;
-    let updated_at_str: String = row.get(16)?;
+    let last_failure_json: Option<String> = row.get(14)?;
+    let source_created_at_str: Option<String> = row.get(15)?;
+    let created_at_str: String = row.get(16)?;
+    let updated_at_str: String = row.get(17)?;
 
     let source: TaskSource = serde_json::from_str(&source_json).map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Text, Box::new(e))
@@ -388,13 +395,24 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
                 })
         })
         .transpose()?;
+    let last_failure: Option<FailureInfo> = last_failure_json
+        .map(|s| {
+            serde_json::from_str(&s).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    14,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })
+        })
+        .transpose()?;
     let source_created_at = source_created_at_str
         .map(|s| {
             DateTime::parse_from_rfc3339(&s)
                 .map(|dt| dt.with_timezone(&Utc))
                 .map_err(|e| {
                     rusqlite::Error::FromSqlConversionFailure(
-                        14,
+                        15,
                         rusqlite::types::Type::Text,
                         Box::new(e),
                     )
@@ -405,7 +423,7 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
         .map(|dt| dt.with_timezone(&Utc))
         .map_err(|e| {
             rusqlite::Error::FromSqlConversionFailure(
-                14,
+                16,
                 rusqlite::types::Type::Text,
                 Box::new(e),
             )
@@ -414,7 +432,7 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
         .map(|dt| dt.with_timezone(&Utc))
         .map_err(|e| {
             rusqlite::Error::FromSqlConversionFailure(
-                15,
+                17,
                 rusqlite::types::Type::Text,
                 Box::new(e),
             )
@@ -435,6 +453,7 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
         workspace_id,
         retry_count,
         last_failure_at,
+        last_failure,
         source_created_at,
         created_at,
         updated_at,

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -28,6 +28,7 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
             workspace_id TEXT,
             retry_count INTEGER NOT NULL DEFAULT 0,
             last_failure_at TEXT,
+            last_failure_json TEXT,
             source_created_at TEXT,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
@@ -41,5 +42,28 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
             queued_at TEXT NOT NULL
         );
         ",
-    )
+    )?;
+
+    // Migration: add last_failure_json column if it doesn't exist (spec §13.4)
+    // This handles existing databases that were created before this column was added.
+    match conn.execute(
+        "ALTER TABLE tasks ADD COLUMN last_failure_json TEXT",
+        [],
+    ) {
+        Ok(_) => {
+            tracing::info!("added last_failure_json column to tasks table");
+        }
+        Err(rusqlite::Error::SqliteFailure(e, _))
+            if e.extended_code == rusqlite::ffi::SQLITE_ERROR =>
+        {
+            // Column already exists — this is expected for existing databases
+            tracing::debug!("last_failure_json column already exists");
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "failed to add last_failure_json column");
+            return Err(e);
+        }
+    }
+
+    Ok(())
 }

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -53,8 +53,9 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
         Ok(_) => {
             tracing::info!("added last_failure_json column to tasks table");
         }
-        Err(rusqlite::Error::SqliteFailure(e, _))
-            if e.extended_code == rusqlite::ffi::SQLITE_ERROR =>
+        Err(rusqlite::Error::SqliteFailure(e, Some(ref msg)))
+            if e.extended_code == rusqlite::ffi::SQLITE_ERROR
+                && msg.contains("duplicate column name") =>
         {
             // Column already exists — this is expected for existing databases
             tracing::debug!("last_failure_json column already exists");

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -17,6 +17,19 @@ export type TaskSource =
   | { type: "github_pr"; owner: string; repo: string; number: number }
   | { type: "internal"; description: string };
 
+/** Failure classification per spec §13.1 */
+export type FailureType = "transient" | "deterministic";
+
+/** Detailed failure information per spec §13.4 */
+export interface FailureInfo {
+  exit_code: number | null;
+  signal: string | null;
+  duration_secs: number;
+  stderr_tail: string[];
+  failure_type: FailureType;
+  summary: string;
+}
+
 export interface Task {
   id: string;
   source: TaskSource;
@@ -32,6 +45,7 @@ export interface Task {
   workspace_id: string | null;
   retry_count: number;
   last_failure_at: string | null;
+  last_failure: FailureInfo | null;
   created_at: string;
   updated_at: string;
 }

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -28,7 +28,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import type { Event, Task, TaskState } from "@/lib/types";
+import type { Event, FailureInfo, Task, TaskState } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // State badge
@@ -449,6 +449,86 @@ function SessionView({ taskId, chatEnabled }: { taskId: string; chatEnabled: boo
 }
 
 // ---------------------------------------------------------------------------
+// Failure info display
+// ---------------------------------------------------------------------------
+
+function FailureInfoCard({ failure }: { failure: FailureInfo }) {
+  const [stderrExpanded, setStderrExpanded] = useState(false);
+  const hasStderr = failure.stderr_tail.length > 0;
+
+  return (
+    <Card className="border-red-500/30">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-red-400">
+          Last Failure
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <dl className="grid grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-2 text-sm">
+          <div>
+            <dt className="text-muted-foreground">Type</dt>
+            <dd className="font-medium">
+              <Badge
+                variant="outline"
+                className={cn(
+                  failure.failure_type === "transient"
+                    ? "border-yellow-500/50 text-yellow-400"
+                    : "border-red-500/50 text-red-400"
+                )}
+              >
+                {failure.failure_type}
+              </Badge>
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Duration</dt>
+            <dd className="font-medium">{failure.duration_secs}s</dd>
+          </div>
+          {failure.exit_code !== null && (
+            <div>
+              <dt className="text-muted-foreground">Exit Code</dt>
+              <dd className="font-mono">{failure.exit_code}</dd>
+            </div>
+          )}
+          {failure.signal && (
+            <div>
+              <dt className="text-muted-foreground">Signal</dt>
+              <dd className="font-mono">{failure.signal}</dd>
+            </div>
+          )}
+        </dl>
+
+        <div>
+          <p className="text-sm text-muted-foreground">{failure.summary}</p>
+        </div>
+
+        {hasStderr && (
+          <div className="space-y-1">
+            <button
+              onClick={() => setStderrExpanded(!stderrExpanded)}
+              className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {stderrExpanded ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+              <Terminal className="h-3 w-3" />
+              Stderr ({failure.stderr_tail.length} lines)
+            </button>
+            {stderrExpanded && (
+              <pre className="text-xs font-mono bg-muted/50 rounded-md p-3 overflow-x-auto max-h-48 overflow-y-auto text-red-300/80">
+                {failure.stderr_tail.join("\n")}
+              </pre>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Event data preview
 // ---------------------------------------------------------------------------
 
@@ -660,6 +740,11 @@ export function TaskDetailPage() {
                 </dl>
               </CardContent>
             </Card>
+
+            {/* Failure info — shown when task has failed or has last_failure */}
+            {task.last_failure && (
+              <FailureInfoCard failure={task.last_failure} />
+            )}
 
             {/* Description */}
             {task.description && (


### PR DESCRIPTION
## Summary

Implements failure diagnosis and surfacing per spec §13.1, §13.4, and §13.5.

- Add `FailureType` enum (Transient/Deterministic) and `FailureInfo` struct to classify and capture failure context
- Add `last_failure` field to Task model with SQLite schema migration
- Implement rolling 50-line stderr buffer in session monitor for failure diagnosis
- Classify failures based on exit code, signal, and progress:
  - **Transient**: made progress, SIGKILL (OOM), or resource pressure
  - **Deterministic**: quick failures without progress
- Include `failure_info` in `TaskStateFailed` events and store in task
- Surface failure details in task detail UI with expandable stderr output

## Changes

- `crates/models/src/task.rs`: Add `FailureType`, `FailureInfo`, `classify()` helper, and `last_failure` field
- `crates/store/src/schema.rs`: Add migration for `last_failure_json` column with proper error logging
- `crates/store/src/lib.rs`: Update save/load to handle failure info JSON
- `crates/session/src/manager.rs`: Add stderr buffering, update `handle_exit` with failure classification
- `crates/server/src/server.rs`: Update `handle_task_failure` to accept and store failure info
- `crates/app/src/run_loop.rs`: Extract failure_info from events, include in session start failures
- `web/src/lib/types.ts`: Add `FailureType` and `FailureInfo` TypeScript types
- `web/src/pages/task-detail.tsx`: Add `FailureInfoCard` component to display failure details

## Test plan

- [x] Rust compilation passes (`cargo check`)
- [x] All tests pass (`cargo test --workspace`)
- [x] Frontend builds (`npm run build`)
- [ ] Manual test: verify failure info is captured and displayed when a task fails
- [ ] Manual test: verify transient vs deterministic classification works correctly

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)