### PR TITLE
Fix critical path blockers for end-to-end task sessions

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 
 use tracing::{error, info, warn};
+use uuid::Uuid;
 
 use events::{Actor, Event, EventBus, EventStore, EventType};
 use runtime::{AppleContainerRuntime, ContainerConfig};
@@ -332,12 +333,13 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 .await
                                 .unwrap_or_default();
 
-                            // Create merge queue entry
+                            // Create merge queue entry with branch for cleanup (issue #143)
                             let entry_id = format!("mq-{}-{}-pr-{}", pr.owner, pr.repo, pr.number);
-                            let entry = MergeQueueEntry::new(
+                            let entry = MergeQueueEntry::new_with_branch(
                                 entry_id.clone(),
                                 task_id.clone(),
                                 &pr_url,
+                                &pr.head_ref,
                             );
 
                             if let Err(e) = poll_server.add_to_merge_queue(entry).await {
@@ -598,7 +600,9 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 .as_ref()
                                 .map(|p| format!("https://github.com/{}.git", p.repo))
                                 .unwrap_or_default();
-                            let branch = format!("tasks/{}", task.id);
+                            // Use unique branch names to prevent collisions on retry (issue #144)
+                            let session_suffix = &Uuid::new_v4().to_string()[..8];
+                            let branch = format!("tasks/{}/{}", task.id, session_suffix);
 
                             // Load workflow settings (spec §14, §15)
                             let workflow_settings = load_workflow_settings_for_project(
@@ -939,6 +943,17 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                             {
                                 error!(entry_id = %entry_id, error = %e, "failed to reject merge entry for closed issue");
                             }
+
+                            // Clean up the remote branch (issue #143)
+                            if let Some(branch) = &context.entry.branch {
+                                if let Some((owner, repo, _)) = tasks_orchestrator::parse_pr_url(&pr_url) {
+                                    match merge_github.delete_branch(&owner, &repo, branch).await {
+                                        Ok(true) => info!(branch = %branch, "deleted remote branch after rejection"),
+                                        Ok(false) => info!(branch = %branch, "remote branch already deleted or never existed"),
+                                        Err(e) => warn!(branch = %branch, error = %e, "failed to delete remote branch"),
+                                    }
+                                }
+                            }
                         } else {
                             // Issue is still open — normal rejection with re-dispatch.
                             if let Err(e) = orch_server
@@ -951,6 +966,19 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                             {
                                 error!(entry_id = %entry_id, error = %e, "failed to reject merge entry");
                             }
+
+                            // Clean up the remote branch (issue #143)
+                            // This prevents agents from re-discovering the old branch on retry.
+                            if let Some(branch) = &context.entry.branch {
+                                if let Some((owner, repo, _)) = tasks_orchestrator::parse_pr_url(&pr_url) {
+                                    match merge_github.delete_branch(&owner, &repo, branch).await {
+                                        Ok(true) => info!(branch = %branch, "deleted remote branch after rejection"),
+                                        Ok(false) => info!(branch = %branch, "remote branch already deleted or never existed"),
+                                        Err(e) => warn!(branch = %branch, error = %e, "failed to delete remote branch"),
+                                    }
+                                }
+                            }
+
                             // Emit orchestrator:feedback event when feedback is provided
                             if let Some(feedback) = &evaluation.feedback {
                                 if let Err(e) = orch_server.emit_orchestrator_feedback(

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -497,6 +497,60 @@ impl GitHubClient {
     }
 
     // -----------------------------------------------------------------------
+    // Branch cleanup (issue #143)
+    // -----------------------------------------------------------------------
+
+    /// Delete a remote branch via the GitHub REST API.
+    ///
+    /// This is used for cleanup when tasks are rejected or discarded. Unlike
+    /// most GitHub mutations (which happen via agents using `gh` CLI), branch
+    /// cleanup is a platform-level operation that occurs after the agent session
+    /// ends. Returns `Ok(true)` if the branch was deleted, `Ok(false)` if it
+    /// didn't exist (already deleted or never pushed).
+    pub async fn delete_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+    ) -> Result<bool, GitHubError> {
+        self.wait_for_rate_limit().await;
+
+        // GitHub REST API: DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}
+        let url = format!(
+            "{}/repos/{}/{}/git/refs/heads/{}",
+            self.base_url, owner, repo, branch
+        );
+
+        let response = self.http.delete(&url).send().await?;
+        self.update_rate_limit(&response);
+
+        let status = response.status();
+
+        // 204 No Content = successfully deleted
+        if status == reqwest::StatusCode::NO_CONTENT {
+            return Ok(true);
+        }
+
+        // 422 Unprocessable Entity = branch doesn't exist (already deleted or never created)
+        // 404 Not Found = branch doesn't exist
+        if status == reqwest::StatusCode::UNPROCESSABLE_ENTITY
+            || status == reqwest::StatusCode::NOT_FOUND
+        {
+            return Ok(false);
+        }
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        let text = response.text().await.unwrap_or_default();
+        Err(GitHubError::Decode(format!(
+            "unexpected delete_branch status {status}: {text}"
+        )))
+    }
+
+    // -----------------------------------------------------------------------
     // PR discovery
     // -----------------------------------------------------------------------
 

--- a/crates/models/src/merge_queue.rs
+++ b/crates/models/src/merge_queue.rs
@@ -27,6 +27,12 @@ pub struct MergeQueueEntry {
     pub task_id: String,
     /// GitHub PR URL.
     pub pr_url: String,
+    /// The branch name for this entry (issue #143, #144).
+    ///
+    /// Stored so we can clean up the remote branch when the entry is rejected.
+    /// Branch names include a session suffix for uniqueness on retry.
+    #[serde(default)]
+    pub branch: Option<String>,
     pub status: MergeStatus,
     pub queued_at: DateTime<Utc>,
 }
@@ -37,6 +43,24 @@ impl MergeQueueEntry {
             id: id.into(),
             task_id: task_id.into(),
             pr_url: pr_url.into(),
+            branch: None,
+            status: MergeStatus::Pending,
+            queued_at: Utc::now(),
+        }
+    }
+
+    /// Create a new entry with a branch name for cleanup (issue #143, #144).
+    pub fn new_with_branch(
+        id: impl Into<String>,
+        task_id: impl Into<String>,
+        pr_url: impl Into<String>,
+        branch: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            task_id: task_id.into(),
+            pr_url: pr_url.into(),
+            branch: Some(branch.into()),
             status: MergeStatus::Pending,
             queued_at: Utc::now(),
         }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -387,11 +387,14 @@ impl Server {
 
     /// Find a task ID by its branch name.
     ///
-    /// Tasks use branches named `tasks/{task_id}`, so we extract the task ID
-    /// from the branch name and look it up.
+    /// Tasks use branches named `tasks/{task_id}/{session_suffix}`, so we extract
+    /// the task ID from the branch name and look it up. The session suffix is an
+    /// 8-character UUID prefix for uniqueness on retry (issue #144).
     pub async fn find_task_by_branch(&self, branch: &str) -> Option<String> {
-        // Tasks use branches like "tasks/gh-owner-repo-issue-123"
-        let task_id = branch.strip_prefix("tasks/")?;
+        // Tasks use branches like "tasks/gh-owner-repo-issue-123/a1b2c3d4"
+        let after_prefix = branch.strip_prefix("tasks/")?;
+        // Extract task_id by removing the session suffix (last path component)
+        let task_id = after_prefix.rsplit_once('/').map(|(id, _)| id).unwrap_or(after_prefix);
         let state = self.state.read().await;
         if state.tasks.contains_key(task_id) {
             Some(task_id.to_string())

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -131,8 +131,8 @@ impl Store {
             .to_string();
         let queued_at = entry.queued_at.to_rfc3339();
         self.conn.execute(
-            "INSERT OR REPLACE INTO merge_queue (id, task_id, pr_url, status, queued_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![entry.id, entry.task_id, entry.pr_url, status, queued_at],
+            "INSERT OR REPLACE INTO merge_queue (id, task_id, pr_url, branch, status, queued_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![entry.id, entry.task_id, entry.pr_url, entry.branch, status, queued_at],
         )?;
         Ok(())
     }
@@ -140,20 +140,21 @@ impl Store {
     /// Get a merge queue entry by ID.
     pub fn get_merge_entry(&self, id: &str) -> Result<Option<MergeQueueEntry>, StoreError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, task_id, pr_url, status, queued_at FROM merge_queue WHERE id = ?1",
+            "SELECT id, task_id, pr_url, branch, status, queued_at FROM merge_queue WHERE id = ?1",
         )?;
         let mut rows = stmt.query_map(params![id], |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(3)?,
                 row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
             ))
         })?;
         match rows.next() {
             Some(row) => {
-                let (id, task_id, pr_url, status_str, queued_at_str) = row?;
+                let (id, task_id, pr_url, branch, status_str, queued_at_str) = row?;
                 let status: MergeStatus = serde_json::from_str(&format!("\"{status_str}\""))?;
                 let queued_at: DateTime<Utc> = queued_at_str
                     .parse()
@@ -164,6 +165,7 @@ impl Store {
                     id,
                     task_id,
                     pr_url,
+                    branch,
                     status,
                     queued_at,
                 }))
@@ -176,19 +178,20 @@ impl Store {
     pub fn list_merge_entries(&self) -> Result<Vec<MergeQueueEntry>, StoreError> {
         let mut stmt = self
             .conn
-            .prepare("SELECT id, task_id, pr_url, status, queued_at FROM merge_queue")?;
+            .prepare("SELECT id, task_id, pr_url, branch, status, queued_at FROM merge_queue")?;
         let rows = stmt.query_map([], |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(3)?,
                 row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
             ))
         })?;
         let mut entries = Vec::new();
         for row in rows {
-            let (id, task_id, pr_url, status_str, queued_at_str) = row?;
+            let (id, task_id, pr_url, branch, status_str, queued_at_str) = row?;
             let status: MergeStatus = serde_json::from_str(&format!("\"{status_str}\""))?;
             let queued_at: DateTime<Utc> = queued_at_str
                 .parse()
@@ -199,6 +202,7 @@ impl Store {
                 id,
                 task_id,
                 pr_url,
+                branch,
                 status,
                 queued_at,
             });

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -37,6 +37,7 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
             id TEXT PRIMARY KEY,
             task_id TEXT NOT NULL,
             pr_url TEXT,
+            branch TEXT,
             status TEXT NOT NULL DEFAULT 'pending',
             queued_at TEXT NOT NULL
         );

--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -56,6 +56,15 @@ const ACTIVE_STATES: TaskState[] = [
 export function DashboardPage() {
   const { snapshot, events, filteredTasks, filteredMergeQueue, selectedProject } = useAppState();
 
+  // Map project ID to display name (issue #147)
+  const projectIdToRepo = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const p of snapshot?.projects ?? []) {
+      map[p.id] = p.repo;
+    }
+    return map;
+  }, [snapshot?.projects]);
+
   const runningCount = useMemo(
     () => filteredTasks.filter((t) => t.state === "running").length,
     [filteredTasks],
@@ -179,7 +188,7 @@ export function DashboardPage() {
                   {/* Only show project when viewing all projects */}
                   {!selectedProject && (
                     <span className="text-muted-foreground text-sm shrink-0">
-                      {task.project}
+                      {projectIdToRepo[task.project] ?? task.project}
                     </span>
                   )}
                   <span className="text-muted-foreground text-sm shrink-0">

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -471,6 +471,11 @@ export function TaskDetailPage() {
 
   const task = snapshot?.tasks.find((t) => t.id === id);
 
+  // Map project ID to display name (issue #147)
+  const projectDisplayName = task
+    ? snapshot?.projects.find((p) => p.id === task.project)?.repo ?? task.project
+    : "";
+
   const isSessionActive =
     task?.state === "running" ||
     task?.state === "question" ||
@@ -556,7 +561,7 @@ export function TaskDetailPage() {
             <Separator orientation="vertical" className="h-4" />
             {sourceDisplay(task)}
             <Separator orientation="vertical" className="h-4" />
-            <span>{task.project}</span>
+            <span>{projectDisplayName}</span>
             {task.labels.length > 0 && (
               <>
                 <Separator orientation="vertical" className="h-4" />


### PR DESCRIPTION
## Summary

This PR addresses three blockers on the critical path to a working end-to-end task session, as identified in issue #150:

- **#144 - Unique branch names**: Branch names now include an 8-character UUID suffix (`tasks/{task_id}/{session_suffix}`) to prevent collisions when tasks are re-dispatched
- **#143 - Remote branch cleanup**: Added `delete_branch` method to the GitHub client; branches are now deleted when tasks are rejected
- **#147 - Project name display**: Fixed `task-detail.tsx` and `dashboard.tsx` to show `owner/repo` instead of internal project IDs

## Changes

### Rust (backend)
- `crates/app/src/run_loop.rs`: Generate unique branch names with UUID suffix; call branch deletion on rejection
- `crates/github/src/client.rs`: New `delete_branch` method using GitHub REST API
- `crates/models/src/merge_queue.rs`: Added `branch` field to `MergeQueueEntry`
- `crates/server/src/server.rs`: Updated `find_task_by_branch` to handle new branch format
- `crates/store/src/lib.rs` + `schema.rs`: Added `branch` column to merge_queue table and updated queries

### Web (frontend)
- `web/src/pages/task-detail.tsx`: Map project ID to repo name for display
- `web/src/pages/dashboard.tsx`: Map project ID to repo name for display

## Test plan

- [ ] Verify branch names include unique suffix when sessions are dispatched
- [ ] Verify branches are deleted when merge queue entries are rejected
- [ ] Verify project repo names display correctly in task detail and dashboard views
- [ ] Test with existing database (backward compatible due to nullable `branch` field)

Fixes #144, fixes #143, fixes #147
Addresses #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)