### PR TITLE
Fix project ID showing instead of name in UI

### DIFF
--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import type { Project } from "./types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -14,4 +15,12 @@ export function formatRelativeTime(date: string | Date): string {
   if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
   if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
   return `${Math.floor(diff / 86_400_000)}d ago`;
+}
+
+/**
+ * Get the display name (repo) for a project ID.
+ * Falls back to the raw project ID if not found.
+ */
+export function projectLabel(projectId: string, projects: Project[]): string {
+  return projects.find((p) => p.id === projectId)?.repo ?? projectId;
 }

--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { useAppState } from "@/hooks/use-app-state";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { formatRelativeTime } from "@/lib/utils";
+import { formatRelativeTime, projectLabel } from "@/lib/utils";
 import type { TaskState, Event } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -179,7 +179,7 @@ export function DashboardPage() {
                   {/* Only show project when viewing all projects */}
                   {!selectedProject && (
                     <span className="text-muted-foreground text-sm shrink-0">
-                      {task.project}
+                      {projectLabel(task.project, snapshot.projects)}
                     </span>
                   )}
                   <span className="text-muted-foreground text-sm shrink-0">

--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -5,7 +5,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatRelativeTime } from "@/lib/utils";
 import { approveMerge, rejectMerge } from "@/lib/api";
-import type { MergeQueueEntry, MergeStatus, Task } from "@/lib/types";
+import type { MergeQueueEntry, MergeStatus, Project, Task } from "@/lib/types";
+import { projectLabel } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
 // Status badge
@@ -65,11 +66,14 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
     id: "project",
     header: "Project",
     cell: ({ row, table }) => {
-      const tasks = (table.options.meta as { tasks?: Task[] })?.tasks ?? [];
+      const meta = table.options.meta as { tasks?: Task[]; projects?: Project[] } | undefined;
+      const tasks = meta?.tasks ?? [];
+      const projects = meta?.projects ?? [];
       const task = tasks.find((t) => t.id === row.original.task_id);
+      const displayName = task?.project ? projectLabel(task.project, projects) : "—";
       return (
         <span className="text-muted-foreground">
-          {task?.project ?? "—"}
+          {displayName}
         </span>
       );
     },

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -73,6 +73,7 @@ export function MergeQueuePage() {
     meta: {
       refreshSnapshot,
       tasks: snapshot?.tasks ?? [],
+      projects: snapshot?.projects ?? [],
     },
   });
 

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -14,7 +14,7 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useAppState } from "@/hooks/use-app-state";
 import { cancelTask, fetchTaskEvents, sendChat, subscribeEvents } from "@/lib/api";
-import { cn, formatRelativeTime } from "@/lib/utils";
+import { cn, formatRelativeTime, projectLabel } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -556,7 +556,7 @@ export function TaskDetailPage() {
             <Separator orientation="vertical" className="h-4" />
             {sourceDisplay(task)}
             <Separator orientation="vertical" className="h-4" />
-            <span>{task.project}</span>
+            <span>{projectLabel(task.project, snapshot.projects)}</span>
             {task.labels.length > 0 && (
               <>
                 <Separator orientation="vertical" className="h-4" />


### PR DESCRIPTION
## Summary

- Add `projectLabel` helper function to resolve project IDs to human-readable repo names
- Update dashboard active tasks list to show project name instead of ID
- Update task detail page header to show project name
- Update merge queue project column to resolve project names via the helper

This is a frontend-only change with no backend or schema modifications.

Fixes #147

## Test plan

- [ ] View dashboard with multiple projects — project names should show as "owner/repo" format
- [ ] View task detail page — project name in header should display correctly
- [ ] View merge queue — project column should show repo names instead of UUIDs
- [ ] Build succeeds (`npm run build` in web/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)