### PR TITLE
Implement GPUI desktop crate with SSE event subscription

### DIFF
--- a/crates/desktop/Cargo.toml
+++ b/crates/desktop/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "tasks-desktop"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+# GPUI from Zed
+gpui = { git = "https://github.com/zed-industries/zed", rev = "v0.175.5" }
+
+# Workspace dependencies
+serde.workspace = true
+serde_json.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+futures.workspace = true
+reqwest.workspace = true
+bytes.workspace = true
+
+# Internal crates
+events = { path = "../events" }
+models = { path = "../models" }
+
+# Async runtime (GPUI uses smol internally)
+smol = "2.0"
+async-sse = "5.1"
+async-channel = "2.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.26"
+objc = "0.2"

--- a/crates/desktop/src/lib.rs
+++ b/crates/desktop/src/lib.rs
@@ -1,0 +1,8 @@
+//! Tasks Desktop — GPUI-based desktop application.
+//!
+//! This crate provides a native desktop UI for the Tasks platform,
+//! built with GPUI (Zed's GPU-accelerated UI framework).
+
+mod sse;
+
+pub use sse::{SseClient, SseClientEvent, SseConnectionState, SseFilters};

--- a/crates/desktop/src/main.rs
+++ b/crates/desktop/src/main.rs
@@ -1,0 +1,181 @@
+//! Tasks Desktop — Main entry point.
+//!
+//! A GPUI-based native desktop application for the Tasks platform.
+
+use gpui::{
+    actions, div, px, App, AppContext as _, Application, Context, Entity, IntoElement,
+    ParentElement, Render, Styled, Window, WindowOptions,
+};
+use std::sync::Arc;
+use tasks_desktop::{SseClient, SseClientEvent, SseConnectionState, SseFilters};
+use tracing_subscriber::EnvFilter;
+
+actions!(desktop, [Quit]);
+
+/// Default server URL.
+const DEFAULT_SERVER_URL: &str = "http://localhost:4800";
+
+fn main() {
+    // Initialize logging
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    Application::new().run(|cx: &mut App| {
+        // Register quit action
+        cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
+        cx.bind_keys([gpui::KeyBinding::new("cmd-q", Quit, None)]);
+
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(gpui::WindowBounds::Windowed(gpui::Bounds {
+                    origin: gpui::Point::default(),
+                    size: gpui::Size {
+                        width: px(800.),
+                        height: px(600.),
+                    },
+                })),
+                ..Default::default()
+            },
+            |_window, cx| {
+                let view = cx.new(|cx| TasksApp::new(cx));
+                view
+            },
+        )
+        .unwrap();
+
+        cx.activate(true);
+    });
+}
+
+/// Main application view.
+struct TasksApp {
+    #[allow(dead_code)] // Kept for future disconnect functionality
+    sse_client: Entity<SseClient>,
+    connection_state: SseConnectionState,
+    event_count: usize,
+    last_event: Option<Arc<events::Event>>,
+}
+
+impl TasksApp {
+    fn new(cx: &mut Context<Self>) -> Self {
+        // Get server URL from environment or use default
+        let server_url =
+            std::env::var("TASKS_SERVER_URL").unwrap_or_else(|_| DEFAULT_SERVER_URL.to_string());
+
+        // Create SSE client
+        let filters = SseFilters::new();
+        let sse_client = cx.new(|_| SseClient::new(&server_url, filters));
+
+        // Subscribe to SSE events
+        cx.subscribe(
+            &sse_client,
+            |this: &mut Self, _entity, event: &SseClientEvent, cx| match event {
+                SseClientEvent::StateChanged(state) => {
+                    this.connection_state = *state;
+                    cx.notify();
+                }
+                SseClientEvent::EventReceived(event) => {
+                    this.event_count += 1;
+                    this.last_event = Some(event.clone());
+                    cx.notify();
+                }
+                SseClientEvent::Error(err) => {
+                    tracing::error!(error = %err, "SSE error");
+                    cx.notify();
+                }
+            },
+        )
+        .detach();
+
+        // Start connection
+        sse_client.update(cx, |client: &mut SseClient, cx| {
+            client.connect(cx);
+        });
+
+        Self {
+            sse_client,
+            connection_state: SseConnectionState::Connecting,
+            event_count: 0,
+            last_event: None,
+        }
+    }
+}
+
+impl Render for TasksApp {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let status_text = match self.connection_state {
+            SseConnectionState::Disconnected => "Disconnected",
+            SseConnectionState::Connecting => "Connecting...",
+            SseConnectionState::Connected => "Connected",
+            SseConnectionState::Reconnecting => "Reconnecting...",
+            SseConnectionState::Failed => "Connection Failed",
+        };
+
+        let status_color = match self.connection_state {
+            SseConnectionState::Connected => gpui::rgb(0x22c55e), // green
+            SseConnectionState::Connecting | SseConnectionState::Reconnecting => {
+                gpui::rgb(0xeab308) // yellow
+            }
+            SseConnectionState::Disconnected | SseConnectionState::Failed => {
+                gpui::rgb(0xef4444) // red
+            }
+        };
+
+        let last_event_text = self
+            .last_event
+            .as_ref()
+            .map(|e| format!("{}: {}", e.event_type.as_str(), e.task))
+            .unwrap_or_else(|| "No events yet".to_string());
+
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .bg(gpui::rgb(0x1a1a1a))
+            .text_color(gpui::rgb(0xffffff))
+            .p_4()
+            .gap_4()
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_2()
+                    .child(
+                        div()
+                            .text_xl()
+                            .font_weight(gpui::FontWeight::BOLD)
+                            .child("Tasks Desktop"),
+                    )
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(gpui::rgb(0x888888))
+                            .child("GPUI-based desktop client for the Tasks platform"),
+                    ),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(div().w(px(12.)).h(px(12.)).rounded_full().bg(status_color))
+                    .child(div().child(format!("Status: {}", status_text))),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_1()
+                    .child(div().child(format!("Events received: {}", self.event_count)))
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(gpui::rgb(0x888888))
+                            .child(format!("Last event: {}", last_event_text)),
+                    ),
+            )
+    }
+}

--- a/crates/desktop/src/sse.rs
+++ b/crates/desktop/src/sse.rs
@@ -1,0 +1,465 @@
+//! Server-Sent Events (SSE) client for real-time event updates.
+//!
+//! Connects to the Tasks server's `/api/events` endpoint and streams
+//! events to the UI. Handles automatic reconnection with a grace period.
+//!
+//! Reference: web/src/hooks/use-app-state.ts
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::{FutureExt, StreamExt};
+use gpui::{AsyncApp, Context, EventEmitter, WeakEntity};
+use tracing::{debug, info, warn};
+
+/// Maximum number of events to buffer.
+const MAX_EVENTS: usize = 200;
+
+/// Reconnection delay after a connection failure.
+const RECONNECT_DELAY_MS: u64 = 1_000;
+
+/// Maximum reconnection delay (exponential backoff cap).
+const MAX_RECONNECT_DELAY_MS: u64 = 30_000;
+
+/// Optional filters for the SSE stream.
+#[derive(Debug, Clone, Default)]
+pub struct SseFilters {
+    /// Event type pattern filter (e.g., "task:*", "agent:message").
+    pub pattern: Option<String>,
+    /// Task ID filter.
+    pub task_id: Option<String>,
+}
+
+impl SseFilters {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_pattern(mut self, pattern: impl Into<String>) -> Self {
+        self.pattern = Some(pattern.into());
+        self
+    }
+
+    pub fn with_task_id(mut self, task_id: impl Into<String>) -> Self {
+        self.task_id = Some(task_id.into());
+        self
+    }
+
+    /// Build the URL with query parameters.
+    fn build_url(&self, base_url: &str) -> String {
+        let mut url = format!("{}/api/events", base_url);
+        let mut params = Vec::new();
+
+        if let Some(ref pattern) = self.pattern {
+            params.push(format!("pattern={}", urlencoding::encode(pattern)));
+        }
+        if let Some(ref task_id) = self.task_id {
+            params.push(format!("task_id={}", urlencoding::encode(task_id)));
+        }
+
+        if !params.is_empty() {
+            url.push('?');
+            url.push_str(&params.join("&"));
+        }
+        url
+    }
+}
+
+/// Connection state for the SSE client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SseConnectionState {
+    /// Not connected, initial state.
+    Disconnected,
+    /// Attempting to connect.
+    Connecting,
+    /// Connected and receiving events.
+    Connected,
+    /// Connection lost, within grace period (will auto-reconnect).
+    Reconnecting,
+    /// Connection failed after grace period.
+    Failed,
+}
+
+/// Events emitted by the SSE client.
+#[derive(Debug, Clone)]
+pub enum SseClientEvent {
+    /// Connection state changed.
+    StateChanged(SseConnectionState),
+    /// New event received from server.
+    EventReceived(Arc<events::Event>),
+    /// Error occurred.
+    Error(String),
+}
+
+/// SSE client for subscribing to server events.
+///
+/// This client connects to the Tasks server's `/api/events` endpoint,
+/// parses incoming events, and provides them to the UI.
+pub struct SseClient {
+    /// Base URL of the Tasks server (e.g., "http://localhost:4800").
+    base_url: String,
+    /// Optional filters for the event stream.
+    filters: SseFilters,
+    /// Current connection state.
+    state: SseConnectionState,
+    /// Buffered events (most recent first).
+    events: Vec<Arc<events::Event>>,
+    /// Flag to signal the background task to stop.
+    stop_flag: Option<Arc<AtomicBool>>,
+    /// Last error message.
+    last_error: Option<String>,
+}
+
+impl SseClient {
+    /// Create a new SSE client.
+    pub fn new(base_url: impl Into<String>, filters: SseFilters) -> Self {
+        Self {
+            base_url: base_url.into(),
+            filters,
+            state: SseConnectionState::Disconnected,
+            events: Vec::with_capacity(MAX_EVENTS),
+            stop_flag: None,
+            last_error: None,
+        }
+    }
+
+    /// Get the current connection state.
+    pub fn state(&self) -> SseConnectionState {
+        self.state
+    }
+
+    /// Check if currently connected.
+    pub fn is_connected(&self) -> bool {
+        self.state == SseConnectionState::Connected
+    }
+
+    /// Get the buffered events (most recent first).
+    pub fn events(&self) -> &[Arc<events::Event>] {
+        &self.events
+    }
+
+    /// Get the last error message, if any.
+    pub fn last_error(&self) -> Option<&str> {
+        self.last_error.as_deref()
+    }
+
+    /// Start the SSE connection.
+    ///
+    /// This spawns a background task that maintains the connection and
+    /// emits events through the GPUI event system.
+    pub fn connect(&mut self, cx: &mut Context<Self>) {
+        if self.stop_flag.is_some() {
+            // Already connected or connecting
+            return;
+        }
+
+        self.state = SseConnectionState::Connecting;
+        cx.emit(SseClientEvent::StateChanged(self.state));
+
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        self.stop_flag = Some(stop_flag.clone());
+
+        let url = self.filters.build_url(&self.base_url);
+
+        cx.spawn(|this, cx| async move {
+            run_sse_loop(url, stop_flag, this, cx).await;
+        })
+        .detach();
+    }
+
+    /// Disconnect from the server.
+    pub fn disconnect(&mut self, cx: &mut Context<Self>) {
+        if let Some(flag) = self.stop_flag.take() {
+            flag.store(true, Ordering::SeqCst);
+        }
+        self.state = SseConnectionState::Disconnected;
+        cx.emit(SseClientEvent::StateChanged(self.state));
+    }
+
+    /// Update the connection state.
+    fn set_state(&mut self, state: SseConnectionState, cx: &mut Context<Self>) {
+        if self.state != state {
+            self.state = state;
+            cx.emit(SseClientEvent::StateChanged(state));
+            cx.notify();
+        }
+    }
+
+    /// Add an event to the buffer.
+    fn push_event(&mut self, event: events::Event, cx: &mut Context<Self>) {
+        let event = Arc::new(event);
+        self.events.insert(0, event.clone());
+        if self.events.len() > MAX_EVENTS {
+            self.events.truncate(MAX_EVENTS);
+        }
+        cx.emit(SseClientEvent::EventReceived(event));
+        cx.notify();
+    }
+
+    /// Set error state.
+    fn set_error(&mut self, error: String, cx: &mut Context<Self>) {
+        self.last_error = Some(error.clone());
+        cx.emit(SseClientEvent::Error(error));
+        cx.notify();
+    }
+}
+
+impl EventEmitter<SseClientEvent> for SseClient {}
+
+/// Background task that maintains the SSE connection.
+async fn run_sse_loop(
+    url: String,
+    stop_flag: Arc<AtomicBool>,
+    entity: WeakEntity<SseClient>,
+    mut cx: AsyncApp,
+) {
+    let mut reconnect_delay = Duration::from_millis(RECONNECT_DELAY_MS);
+    let mut consecutive_failures = 0u32;
+
+    loop {
+        // Check for stop signal
+        if stop_flag.load(Ordering::SeqCst) {
+            info!(url = %url, "SSE client stopped by user");
+            break;
+        }
+
+        info!(url = %url, "SSE connecting...");
+
+        match connect_and_stream(&url, &stop_flag, &entity, &mut cx).await {
+            Ok(()) => {
+                // Clean disconnect (stop signal received)
+                break;
+            }
+            Err(e) => {
+                consecutive_failures += 1;
+                warn!(
+                    url = %url,
+                    error = %e,
+                    consecutive_failures = consecutive_failures,
+                    "SSE connection failed"
+                );
+
+                // Update state based on failure count
+                let _ = entity.update(&mut cx, |client: &mut SseClient, cx| {
+                    if consecutive_failures == 1 {
+                        // First failure: enter reconnecting state (grace period)
+                        client.set_state(SseConnectionState::Reconnecting, cx);
+                    } else {
+                        // Multiple failures: show as failed
+                        client.set_state(SseConnectionState::Failed, cx);
+                        client.set_error(e.to_string(), cx);
+                    }
+                });
+
+                // Check stop flag before sleeping
+                if stop_flag.load(Ordering::SeqCst) {
+                    break;
+                }
+
+                // Exponential backoff
+                let delay = reconnect_delay.min(Duration::from_millis(MAX_RECONNECT_DELAY_MS));
+                debug!(delay_ms = delay.as_millis(), "SSE reconnecting after delay");
+
+                // Sleep with periodic stop flag checks
+                let check_interval = Duration::from_millis(100);
+                let mut elapsed = Duration::ZERO;
+                while elapsed < delay {
+                    if stop_flag.load(Ordering::SeqCst) {
+                        info!(url = %url, "SSE client stopped during reconnect");
+                        let _ = entity.update(&mut cx, |client: &mut SseClient, cx| {
+                            client.stop_flag = None;
+                            client.set_state(SseConnectionState::Disconnected, cx);
+                        });
+                        return;
+                    }
+                    smol::Timer::after(check_interval).await;
+                    elapsed += check_interval;
+                }
+
+                // Increase delay for next attempt (exponential backoff)
+                reconnect_delay =
+                    (reconnect_delay * 2).min(Duration::from_millis(MAX_RECONNECT_DELAY_MS));
+            }
+        }
+    }
+
+    let _ = entity.update(&mut cx, |client: &mut SseClient, cx| {
+        client.stop_flag = None;
+        client.set_state(SseConnectionState::Disconnected, cx);
+    });
+}
+
+/// Connect to the SSE endpoint and stream events.
+async fn connect_and_stream(
+    url: &str,
+    stop_flag: &Arc<AtomicBool>,
+    entity: &WeakEntity<SseClient>,
+    cx: &mut AsyncApp,
+) -> Result<(), SseError> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(SseError::Request)?;
+
+    let response = client
+        .get(url)
+        .header("Accept", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        .send()
+        .await
+        .map_err(SseError::Request)?;
+
+    if !response.status().is_success() {
+        return Err(SseError::HttpStatus(response.status().as_u16()));
+    }
+
+    // Update state to connected
+    let _ = entity.update(cx, |client: &mut SseClient, cx| {
+        client.set_state(SseConnectionState::Connected, cx);
+    });
+
+    info!(url = %url, "SSE connected");
+
+    // Stream the response body
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+
+    loop {
+        // Check for stop signal
+        if stop_flag.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        // Poll the stream with a timeout to allow checking stop flag
+        let timeout = smol::Timer::after(Duration::from_millis(100));
+        let next_chunk = stream.next();
+
+        futures::select_biased! {
+            chunk = next_chunk.fuse() => {
+                match chunk {
+                    Some(Ok(bytes)) => {
+                        buffer.push_str(&String::from_utf8_lossy(&bytes));
+                        process_buffer(&mut buffer, entity, cx);
+                    }
+                    Some(Err(e)) => {
+                        return Err(SseError::Stream(e.to_string()));
+                    }
+                    None => {
+                        // Stream ended
+                        return Err(SseError::StreamEnded);
+                    }
+                }
+            }
+            _ = futures::FutureExt::fuse(timeout) => {
+                // Timeout - just continue and check stop flag
+            }
+        }
+    }
+}
+
+/// Process the SSE buffer, extracting complete events.
+fn process_buffer(
+    buffer: &mut String,
+    entity: &WeakEntity<SseClient>,
+    cx: &mut AsyncApp,
+) {
+    // SSE format: "data: <json>\n\n"
+    while let Some(pos) = buffer.find("\n\n") {
+        let message = buffer[..pos].to_string();
+        *buffer = buffer[pos + 2..].to_string();
+
+        // Parse SSE message
+        for line in message.lines() {
+            if let Some(data) = line.strip_prefix("data: ") {
+                match serde_json::from_str::<events::Event>(data) {
+                    Ok(event) => {
+                        debug!(event_type = %event.event_type.as_str(), task = %event.task, "SSE event received");
+                        let _ = entity.update(cx, |client: &mut SseClient, cx| {
+                            client.push_event(event, cx);
+                        });
+                    }
+                    Err(e) => {
+                        warn!(data = %data, error = %e, "Failed to parse SSE event");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// SSE-specific errors.
+#[derive(Debug, thiserror::Error)]
+pub enum SseError {
+    #[error("HTTP request failed: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("HTTP status error: {0}")]
+    HttpStatus(u16),
+    #[error("Stream error: {0}")]
+    Stream(String),
+    #[error("Stream ended unexpectedly")]
+    StreamEnded,
+}
+
+/// URL encoding helper (minimal implementation).
+mod urlencoding {
+    pub fn encode(s: &str) -> String {
+        let mut result = String::with_capacity(s.len() * 3);
+        for c in s.chars() {
+            match c {
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' | '~' => {
+                    result.push(c);
+                }
+                _ => {
+                    for byte in c.to_string().as_bytes() {
+                        result.push_str(&format!("%{:02X}", byte));
+                    }
+                }
+            }
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filters_build_url_no_params() {
+        let filters = SseFilters::new();
+        let url = filters.build_url("http://localhost:4800");
+        assert_eq!(url, "http://localhost:4800/api/events");
+    }
+
+    #[test]
+    fn filters_build_url_with_pattern() {
+        let filters = SseFilters::new().with_pattern("task:*");
+        let url = filters.build_url("http://localhost:4800");
+        assert_eq!(url, "http://localhost:4800/api/events?pattern=task%3A%2A");
+    }
+
+    #[test]
+    fn filters_build_url_with_task_id() {
+        let filters = SseFilters::new().with_task_id("task-123");
+        let url = filters.build_url("http://localhost:4800");
+        assert_eq!(url, "http://localhost:4800/api/events?task_id=task-123");
+    }
+
+    #[test]
+    fn filters_build_url_with_both() {
+        let filters = SseFilters::new()
+            .with_pattern("agent:*")
+            .with_task_id("task-456");
+        let url = filters.build_url("http://localhost:4800");
+        assert!(url.contains("pattern=agent%3A%2A"));
+        assert!(url.contains("task_id=task-456"));
+    }
+
+    #[test]
+    fn urlencoding_basic() {
+        assert_eq!(urlencoding::encode("hello"), "hello");
+        assert_eq!(urlencoding::encode("task:*"), "task%3A%2A");
+        assert_eq!(urlencoding::encode("a b"), "a%20b");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `crates/desktop/` with GPUI-based native desktop application
- Implement SSE client for real-time event subscription to `/api/events`
- Support automatic reconnection with exponential backoff (1s to 30s)
- Buffer up to 200 events (most recent first) for UI consumption
- Support optional filters (`pattern`, `task_id`) matching the web frontend

## Implementation Details

The SSE client (`src/sse.rs`) provides:
- `SseClient` - GPUI model that manages connection lifecycle
- `SseFilters` - Builder for optional pattern/task_id filters
- `SseConnectionState` - Connection status (Disconnected/Connecting/Connected/Reconnecting/Failed)
- `SseClientEvent` - Events emitted for UI subscription (StateChanged/EventReceived/Error)

The implementation mirrors `web/src/hooks/use-app-state.ts`:
- Grace period before showing "failed" status on transient errors
- Exponential backoff capped at 30 seconds
- Event parsing from JSON to the `events::Event` type

The basic app shell (`src/main.rs`) demonstrates the SSE client integration with a minimal UI showing connection status and event count.

## Platform Requirements

GPUI requires platform-specific libraries:
- **Linux**: `libxcb`, `libxkbcommon`, `libxkbcommon-x11`
- **macOS**: Built-in frameworks (no additional deps)

## Test plan
- [x] `cargo check -p tasks-desktop` passes (verifies compilation)
- [ ] Manual test: Run desktop app with Tasks server to verify SSE connection
- [ ] Manual test: Stop server and verify reconnection behavior

Closes #155
Related to #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)