### PR TITLE
Delete remote branch when throwing away work on rejection

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use std::sync::Mutex as StdMutex;
 
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use events::{Actor, Event, EventBus, EventStore, EventType};
 use runtime::{AppleContainerRuntime, ContainerConfig};
@@ -951,6 +951,49 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                             {
                                 error!(entry_id = %entry_id, error = %e, "failed to reject merge entry");
                             }
+
+                            // Delete the remote branch so the agent starts fresh (issue #143).
+                            // Without this, the agent would find the old branch and resubmit
+                            // the same work instead of starting over.
+                            let branch = format!("tasks/{}", task_id);
+                            let repo_parts: Vec<&str> = context.project.repo.split('/').collect();
+                            if repo_parts.len() == 2 {
+                                match merge_github.delete_branch(repo_parts[0], repo_parts[1], &branch).await {
+                                    Ok(true) => {
+                                        info!(
+                                            task_id = %task_id,
+                                            branch = %branch,
+                                            "deleted remote branch for re-dispatch"
+                                        );
+                                    }
+                                    Ok(false) => {
+                                        // Branch didn't exist — that's fine
+                                        debug!(
+                                            task_id = %task_id,
+                                            branch = %branch,
+                                            "branch did not exist on remote"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        // Log but don't fail — the task can still be re-dispatched.
+                                        // The agent may find old work, but that's better than
+                                        // blocking the entire rejection flow.
+                                        warn!(
+                                            task_id = %task_id,
+                                            branch = %branch,
+                                            error = %e,
+                                            "failed to delete remote branch for re-dispatch"
+                                        );
+                                    }
+                                }
+                            } else {
+                                warn!(
+                                    task_id = %task_id,
+                                    repo = %context.project.repo,
+                                    "invalid repo format, cannot delete branch"
+                                );
+                            }
+
                             // Emit orchestrator:feedback event when feedback is provided
                             if let Some(feedback) = &evaluation.feedback {
                                 if let Err(e) = orch_server.emit_orchestrator_feedback(

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -497,6 +497,69 @@ impl GitHubClient {
     }
 
     // -----------------------------------------------------------------------
+    // Branch management
+    // -----------------------------------------------------------------------
+
+    /// Delete a branch from the repository.
+    ///
+    /// Uses the GitHub REST API to delete a git ref. Returns `Ok(true)` if
+    /// deleted successfully, `Ok(false)` if the branch doesn't exist (404).
+    ///
+    /// This is used when rejecting and re-dispatching a task to ensure the
+    /// agent starts fresh without finding old work on the branch.
+    pub async fn delete_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+    ) -> Result<bool, GitHubError> {
+        self.wait_for_rate_limit().await;
+
+        // GitHub REST API: DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}
+        let url = format!(
+            "{}/repos/{}/{}/git/refs/heads/{}",
+            self.base_url, owner, repo, branch
+        );
+
+        let response = self.http.delete(&url).send().await?;
+        self.update_rate_limit(&response);
+
+        let status = response.status();
+
+        if status.is_success() || status == reqwest::StatusCode::NO_CONTENT {
+            return Ok(true);
+        }
+
+        // 404 = branch doesn't exist (not an error for our use case)
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(false);
+        }
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::FORBIDDEN {
+            // Could be rate limiting or protected branch
+            if let Some(rl) = self.rate_limit() {
+                if rl.remaining == 0 {
+                    return Err(GitHubError::RateLimited {
+                        reset_at: rl.reset_at,
+                    });
+                }
+            }
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        let text = response.text().await.unwrap_or_default();
+        Err(GitHubError::Decode(format!(
+            "unexpected delete branch status {status}: {text}"
+        )))
+    }
+
+    // -----------------------------------------------------------------------
     // PR discovery
     // -----------------------------------------------------------------------
 

--- a/crates/github/tests/client_tests.rs
+++ b/crates/github/tests/client_tests.rs
@@ -733,3 +733,86 @@ async fn get_file_content_fetches_nested_path() {
     assert!(content.is_some());
     assert!(content.as_ref().unwrap().contains("conventional commits"));
 }
+
+// ---------------------------------------------------------------------------
+// Branch deletion tests (issue #143 — cleanup on rejection)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn delete_branch_returns_true_on_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/repos/owner/repo/git/refs/heads/tasks/test-task-123"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let deleted = client
+        .delete_branch("owner", "repo", "tasks/test-task-123")
+        .await
+        .unwrap();
+
+    assert!(deleted);
+}
+
+#[tokio::test]
+async fn delete_branch_returns_false_on_404() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/repos/owner/repo/git/refs/heads/nonexistent-branch"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Reference does not exist"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let deleted = client
+        .delete_branch("owner", "repo", "nonexistent-branch")
+        .await
+        .unwrap();
+
+    // 404 is not an error — the branch simply doesn't exist
+    assert!(!deleted);
+}
+
+#[tokio::test]
+async fn delete_branch_auth_error_on_401() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/repos/owner/repo/git/refs/heads/tasks/test-task"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Bad credentials"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let result = client
+        .delete_branch("owner", "repo", "tasks/test-task")
+        .await;
+
+    assert!(matches!(result, Err(GitHubError::Auth(_))));
+}
+
+#[tokio::test]
+async fn delete_branch_auth_error_on_protected_branch() {
+    let server = MockServer::start().await;
+
+    // 403 for protected branches (not rate limiting)
+    Mock::given(method("DELETE"))
+        .and(path("/repos/owner/repo/git/refs/heads/main"))
+        .respond_with(
+            ResponseTemplate::new(403)
+                .set_body_string("Cannot delete protected branch")
+                .insert_header("x-ratelimit-remaining", "4999"),
+        )
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let result = client.delete_branch("owner", "repo", "main").await;
+
+    // 403 with remaining rate limit = auth error (protected branch)
+    assert!(matches!(result, Err(GitHubError::Auth(_))));
+}


### PR DESCRIPTION
## Summary

- Adds `delete_branch` method to `GitHubClient` using the GitHub REST API (`DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}`)
- Calls `delete_branch` in the run_loop when rejecting a merge queue entry for re-dispatch
- Ensures agents start fresh when retrying a task instead of finding and resubmitting old work

## Test plan

- [x] Build compiles successfully
- [x] All existing tests pass
- [x] New tests for `delete_branch`:
  - Returns `true` on successful deletion (204)
  - Returns `false` when branch doesn't exist (404)
  - Returns `Auth` error on 401
  - Returns `Auth` error on protected branch (403 with remaining rate limit)

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)