### PR TITLE
Display project names instead of IDs in the UI

### DIFF
--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -55,6 +55,16 @@ const ACTIVE_STATES: TaskState[] = [
 
 export function DashboardPage() {
   const { snapshot, events, filteredTasks, filteredMergeQueue, selectedProject } = useAppState();
+  const projects = snapshot?.projects ?? [];
+
+  // Create a map from project ID to repo name for display
+  const projectIdToRepo = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const p of projects) {
+      map[p.id] = p.repo;
+    }
+    return map;
+  }, [projects]);
 
   const runningCount = useMemo(
     () => filteredTasks.filter((t) => t.state === "running").length,
@@ -179,7 +189,7 @@ export function DashboardPage() {
                   {/* Only show project when viewing all projects */}
                   {!selectedProject && (
                     <span className="text-muted-foreground text-sm shrink-0">
-                      {task.project}
+                      {projectIdToRepo[task.project] ?? task.project}
                     </span>
                   )}
                   <span className="text-muted-foreground text-sm shrink-0">

--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -65,11 +65,15 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
     id: "project",
     header: "Project",
     cell: ({ row, table }) => {
-      const tasks = (table.options.meta as { tasks?: Task[] })?.tasks ?? [];
+      const meta = table.options.meta as { tasks?: Task[]; projectIdToRepo?: Record<string, string> };
+      const tasks = meta?.tasks ?? [];
+      const projectIdToRepo = meta?.projectIdToRepo ?? {};
       const task = tasks.find((t) => t.id === row.original.task_id);
+      const projectId = task?.project;
+      const projectName = projectId ? (projectIdToRepo[projectId] ?? projectId) : "—";
       return (
         <span className="text-muted-foreground">
-          {task?.project ?? "—"}
+          {projectName}
         </span>
       );
     },

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -61,6 +61,15 @@ export function MergeQueuePage() {
     ? snapshot?.projects.find((p) => p.id === selectedProject)?.repo
     : null;
 
+  // Create a map from project ID to repo name for display
+  const projectIdToRepo = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const p of snapshot?.projects ?? []) {
+      map[p.id] = p.repo;
+    }
+    return map;
+  }, [snapshot?.projects]);
+
   const table = useReactTable({
     data: entries,
     columns,
@@ -73,6 +82,7 @@ export function MergeQueuePage() {
     meta: {
       refreshSnapshot,
       tasks: snapshot?.tasks ?? [],
+      projectIdToRepo,
     },
   });
 

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   ArrowLeft,
@@ -471,6 +471,13 @@ export function TaskDetailPage() {
 
   const task = snapshot?.tasks.find((t) => t.id === id);
 
+  // Get project name from project ID
+  const projectName = useMemo(() => {
+    if (!task?.project || !snapshot?.projects) return task?.project;
+    const project = snapshot.projects.find((p) => p.id === task.project);
+    return project?.repo ?? task.project;
+  }, [task?.project, snapshot?.projects]);
+
   const isSessionActive =
     task?.state === "running" ||
     task?.state === "question" ||
@@ -556,7 +563,7 @@ export function TaskDetailPage() {
             <Separator orientation="vertical" className="h-4" />
             {sourceDisplay(task)}
             <Separator orientation="vertical" className="h-4" />
-            <span>{task.project}</span>
+            <span>{projectName}</span>
             {task.labels.length > 0 && (
               <>
                 <Separator orientation="vertical" className="h-4" />


### PR DESCRIPTION
## Summary

- Fixes #147 - Shows human-readable repository names (e.g., `owner/repo`) instead of project IDs (UUIDs) in the UI
- Updates dashboard active tasks list to display project names
- Updates merge queue project column to display project names
- Updates task detail metadata to display project names

Each affected component now creates a `projectIdToRepo` mapping from the projects list to convert project IDs to repository names.

## Test plan

- [ ] Verify dashboard shows project names in the active tasks list (when no project filter is selected)
- [ ] Verify merge queue shows project names in the Project column
- [ ] Verify task detail page shows project name in the metadata header

🤖 Generated with [Claude Code](https://claude.com/claude-code)