### PR TITLE
Add theme and styling system for GPUI desktop app

### DIFF
--- a/crates/desktop/Cargo.toml
+++ b/crates/desktop/Cargo.toml
@@ -10,4 +10,30 @@ name = "tasks-desktop"
 path = "src/main.rs"
 
 [dependencies]
+# GPUI from Zed
 gpui.workspace = true
+
+# Workspace dependencies
+serde.workspace = true
+serde_json.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+futures.workspace = true
+reqwest.workspace = true
+bytes.workspace = true
+smol.workspace = true
+
+# Internal crates
+events = { path = "../events" }
+models = { path = "../models" }
+
+# SSE parsing
+async-sse = "5.1"
+async-channel = "2.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.26"
+objc = "0.2"

--- a/crates/desktop/Cargo.toml
+++ b/crates/desktop/Cargo.toml
@@ -14,26 +14,14 @@ path = "src/main.rs"
 gpui.workspace = true
 
 # Workspace dependencies
-serde.workspace = true
 serde_json.workspace = true
-chrono.workspace = true
-uuid.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 futures.workspace = true
 reqwest.workspace = true
-bytes.workspace = true
 smol.workspace = true
 
 # Internal crates
 events = { path = "../events" }
 models = { path = "../models" }
-
-# SSE parsing
-async-sse = "5.1"
-async-channel = "2.0"
-
-[target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.26"
-objc = "0.2"

--- a/crates/desktop/src/lib.rs
+++ b/crates/desktop/src/lib.rs
@@ -8,13 +8,13 @@
 //! - [`sse`] - Server-Sent Events client for real-time updates
 //! - [`theme`] - Theming and styling system
 
-use gpui::{div, prelude::*, rgb, Context, SharedString, Window};
+use gpui::{Context, SharedString, Window, div, prelude::*, rgb};
 
 mod sse;
 pub mod theme;
 
 pub use sse::{SseClient, SseClientEvent, SseConnectionState, SseFilters};
-pub use theme::{colors, radius, spacing, style_helpers, typography, Theme};
+pub use theme::{Theme, colors, radius, spacing, style_helpers, typography};
 
 /// Root view for the Tasks desktop application.
 pub struct RootView {
@@ -50,11 +50,7 @@ impl Render for RootView {
                             .text_color(rgb(0xcdd6f4))
                             .child(self.title.clone()),
                     )
-                    .child(
-                        div()
-                            .text_color(rgb(0xa6adc8))
-                            .child("GPUI Desktop Shell"),
-                    ),
+                    .child(div().text_color(rgb(0xa6adc8)).child("GPUI Desktop Shell")),
             )
     }
 }

--- a/crates/desktop/src/lib.rs
+++ b/crates/desktop/src/lib.rs
@@ -1,6 +1,13 @@
-//! Tasks Desktop - GPUI-based desktop application for the Tasks platform.
+//! Tasks Desktop — GPUI-based desktop application.
+//!
+//! This crate provides a native desktop UI for the Tasks platform,
+//! built with GPUI (Zed's GPU-accelerated UI framework).
 
 use gpui::{div, prelude::*, rgb, Context, SharedString, Window};
+
+mod sse;
+
+pub use sse::{SseClient, SseClientEvent, SseConnectionState, SseFilters};
 
 /// Root view for the Tasks desktop application.
 pub struct RootView {

--- a/crates/desktop/src/lib.rs
+++ b/crates/desktop/src/lib.rs
@@ -2,12 +2,19 @@
 //!
 //! This crate provides a native desktop UI for the Tasks platform,
 //! built with GPUI (Zed's GPU-accelerated UI framework).
+//!
+//! # Modules
+//!
+//! - [`sse`] - Server-Sent Events client for real-time updates
+//! - [`theme`] - Theming and styling system
 
 use gpui::{div, prelude::*, rgb, Context, SharedString, Window};
 
 mod sse;
+pub mod theme;
 
 pub use sse::{SseClient, SseClientEvent, SseConnectionState, SseFilters};
+pub use theme::{colors, radius, spacing, style_helpers, typography, Theme};
 
 /// Root view for the Tasks desktop application.
 pub struct RootView {

--- a/crates/desktop/src/main.rs
+++ b/crates/desktop/src/main.rs
@@ -3,14 +3,14 @@
 //! A GPUI-based native desktop application for the Tasks platform.
 
 use gpui::{
-    actions, px, App, AppContext as _, Application, Context, Entity, IntoElement, ParentElement,
-    Render, Styled, Window, WindowOptions,
+    App, AppContext as _, Application, Context, Entity, IntoElement, ParentElement, Render, Styled,
+    Window, WindowOptions, actions, px,
 };
 use std::sync::Arc;
 use tasks_desktop::{
-    colors, spacing,
-    style_helpers::{container, heading, muted_text, status_dot, StyledExt},
-    typography, SseClient, SseClientEvent, SseConnectionState, SseFilters,
+    SseClient, SseClientEvent, SseConnectionState, SseFilters, colors, spacing,
+    style_helpers::{StyledExt, container, heading, muted_text, status_dot},
+    typography,
 };
 use tracing_subscriber::EnvFilter;
 
@@ -145,10 +145,7 @@ impl Render for TasksApp {
                             .font_weight(typography::WEIGHT_BOLD)
                             .child("Tasks Desktop"),
                     )
-                    .child(
-                        muted_text()
-                            .child("GPUI-based desktop client for the Tasks platform"),
-                    ),
+                    .child(muted_text().child("GPUI-based desktop client for the Tasks platform")),
             )
             .child(
                 gpui::div()
@@ -156,7 +153,11 @@ impl Render for TasksApp {
                     .items_center()
                     .gap(spacing::SPACE_2)
                     .child(status_dot(status_color))
-                    .child(gpui::div().text_primary().child(format!("Status: {}", status_text))),
+                    .child(
+                        gpui::div()
+                            .text_primary()
+                            .child(format!("Status: {}", status_text)),
+                    ),
             )
             .child(
                 gpui::div()

--- a/crates/desktop/src/main.rs
+++ b/crates/desktop/src/main.rs
@@ -3,11 +3,15 @@
 //! A GPUI-based native desktop application for the Tasks platform.
 
 use gpui::{
-    actions, div, px, App, AppContext as _, Application, Context, Entity, IntoElement,
-    ParentElement, Render, Styled, Window, WindowOptions,
+    actions, px, App, AppContext as _, Application, Context, Entity, IntoElement, ParentElement,
+    Render, Styled, Window, WindowOptions,
 };
 use std::sync::Arc;
-use tasks_desktop::{SseClient, SseClientEvent, SseConnectionState, SseFilters};
+use tasks_desktop::{
+    colors, spacing,
+    style_helpers::{container, heading, muted_text, status_dot, StyledExt},
+    typography, SseClient, SseClientEvent, SseConnectionState, SseFilters,
+};
 use tracing_subscriber::EnvFilter;
 
 actions!(desktop, [Quit]);
@@ -115,13 +119,11 @@ impl Render for TasksApp {
         };
 
         let status_color = match self.connection_state {
-            SseConnectionState::Connected => gpui::rgb(0x22c55e), // green
+            SseConnectionState::Connected => colors::STATE_COMPLETED,
             SseConnectionState::Connecting | SseConnectionState::Reconnecting => {
-                gpui::rgb(0xeab308) // yellow
+                colors::STATE_QUESTION
             }
-            SseConnectionState::Disconnected | SseConnectionState::Failed => {
-                gpui::rgb(0xef4444) // red
-            }
+            SseConnectionState::Disconnected | SseConnectionState::Failed => colors::STATE_FAILED,
         };
 
         let last_event_text = self
@@ -130,52 +132,43 @@ impl Render for TasksApp {
             .map(|e| format!("{}: {}", e.event_type.as_str(), e.task))
             .unwrap_or_else(|| "No events yet".to_string());
 
-        div()
-            .flex()
-            .flex_col()
-            .size_full()
-            .bg(gpui::rgb(0x1a1a1a))
-            .text_color(gpui::rgb(0xffffff))
-            .p_4()
-            .gap_4()
+        container()
+            .p(spacing::SPACE_4)
+            .gap(spacing::SPACE_4)
             .child(
-                div()
+                gpui::div()
                     .flex()
                     .flex_col()
-                    .gap_2()
+                    .gap(spacing::SPACE_2)
                     .child(
-                        div()
-                            .text_xl()
-                            .font_weight(gpui::FontWeight::BOLD)
+                        heading(typography::TEXT_XL)
+                            .font_weight(typography::WEIGHT_BOLD)
                             .child("Tasks Desktop"),
                     )
                     .child(
-                        div()
-                            .text_sm()
-                            .text_color(gpui::rgb(0x888888))
+                        muted_text()
                             .child("GPUI-based desktop client for the Tasks platform"),
                     ),
             )
             .child(
-                div()
+                gpui::div()
                     .flex()
                     .items_center()
-                    .gap_2()
-                    .child(div().w(px(12.)).h(px(12.)).rounded_full().bg(status_color))
-                    .child(div().child(format!("Status: {}", status_text))),
+                    .gap(spacing::SPACE_2)
+                    .child(status_dot(status_color))
+                    .child(gpui::div().text_primary().child(format!("Status: {}", status_text))),
             )
             .child(
-                div()
+                gpui::div()
                     .flex()
                     .flex_col()
-                    .gap_1()
-                    .child(div().child(format!("Events received: {}", self.event_count)))
+                    .gap(spacing::SPACE_1)
                     .child(
-                        div()
-                            .text_sm()
-                            .text_color(gpui::rgb(0x888888))
-                            .child(format!("Last event: {}", last_event_text)),
-                    ),
+                        gpui::div()
+                            .text_primary()
+                            .child(format!("Events received: {}", self.event_count)),
+                    )
+                    .child(muted_text().child(format!("Last event: {}", last_event_text))),
             )
     }
 }

--- a/crates/desktop/src/main.rs
+++ b/crates/desktop/src/main.rs
@@ -1,21 +1,181 @@
-//! Tasks Desktop - Main entry point for the GPUI desktop application.
+//! Tasks Desktop — Main entry point.
+//!
+//! A GPUI-based native desktop application for the Tasks platform.
 
-use gpui::{px, size, Application, Bounds, WindowBounds, WindowOptions};
-use tasks_desktop::RootView;
+use gpui::{
+    actions, div, px, App, AppContext as _, Application, Context, Entity, IntoElement,
+    ParentElement, Render, Styled, Window, WindowOptions,
+};
+use std::sync::Arc;
+use tasks_desktop::{SseClient, SseClientEvent, SseConnectionState, SseFilters};
+use tracing_subscriber::EnvFilter;
+
+actions!(desktop, [Quit]);
+
+/// Default server URL.
+const DEFAULT_SERVER_URL: &str = "http://localhost:4800";
 
 fn main() {
-    Application::new().run(|cx| {
-        let bounds = Bounds::centered(None, size(px(800.), px(600.)), cx);
+    // Initialize logging
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    Application::new().run(|cx: &mut App| {
+        // Register quit action
+        cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
+        cx.bind_keys([gpui::KeyBinding::new("cmd-q", Quit, None)]);
 
         cx.open_window(
             WindowOptions {
-                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                window_bounds: Some(gpui::WindowBounds::Windowed(gpui::Bounds {
+                    origin: gpui::Point::default(),
+                    size: gpui::Size {
+                        width: px(800.),
+                        height: px(600.),
+                    },
+                })),
                 ..Default::default()
             },
-            |_, cx| cx.new(|_| RootView::new("Tasks")),
+            |_window, cx| {
+                let view = cx.new(|cx| TasksApp::new(cx));
+                view
+            },
         )
-        .expect("Failed to open window");
+        .unwrap();
 
         cx.activate(true);
     });
+}
+
+/// Main application view.
+struct TasksApp {
+    #[allow(dead_code)] // Kept for future disconnect functionality
+    sse_client: Entity<SseClient>,
+    connection_state: SseConnectionState,
+    event_count: usize,
+    last_event: Option<Arc<events::Event>>,
+}
+
+impl TasksApp {
+    fn new(cx: &mut Context<Self>) -> Self {
+        // Get server URL from environment or use default
+        let server_url =
+            std::env::var("TASKS_SERVER_URL").unwrap_or_else(|_| DEFAULT_SERVER_URL.to_string());
+
+        // Create SSE client
+        let filters = SseFilters::new();
+        let sse_client = cx.new(|_| SseClient::new(&server_url, filters));
+
+        // Subscribe to SSE events
+        cx.subscribe(
+            &sse_client,
+            |this: &mut Self, _entity, event: &SseClientEvent, cx| match event {
+                SseClientEvent::StateChanged(state) => {
+                    this.connection_state = *state;
+                    cx.notify();
+                }
+                SseClientEvent::EventReceived(event) => {
+                    this.event_count += 1;
+                    this.last_event = Some(event.clone());
+                    cx.notify();
+                }
+                SseClientEvent::Error(err) => {
+                    tracing::error!(error = %err, "SSE error");
+                    cx.notify();
+                }
+            },
+        )
+        .detach();
+
+        // Start connection
+        sse_client.update(cx, |client: &mut SseClient, cx| {
+            client.connect(cx);
+        });
+
+        Self {
+            sse_client,
+            connection_state: SseConnectionState::Connecting,
+            event_count: 0,
+            last_event: None,
+        }
+    }
+}
+
+impl Render for TasksApp {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let status_text = match self.connection_state {
+            SseConnectionState::Disconnected => "Disconnected",
+            SseConnectionState::Connecting => "Connecting...",
+            SseConnectionState::Connected => "Connected",
+            SseConnectionState::Reconnecting => "Reconnecting...",
+            SseConnectionState::Failed => "Connection Failed",
+        };
+
+        let status_color = match self.connection_state {
+            SseConnectionState::Connected => gpui::rgb(0x22c55e), // green
+            SseConnectionState::Connecting | SseConnectionState::Reconnecting => {
+                gpui::rgb(0xeab308) // yellow
+            }
+            SseConnectionState::Disconnected | SseConnectionState::Failed => {
+                gpui::rgb(0xef4444) // red
+            }
+        };
+
+        let last_event_text = self
+            .last_event
+            .as_ref()
+            .map(|e| format!("{}: {}", e.event_type.as_str(), e.task))
+            .unwrap_or_else(|| "No events yet".to_string());
+
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .bg(gpui::rgb(0x1a1a1a))
+            .text_color(gpui::rgb(0xffffff))
+            .p_4()
+            .gap_4()
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_2()
+                    .child(
+                        div()
+                            .text_xl()
+                            .font_weight(gpui::FontWeight::BOLD)
+                            .child("Tasks Desktop"),
+                    )
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(gpui::rgb(0x888888))
+                            .child("GPUI-based desktop client for the Tasks platform"),
+                    ),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(div().w(px(12.)).h(px(12.)).rounded_full().bg(status_color))
+                    .child(div().child(format!("Status: {}", status_text))),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_1()
+                    .child(div().child(format!("Events received: {}", self.event_count)))
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(gpui::rgb(0x888888))
+                            .child(format!("Last event: {}", last_event_text)),
+                    ),
+            )
+    }
 }

--- a/crates/desktop/src/sse.rs
+++ b/crates/desktop/src/sse.rs
@@ -1,0 +1,465 @@
+//! Server-Sent Events (SSE) client for real-time event updates.
+//!
+//! Connects to the Tasks server's `/api/events` endpoint and streams
+//! events to the UI. Handles automatic reconnection with a grace period.
+//!
+//! Reference: web/src/hooks/use-app-state.ts
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::{FutureExt, StreamExt};
+use gpui::{AsyncApp, Context, EventEmitter, WeakEntity};
+use tracing::{debug, info, warn};
+
+/// Maximum number of events to buffer.
+const MAX_EVENTS: usize = 200;
+
+/// Reconnection delay after a connection failure.
+const RECONNECT_DELAY_MS: u64 = 1_000;
+
+/// Maximum reconnection delay (exponential backoff cap).
+const MAX_RECONNECT_DELAY_MS: u64 = 30_000;
+
+/// Optional filters for the SSE stream.
+#[derive(Debug, Clone, Default)]
+pub struct SseFilters {
+    /// Event type pattern filter (e.g., "task:*", "agent:message").
+    pub pattern: Option<String>,
+    /// Task ID filter.
+    pub task_id: Option<String>,
+}
+
+impl SseFilters {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_pattern(mut self, pattern: impl Into<String>) -> Self {
+        self.pattern = Some(pattern.into());
+        self
+    }
+
+    pub fn with_task_id(mut self, task_id: impl Into<String>) -> Self {
+        self.task_id = Some(task_id.into());
+        self
+    }
+
+    /// Build the URL with query parameters.
+    fn build_url(&self, base_url: &str) -> String {
+        let mut url = format!("{}/api/events", base_url);
+        let mut params = Vec::new();
+
+        if let Some(ref pattern) = self.pattern {
+            params.push(format!("pattern={}", urlencoding::encode(pattern)));
+        }
+        if let Some(ref task_id) = self.task_id {
+            params.push(format!("task_id={}", urlencoding::encode(task_id)));
+        }
+
+        if !params.is_empty() {
+            url.push('?');
+            url.push_str(&params.join("&"));
+        }
+        url
+    }
+}
+
+/// Connection state for the SSE client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SseConnectionState {
+    /// Not connected, initial state.
+    Disconnected,
+    /// Attempting to connect.
+    Connecting,
+    /// Connected and receiving events.
+    Connected,
+    /// Connection lost, within grace period (will auto-reconnect).
+    Reconnecting,
+    /// Connection failed after grace period.
+    Failed,
+}
+
+/// Events emitted by the SSE client.
+#[derive(Debug, Clone)]
+pub enum SseClientEvent {
+    /// Connection state changed.
+    StateChanged(SseConnectionState),
+    /// New event received from server.
+    EventReceived(Arc<events::Event>),
+    /// Error occurred.
+    Error(String),
+}
+
+/// SSE client for subscribing to server events.
+///
+/// This client connects to the Tasks server's `/api/events` endpoint,
+/// parses incoming events, and provides them to the UI.
+pub struct SseClient {
+    /// Base URL of the Tasks server (e.g., "http://localhost:4800").
+    base_url: String,
+    /// Optional filters for the event stream.
+    filters: SseFilters,
+    /// Current connection state.
+    state: SseConnectionState,
+    /// Buffered events (most recent first).
+    events: Vec<Arc<events::Event>>,
+    /// Flag to signal the background task to stop.
+    stop_flag: Option<Arc<AtomicBool>>,
+    /// Last error message.
+    last_error: Option<String>,
+}
+
+impl SseClient {
+    /// Create a new SSE client.
+    pub fn new(base_url: impl Into<String>, filters: SseFilters) -> Self {
+        Self {
+            base_url: base_url.into(),
+            filters,
+            state: SseConnectionState::Disconnected,
+            events: Vec::with_capacity(MAX_EVENTS),
+            stop_flag: None,
+            last_error: None,
+        }
+    }
+
+    /// Get the current connection state.
+    pub fn state(&self) -> SseConnectionState {
+        self.state
+    }
+
+    /// Check if currently connected.
+    pub fn is_connected(&self) -> bool {
+        self.state == SseConnectionState::Connected
+    }
+
+    /// Get the buffered events (most recent first).
+    pub fn events(&self) -> &[Arc<events::Event>] {
+        &self.events
+    }
+
+    /// Get the last error message, if any.
+    pub fn last_error(&self) -> Option<&str> {
+        self.last_error.as_deref()
+    }
+
+    /// Start the SSE connection.
+    ///
+    /// This spawns a background task that maintains the connection and
+    /// emits events through the GPUI event system.
+    pub fn connect(&mut self, cx: &mut Context<Self>) {
+        if self.stop_flag.is_some() {
+            // Already connected or connecting
+            return;
+        }
+
+        self.state = SseConnectionState::Connecting;
+        cx.emit(SseClientEvent::StateChanged(self.state));
+
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        self.stop_flag = Some(stop_flag.clone());
+
+        let url = self.filters.build_url(&self.base_url);
+
+        cx.spawn(|this, cx| async move {
+            run_sse_loop(url, stop_flag, this, cx).await;
+        })
+        .detach();
+    }
+
+    /// Disconnect from the server.
+    pub fn disconnect(&mut self, cx: &mut Context<Self>) {
+        if let Some(flag) = self.stop_flag.take() {
+            flag.store(true, Ordering::SeqCst);
+        }
+        self.state = SseConnectionState::Disconnected;
+        cx.emit(SseClientEvent::StateChanged(self.state));
+    }
+
+    /// Update the connection state.
+    fn set_state(&mut self, state: SseConnectionState, cx: &mut Context<Self>) {
+        if self.state != state {
+            self.state = state;
+            cx.emit(SseClientEvent::StateChanged(state));
+            cx.notify();
+        }
+    }
+
+    /// Add an event to the buffer.
+    fn push_event(&mut self, event: events::Event, cx: &mut Context<Self>) {
+        let event = Arc::new(event);
+        self.events.insert(0, event.clone());
+        if self.events.len() > MAX_EVENTS {
+            self.events.truncate(MAX_EVENTS);
+        }
+        cx.emit(SseClientEvent::EventReceived(event));
+        cx.notify();
+    }
+
+    /// Set error state.
+    fn set_error(&mut self, error: String, cx: &mut Context<Self>) {
+        self.last_error = Some(error.clone());
+        cx.emit(SseClientEvent::Error(error));
+        cx.notify();
+    }
+}
+
+impl EventEmitter<SseClientEvent> for SseClient {}
+
+/// Background task that maintains the SSE connection.
+async fn run_sse_loop(
+    url: String,
+    stop_flag: Arc<AtomicBool>,
+    entity: WeakEntity<SseClient>,
+    mut cx: AsyncApp,
+) {
+    let mut reconnect_delay = Duration::from_millis(RECONNECT_DELAY_MS);
+    let mut consecutive_failures = 0u32;
+
+    loop {
+        // Check for stop signal
+        if stop_flag.load(Ordering::SeqCst) {
+            info!(url = %url, "SSE client stopped by user");
+            break;
+        }
+
+        info!(url = %url, "SSE connecting...");
+
+        match connect_and_stream(&url, &stop_flag, &entity, &mut cx).await {
+            Ok(()) => {
+                // Clean disconnect (stop signal received)
+                break;
+            }
+            Err(e) => {
+                consecutive_failures += 1;
+                warn!(
+                    url = %url,
+                    error = %e,
+                    consecutive_failures = consecutive_failures,
+                    "SSE connection failed"
+                );
+
+                // Update state based on failure count
+                let _ = entity.update(&mut cx, |client: &mut SseClient, cx| {
+                    if consecutive_failures == 1 {
+                        // First failure: enter reconnecting state (grace period)
+                        client.set_state(SseConnectionState::Reconnecting, cx);
+                    } else {
+                        // Multiple failures: show as failed
+                        client.set_state(SseConnectionState::Failed, cx);
+                        client.set_error(e.to_string(), cx);
+                    }
+                });
+
+                // Check stop flag before sleeping
+                if stop_flag.load(Ordering::SeqCst) {
+                    break;
+                }
+
+                // Exponential backoff
+                let delay = reconnect_delay.min(Duration::from_millis(MAX_RECONNECT_DELAY_MS));
+                debug!(delay_ms = delay.as_millis(), "SSE reconnecting after delay");
+
+                // Sleep with periodic stop flag checks
+                let check_interval = Duration::from_millis(100);
+                let mut elapsed = Duration::ZERO;
+                while elapsed < delay {
+                    if stop_flag.load(Ordering::SeqCst) {
+                        info!(url = %url, "SSE client stopped during reconnect");
+                        let _ = entity.update(&mut cx, |client: &mut SseClient, cx| {
+                            client.stop_flag = None;
+                            client.set_state(SseConnectionState::Disconnected, cx);
+                        });
+                        return;
+                    }
+                    smol::Timer::after(check_interval).await;
+                    elapsed += check_interval;
+                }
+
+                // Increase delay for next attempt (exponential backoff)
+                reconnect_delay =
+                    (reconnect_delay * 2).min(Duration::from_millis(MAX_RECONNECT_DELAY_MS));
+            }
+        }
+    }
+
+    let _ = entity.update(&mut cx, |client: &mut SseClient, cx| {
+        client.stop_flag = None;
+        client.set_state(SseConnectionState::Disconnected, cx);
+    });
+}
+
+/// Connect to the SSE endpoint and stream events.
+async fn connect_and_stream(
+    url: &str,
+    stop_flag: &Arc<AtomicBool>,
+    entity: &WeakEntity<SseClient>,
+    cx: &mut AsyncApp,
+) -> Result<(), SseError> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(SseError::Request)?;
+
+    let response = client
+        .get(url)
+        .header("Accept", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        .send()
+        .await
+        .map_err(SseError::Request)?;
+
+    if !response.status().is_success() {
+        return Err(SseError::HttpStatus(response.status().as_u16()));
+    }
+
+    // Update state to connected
+    let _ = entity.update(cx, |client: &mut SseClient, cx| {
+        client.set_state(SseConnectionState::Connected, cx);
+    });
+
+    info!(url = %url, "SSE connected");
+
+    // Stream the response body
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+
+    loop {
+        // Check for stop signal
+        if stop_flag.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        // Poll the stream with a timeout to allow checking stop flag
+        let timeout = smol::Timer::after(Duration::from_millis(100));
+        let next_chunk = stream.next();
+
+        futures::select_biased! {
+            chunk = next_chunk.fuse() => {
+                match chunk {
+                    Some(Ok(bytes)) => {
+                        buffer.push_str(&String::from_utf8_lossy(&bytes));
+                        process_buffer(&mut buffer, entity, cx);
+                    }
+                    Some(Err(e)) => {
+                        return Err(SseError::Stream(e.to_string()));
+                    }
+                    None => {
+                        // Stream ended
+                        return Err(SseError::StreamEnded);
+                    }
+                }
+            }
+            _ = futures::FutureExt::fuse(timeout) => {
+                // Timeout - just continue and check stop flag
+            }
+        }
+    }
+}
+
+/// Process the SSE buffer, extracting complete events.
+fn process_buffer(
+    buffer: &mut String,
+    entity: &WeakEntity<SseClient>,
+    cx: &mut AsyncApp,
+) {
+    // SSE format: "data: <json>\n\n"
+    while let Some(pos) = buffer.find("\n\n") {
+        let message = buffer[..pos].to_string();
+        *buffer = buffer[pos + 2..].to_string();
+
+        // Parse SSE message
+        for line in message.lines() {
+            if let Some(data) = line.strip_prefix("data: ") {
+                match serde_json::from_str::<events::Event>(data) {
+                    Ok(event) => {
+                        debug!(event_type = %event.event_type.as_str(), task = %event.task, "SSE event received");
+                        let _ = entity.update(cx, |client: &mut SseClient, cx| {
+                            client.push_event(event, cx);
+                        });
+                    }
+                    Err(e) => {
+                        warn!(data = %data, error = %e, "Failed to parse SSE event");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// SSE-specific errors.
+#[derive(Debug, thiserror::Error)]
+pub enum SseError {
+    #[error("HTTP request failed: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("HTTP status error: {0}")]
+    HttpStatus(u16),
+    #[error("Stream error: {0}")]
+    Stream(String),
+    #[error("Stream ended unexpectedly")]
+    StreamEnded,
+}
+
+/// URL encoding helper (minimal implementation).
+mod urlencoding {
+    pub fn encode(s: &str) -> String {
+        let mut result = String::with_capacity(s.len() * 3);
+        for c in s.chars() {
+            match c {
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' | '~' => {
+                    result.push(c);
+                }
+                _ => {
+                    for byte in c.to_string().as_bytes() {
+                        result.push_str(&format!("%{:02X}", byte));
+                    }
+                }
+            }
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filters_build_url_no_params() {
+        let filters = SseFilters::new();
+        let url = filters.build_url("http://localhost:4800");
+        assert_eq!(url, "http://localhost:4800/api/events");
+    }
+
+    #[test]
+    fn filters_build_url_with_pattern() {
+        let filters = SseFilters::new().with_pattern("task:*");
+        let url = filters.build_url("http://localhost:4800");
+        assert_eq!(url, "http://localhost:4800/api/events?pattern=task%3A%2A");
+    }
+
+    #[test]
+    fn filters_build_url_with_task_id() {
+        let filters = SseFilters::new().with_task_id("task-123");
+        let url = filters.build_url("http://localhost:4800");
+        assert_eq!(url, "http://localhost:4800/api/events?task_id=task-123");
+    }
+
+    #[test]
+    fn filters_build_url_with_both() {
+        let filters = SseFilters::new()
+            .with_pattern("agent:*")
+            .with_task_id("task-456");
+        let url = filters.build_url("http://localhost:4800");
+        assert!(url.contains("pattern=agent%3A%2A"));
+        assert!(url.contains("task_id=task-456"));
+    }
+
+    #[test]
+    fn urlencoding_basic() {
+        assert_eq!(urlencoding::encode("hello"), "hello");
+        assert_eq!(urlencoding::encode("task:*"), "task%3A%2A");
+        assert_eq!(urlencoding::encode("a b"), "a%20b");
+    }
+}

--- a/crates/desktop/src/sse.rs
+++ b/crates/desktop/src/sse.rs
@@ -5,8 +5,8 @@
 //!
 //! Reference: web/src/hooks/use-app-state.ts
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use futures::{FutureExt, StreamExt};
@@ -359,11 +359,7 @@ async fn connect_and_stream(
 }
 
 /// Process the SSE buffer, extracting complete events.
-fn process_buffer(
-    buffer: &mut String,
-    entity: &WeakEntity<SseClient>,
-    cx: &mut AsyncApp,
-) {
+fn process_buffer(buffer: &mut String, entity: &WeakEntity<SseClient>, cx: &mut AsyncApp) {
     // SSE format: "data: <json>\n\n"
     while let Some(pos) = buffer.find("\n\n") {
         let message = buffer[..pos].to_string();

--- a/crates/desktop/src/theme.rs
+++ b/crates/desktop/src/theme.rs
@@ -7,7 +7,8 @@
 //! - Spacing scale
 //! - Style helpers for common patterns
 
-use gpui::{px, Hsla, Pixels, Rgba};
+use gpui::{Pixels, Rgba, px};
+use models::TaskState;
 
 // =============================================================================
 // Color Palette
@@ -100,65 +101,17 @@ pub mod colors {
     /// Pending state - Tailwind gray-500
     pub const STATE_PENDING: u32 = 0x6b7280;
 
-    // -------------------------------------------------------------------------
-    // Sidebar Colors
-    // -------------------------------------------------------------------------
+    /// Merged/awaiting-merge state - Tailwind purple-600
+    pub const STATE_MERGED: u32 = 0x9333ea;
 
-    /// Sidebar background
-    pub const SIDEBAR_BACKGROUND: u32 = 0x1a1a1a;
-
-    /// Sidebar foreground - muted
-    pub const SIDEBAR_FOREGROUND: u32 = 0xa3a3a3;
-
-    /// Sidebar primary
-    pub const SIDEBAR_PRIMARY: u32 = 0xfafafa;
-
-    /// Sidebar accent
-    pub const SIDEBAR_ACCENT: u32 = 0x3f3f3f;
-
-    /// Sidebar border
-    pub const SIDEBAR_BORDER: u32 = 0x3f3f3f;
-
-    // -------------------------------------------------------------------------
-    // Chart/Data Visualization Colors
-    // -------------------------------------------------------------------------
-
-    /// Chart color 1 - blue
-    pub const CHART_1: u32 = 0x3b82f6;
-
-    /// Chart color 2 - green/teal
-    pub const CHART_2: u32 = 0x22c55e;
-
-    /// Chart color 3 - yellow/orange
-    pub const CHART_3: u32 = 0xeab308;
-
-    /// Chart color 4 - purple
-    pub const CHART_4: u32 = 0xa855f7;
-
-    /// Chart color 5 - red/pink
-    pub const CHART_5: u32 = 0xef4444;
-
-    // -------------------------------------------------------------------------
-    // Hover State Variations
-    // -------------------------------------------------------------------------
-
-    /// Accent hover - slightly lighter than accent
-    pub const ACCENT_HOVER: u32 = 0x4a4a4a;
-
-    /// Card hover background
-    pub const CARD_HOVER: u32 = 0x252525;
+    /// Cancelled state - Tailwind gray-400
+    pub const STATE_CANCELLED: u32 = 0x9ca3af;
 }
 
 /// Convert a hex color to GPUI's Rgba format.
 #[inline]
 pub fn rgb(hex: u32) -> Rgba {
     gpui::rgb(hex)
-}
-
-/// Convert a hex color to GPUI's Hsla format with full opacity.
-#[inline]
-pub fn hsla_from_hex(hex: u32) -> Hsla {
-    gpui::rgb(hex).into()
 }
 
 /// Create a color with custom alpha from a hex value.
@@ -373,9 +326,9 @@ pub mod radius {
 
 /// Style helper traits and extensions for common patterns.
 pub mod style_helpers {
-    use gpui::{div, Div, Styled};
+    use gpui::{Div, Styled, div};
 
-    use super::*;
+    use super::{Pixels, colors, radius, rgb, spacing, typography};
 
     /// Extension trait for applying common styles to elements.
     pub trait StyledExt: Styled + Sized {
@@ -447,8 +400,8 @@ pub mod style_helpers {
         }
     }
 
-    /// Implement StyledExt for Div (the most common element type).
-    impl StyledExt for Div {}
+    /// Blanket impl for any GPUI element that implements `Styled`.
+    impl<T: Styled + Sized> StyledExt for T {}
 
     /// Create a themed container div with standard padding and background.
     pub fn container() -> Div {
@@ -540,6 +493,8 @@ pub struct Theme {
     pub state_question: u32,
     pub state_failed: u32,
     pub state_pending: u32,
+    pub state_merged: u32,
+    pub state_cancelled: u32,
 }
 
 impl Default for Theme {
@@ -572,17 +527,21 @@ impl Theme {
             state_question: colors::STATE_QUESTION,
             state_failed: colors::STATE_FAILED,
             state_pending: colors::STATE_PENDING,
+            state_merged: colors::STATE_MERGED,
+            state_cancelled: colors::STATE_CANCELLED,
         }
     }
 
     /// Get the appropriate state color for a task state.
-    pub fn state_color(&self, state: &str) -> u32 {
+    pub fn state_color(&self, state: &TaskState) -> u32 {
         match state {
-            "running" | "in_progress" => self.state_running,
-            "completed" | "done" | "merged" => self.state_completed,
-            "question" | "waiting" | "blocked" => self.state_question,
-            "failed" | "error" | "rejected" => self.state_failed,
-            _ => self.state_pending,
+            TaskState::Waiting | TaskState::Blocked => self.state_pending,
+            TaskState::Running | TaskState::Testing => self.state_running,
+            TaskState::Question => self.state_question,
+            TaskState::AwaitingMerge => self.state_merged,
+            TaskState::Completed => self.state_completed,
+            TaskState::Failed | TaskState::Conflict => self.state_failed,
+            TaskState::Cancelled => self.state_cancelled,
         }
     }
 }
@@ -603,10 +562,42 @@ mod tests {
     #[test]
     fn test_theme_state_colors() {
         let theme = Theme::dark();
-        assert_eq!(theme.state_color("running"), colors::STATE_RUNNING);
-        assert_eq!(theme.state_color("completed"), colors::STATE_COMPLETED);
-        assert_eq!(theme.state_color("question"), colors::STATE_QUESTION);
-        assert_eq!(theme.state_color("failed"), colors::STATE_FAILED);
-        assert_eq!(theme.state_color("unknown"), colors::STATE_PENDING);
+        assert_eq!(
+            theme.state_color(&TaskState::Running),
+            colors::STATE_RUNNING
+        );
+        assert_eq!(
+            theme.state_color(&TaskState::Testing),
+            colors::STATE_RUNNING
+        );
+        assert_eq!(
+            theme.state_color(&TaskState::Completed),
+            colors::STATE_COMPLETED
+        );
+        assert_eq!(
+            theme.state_color(&TaskState::Question),
+            colors::STATE_QUESTION
+        );
+        assert_eq!(theme.state_color(&TaskState::Failed), colors::STATE_FAILED);
+        assert_eq!(
+            theme.state_color(&TaskState::Conflict),
+            colors::STATE_FAILED
+        );
+        assert_eq!(
+            theme.state_color(&TaskState::Waiting),
+            colors::STATE_PENDING
+        );
+        assert_eq!(
+            theme.state_color(&TaskState::Blocked),
+            colors::STATE_PENDING
+        );
+        assert_eq!(
+            theme.state_color(&TaskState::AwaitingMerge),
+            colors::STATE_MERGED
+        );
+        assert_eq!(
+            theme.state_color(&TaskState::Cancelled),
+            colors::STATE_CANCELLED
+        );
     }
 }

--- a/crates/desktop/src/theme.rs
+++ b/crates/desktop/src/theme.rs
@@ -1,0 +1,612 @@
+//! Theme and styling system for Tasks Desktop.
+//!
+//! This module provides a consistent theming system matching the web frontend's
+//! Tailwind CSS colors and styles. It includes:
+//! - Color palette (semantic colors and state colors)
+//! - Typography scale (font sizes, weights, line heights)
+//! - Spacing scale
+//! - Style helpers for common patterns
+
+use gpui::{px, Hsla, Pixels, Rgba};
+
+// =============================================================================
+// Color Palette
+// =============================================================================
+
+/// Semantic colors matching the web frontend's Tailwind CSS theme.
+/// All colors are defined for dark mode (the default GPUI theme).
+pub mod colors {
+
+    // -------------------------------------------------------------------------
+    // Base Colors (from web/src/index.css oklch values, converted to hex)
+    // -------------------------------------------------------------------------
+
+    /// Background color - very dark, almost black
+    /// oklch(0.145 0 0) ≈ #1a1a1a
+    pub const BACKGROUND: u32 = 0x1a1a1a;
+
+    /// Foreground (text) color - almost white
+    /// oklch(0.985 0 0) ≈ #fafafa
+    pub const FOREGROUND: u32 = 0xfafafa;
+
+    /// Card background color - same as background
+    pub const CARD: u32 = 0x1a1a1a;
+
+    /// Card foreground color
+    pub const CARD_FOREGROUND: u32 = 0xfafafa;
+
+    /// Primary color - white for dark mode
+    pub const PRIMARY: u32 = 0xfafafa;
+
+    /// Primary foreground - dark for contrast
+    /// oklch(0.205 0 0) ≈ #2b2b2b
+    pub const PRIMARY_FOREGROUND: u32 = 0x2b2b2b;
+
+    /// Secondary color - dark gray
+    /// oklch(0.269 0 0) ≈ #3f3f3f
+    pub const SECONDARY: u32 = 0x3f3f3f;
+
+    /// Secondary foreground
+    pub const SECONDARY_FOREGROUND: u32 = 0xfafafa;
+
+    /// Muted color - same as secondary
+    pub const MUTED: u32 = 0x3f3f3f;
+
+    /// Muted foreground - medium gray for secondary text
+    /// oklch(0.708 0 0) ≈ #a3a3a3
+    pub const MUTED_FOREGROUND: u32 = 0xa3a3a3;
+
+    /// Accent color - same as secondary
+    pub const ACCENT: u32 = 0x3f3f3f;
+
+    /// Accent foreground
+    pub const ACCENT_FOREGROUND: u32 = 0xfafafa;
+
+    /// Border color - dark gray
+    /// oklch(0.269 0 0) ≈ #3f3f3f
+    pub const BORDER: u32 = 0x3f3f3f;
+
+    /// Input border color
+    pub const INPUT: u32 = 0x3f3f3f;
+
+    /// Focus ring color
+    /// oklch(0.556 0 0) ≈ #7c7c7c
+    pub const RING: u32 = 0x7c7c7c;
+
+    /// Destructive color - red
+    /// oklch(0.396 0.141 25.723)
+    pub const DESTRUCTIVE: u32 = 0x7f1d1d;
+
+    /// Destructive foreground - lighter red for text
+    /// oklch(0.637 0.237 25.331)
+    pub const DESTRUCTIVE_FOREGROUND: u32 = 0xef4444;
+
+    // -------------------------------------------------------------------------
+    // State Colors (Tailwind colors for task states)
+    // -------------------------------------------------------------------------
+
+    /// Running state - Tailwind blue-600
+    pub const STATE_RUNNING: u32 = 0x2563eb;
+
+    /// Completed state - Tailwind green-600
+    pub const STATE_COMPLETED: u32 = 0x16a34a;
+
+    /// Question/waiting state - Tailwind yellow-600
+    pub const STATE_QUESTION: u32 = 0xca8a04;
+
+    /// Failed state - Tailwind red-600
+    pub const STATE_FAILED: u32 = 0xdc2626;
+
+    /// Pending state - Tailwind gray-500
+    pub const STATE_PENDING: u32 = 0x6b7280;
+
+    // -------------------------------------------------------------------------
+    // Sidebar Colors
+    // -------------------------------------------------------------------------
+
+    /// Sidebar background
+    pub const SIDEBAR_BACKGROUND: u32 = 0x1a1a1a;
+
+    /// Sidebar foreground - muted
+    pub const SIDEBAR_FOREGROUND: u32 = 0xa3a3a3;
+
+    /// Sidebar primary
+    pub const SIDEBAR_PRIMARY: u32 = 0xfafafa;
+
+    /// Sidebar accent
+    pub const SIDEBAR_ACCENT: u32 = 0x3f3f3f;
+
+    /// Sidebar border
+    pub const SIDEBAR_BORDER: u32 = 0x3f3f3f;
+
+    // -------------------------------------------------------------------------
+    // Chart/Data Visualization Colors
+    // -------------------------------------------------------------------------
+
+    /// Chart color 1 - blue
+    pub const CHART_1: u32 = 0x3b82f6;
+
+    /// Chart color 2 - green/teal
+    pub const CHART_2: u32 = 0x22c55e;
+
+    /// Chart color 3 - yellow/orange
+    pub const CHART_3: u32 = 0xeab308;
+
+    /// Chart color 4 - purple
+    pub const CHART_4: u32 = 0xa855f7;
+
+    /// Chart color 5 - red/pink
+    pub const CHART_5: u32 = 0xef4444;
+
+    // -------------------------------------------------------------------------
+    // Hover State Variations
+    // -------------------------------------------------------------------------
+
+    /// Accent hover - slightly lighter than accent
+    pub const ACCENT_HOVER: u32 = 0x4a4a4a;
+
+    /// Card hover background
+    pub const CARD_HOVER: u32 = 0x252525;
+}
+
+/// Convert a hex color to GPUI's Rgba format.
+#[inline]
+pub fn rgb(hex: u32) -> Rgba {
+    gpui::rgb(hex)
+}
+
+/// Convert a hex color to GPUI's Hsla format with full opacity.
+#[inline]
+pub fn hsla_from_hex(hex: u32) -> Hsla {
+    gpui::rgb(hex).into()
+}
+
+/// Create a color with custom alpha from a hex value.
+pub fn rgba(hex: u32, alpha: f32) -> Rgba {
+    let r = ((hex >> 16) & 0xff) as f32 / 255.0;
+    let g = ((hex >> 8) & 0xff) as f32 / 255.0;
+    let b = (hex & 0xff) as f32 / 255.0;
+    Rgba { r, g, b, a: alpha }
+}
+
+// =============================================================================
+// Typography
+// =============================================================================
+
+/// Typography scale matching common web patterns.
+pub mod typography {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Font Sizes (in pixels, matching Tailwind's default scale)
+    // -------------------------------------------------------------------------
+
+    /// Extra small text (12px) - Tailwind text-xs
+    pub const TEXT_XS: Pixels = px(12.0);
+
+    /// Small text (14px) - Tailwind text-sm
+    pub const TEXT_SM: Pixels = px(14.0);
+
+    /// Base text (16px) - Tailwind text-base
+    pub const TEXT_BASE: Pixels = px(16.0);
+
+    /// Large text (18px) - Tailwind text-lg
+    pub const TEXT_LG: Pixels = px(18.0);
+
+    /// Extra large text (20px) - Tailwind text-xl
+    pub const TEXT_XL: Pixels = px(20.0);
+
+    /// 2XL text (24px) - Tailwind text-2xl
+    pub const TEXT_2XL: Pixels = px(24.0);
+
+    /// 3XL text (30px) - Tailwind text-3xl
+    pub const TEXT_3XL: Pixels = px(30.0);
+
+    /// 4XL text (36px) - Tailwind text-4xl
+    pub const TEXT_4XL: Pixels = px(36.0);
+
+    // -------------------------------------------------------------------------
+    // Line Heights (as multipliers)
+    // -------------------------------------------------------------------------
+
+    /// Tight line height (1.25)
+    pub const LINE_HEIGHT_TIGHT: f32 = 1.25;
+
+    /// Snug line height (1.375)
+    pub const LINE_HEIGHT_SNUG: f32 = 1.375;
+
+    /// Normal line height (1.5)
+    pub const LINE_HEIGHT_NORMAL: f32 = 1.5;
+
+    /// Relaxed line height (1.625)
+    pub const LINE_HEIGHT_RELAXED: f32 = 1.625;
+
+    /// Loose line height (2.0)
+    pub const LINE_HEIGHT_LOOSE: f32 = 2.0;
+
+    // -------------------------------------------------------------------------
+    // Font Weights (using GPUI's FontWeight)
+    // -------------------------------------------------------------------------
+
+    pub use gpui::FontWeight;
+
+    /// Thin font weight (100)
+    pub const WEIGHT_THIN: FontWeight = FontWeight::THIN;
+
+    /// Extra light font weight (200)
+    pub const WEIGHT_EXTRA_LIGHT: FontWeight = FontWeight::EXTRA_LIGHT;
+
+    /// Light font weight (300)
+    pub const WEIGHT_LIGHT: FontWeight = FontWeight::LIGHT;
+
+    /// Normal font weight (400)
+    pub const WEIGHT_NORMAL: FontWeight = FontWeight::NORMAL;
+
+    /// Medium font weight (500)
+    pub const WEIGHT_MEDIUM: FontWeight = FontWeight::MEDIUM;
+
+    /// Semibold font weight (600)
+    pub const WEIGHT_SEMIBOLD: FontWeight = FontWeight::SEMIBOLD;
+
+    /// Bold font weight (700)
+    pub const WEIGHT_BOLD: FontWeight = FontWeight::BOLD;
+
+    /// Extra bold font weight (800)
+    pub const WEIGHT_EXTRA_BOLD: FontWeight = FontWeight::EXTRA_BOLD;
+
+    /// Black font weight (900)
+    pub const WEIGHT_BLACK: FontWeight = FontWeight::BLACK;
+}
+
+// =============================================================================
+// Spacing
+// =============================================================================
+
+/// Spacing scale matching Tailwind's default spacing values.
+/// Each unit represents 4px (0.25rem at 16px base).
+pub mod spacing {
+    use super::*;
+
+    /// 0px spacing
+    pub const SPACE_0: Pixels = px(0.0);
+
+    /// 1px spacing
+    pub const SPACE_PX: Pixels = px(1.0);
+
+    /// 2px spacing (0.5 unit)
+    pub const SPACE_0_5: Pixels = px(2.0);
+
+    /// 4px spacing (1 unit) - Tailwind p-1
+    pub const SPACE_1: Pixels = px(4.0);
+
+    /// 6px spacing (1.5 units)
+    pub const SPACE_1_5: Pixels = px(6.0);
+
+    /// 8px spacing (2 units) - Tailwind p-2
+    pub const SPACE_2: Pixels = px(8.0);
+
+    /// 10px spacing (2.5 units)
+    pub const SPACE_2_5: Pixels = px(10.0);
+
+    /// 12px spacing (3 units) - Tailwind p-3
+    pub const SPACE_3: Pixels = px(12.0);
+
+    /// 14px spacing (3.5 units)
+    pub const SPACE_3_5: Pixels = px(14.0);
+
+    /// 16px spacing (4 units) - Tailwind p-4
+    pub const SPACE_4: Pixels = px(16.0);
+
+    /// 20px spacing (5 units) - Tailwind p-5
+    pub const SPACE_5: Pixels = px(20.0);
+
+    /// 24px spacing (6 units) - Tailwind p-6
+    pub const SPACE_6: Pixels = px(24.0);
+
+    /// 28px spacing (7 units) - Tailwind p-7
+    pub const SPACE_7: Pixels = px(28.0);
+
+    /// 32px spacing (8 units) - Tailwind p-8
+    pub const SPACE_8: Pixels = px(32.0);
+
+    /// 36px spacing (9 units) - Tailwind p-9
+    pub const SPACE_9: Pixels = px(36.0);
+
+    /// 40px spacing (10 units) - Tailwind p-10
+    pub const SPACE_10: Pixels = px(40.0);
+
+    /// 44px spacing (11 units) - Tailwind p-11
+    pub const SPACE_11: Pixels = px(44.0);
+
+    /// 48px spacing (12 units) - Tailwind p-12
+    pub const SPACE_12: Pixels = px(48.0);
+
+    /// 56px spacing (14 units) - Tailwind p-14
+    pub const SPACE_14: Pixels = px(56.0);
+
+    /// 64px spacing (16 units) - Tailwind p-16
+    pub const SPACE_16: Pixels = px(64.0);
+
+    /// 80px spacing (20 units) - Tailwind p-20
+    pub const SPACE_20: Pixels = px(80.0);
+
+    /// 96px spacing (24 units) - Tailwind p-24
+    pub const SPACE_24: Pixels = px(96.0);
+}
+
+// =============================================================================
+// Border Radius
+// =============================================================================
+
+/// Border radius values matching Tailwind's scale.
+pub mod radius {
+    use super::*;
+
+    /// No radius
+    pub const NONE: Pixels = px(0.0);
+
+    /// Small radius (4px) - Tailwind rounded-sm
+    pub const SM: Pixels = px(4.0);
+
+    /// Default radius (6px) - Tailwind rounded
+    pub const DEFAULT: Pixels = px(6.0);
+
+    /// Medium radius (8px) - Tailwind rounded-md
+    pub const MD: Pixels = px(8.0);
+
+    /// Large radius (12px) - Tailwind rounded-lg
+    pub const LG: Pixels = px(12.0);
+
+    /// Extra large radius (16px) - Tailwind rounded-xl
+    pub const XL: Pixels = px(16.0);
+
+    /// 2XL radius (24px) - Tailwind rounded-2xl
+    pub const XXL: Pixels = px(24.0);
+
+    /// Full radius (9999px) - Tailwind rounded-full
+    pub const FULL: Pixels = px(9999.0);
+}
+
+// =============================================================================
+// Style Helpers
+// =============================================================================
+
+/// Style helper traits and extensions for common patterns.
+pub mod style_helpers {
+    use gpui::{div, Div, Styled};
+
+    use super::*;
+
+    /// Extension trait for applying common styles to elements.
+    pub trait StyledExt: Styled + Sized {
+        /// Apply background color from the theme.
+        fn bg_theme(self) -> Self {
+            self.bg(rgb(colors::BACKGROUND))
+        }
+
+        /// Apply card background color.
+        fn bg_card(self) -> Self {
+            self.bg(rgb(colors::CARD))
+        }
+
+        /// Apply accent background color.
+        fn bg_accent(self) -> Self {
+            self.bg(rgb(colors::ACCENT))
+        }
+
+        /// Apply muted background color.
+        fn bg_muted(self) -> Self {
+            self.bg(rgb(colors::MUTED))
+        }
+
+        /// Apply primary text color.
+        fn text_primary(self) -> Self {
+            self.text_color(rgb(colors::FOREGROUND))
+        }
+
+        /// Apply muted text color (for secondary text).
+        fn text_muted(self) -> Self {
+            self.text_color(rgb(colors::MUTED_FOREGROUND))
+        }
+
+        /// Apply destructive text color.
+        fn text_destructive(self) -> Self {
+            self.text_color(rgb(colors::DESTRUCTIVE_FOREGROUND))
+        }
+
+        /// Apply border with theme color.
+        fn border_theme(self) -> Self {
+            self.border_color(rgb(colors::BORDER))
+        }
+
+        // State colors
+
+        /// Apply running state color (blue).
+        fn text_running(self) -> Self {
+            self.text_color(rgb(colors::STATE_RUNNING))
+        }
+
+        /// Apply completed state color (green).
+        fn text_completed(self) -> Self {
+            self.text_color(rgb(colors::STATE_COMPLETED))
+        }
+
+        /// Apply question state color (yellow).
+        fn text_question(self) -> Self {
+            self.text_color(rgb(colors::STATE_QUESTION))
+        }
+
+        /// Apply failed state color (red).
+        fn text_failed(self) -> Self {
+            self.text_color(rgb(colors::STATE_FAILED))
+        }
+
+        /// Apply pending state color (gray).
+        fn text_pending(self) -> Self {
+            self.text_color(rgb(colors::STATE_PENDING))
+        }
+    }
+
+    /// Implement StyledExt for Div (the most common element type).
+    impl StyledExt for Div {}
+
+    /// Create a themed container div with standard padding and background.
+    pub fn container() -> Div {
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .bg(rgb(colors::BACKGROUND))
+            .text_color(rgb(colors::FOREGROUND))
+    }
+
+    /// Create a card-style div with standard styling.
+    pub fn card() -> Div {
+        div()
+            .flex()
+            .flex_col()
+            .bg(rgb(colors::CARD))
+            .text_color(rgb(colors::CARD_FOREGROUND))
+            .border_1()
+            .border_color(rgb(colors::BORDER))
+            .rounded(radius::LG)
+            .p(spacing::SPACE_4)
+    }
+
+    /// Create a status indicator dot.
+    pub fn status_dot(color: u32) -> Div {
+        div()
+            .w(spacing::SPACE_3)
+            .h(spacing::SPACE_3)
+            .rounded_full()
+            .bg(rgb(color))
+    }
+
+    /// Create a badge with the given background color.
+    pub fn badge(bg_color: u32) -> Div {
+        div()
+            .px(spacing::SPACE_2)
+            .py(spacing::SPACE_1)
+            .rounded(radius::SM)
+            .bg(rgb(bg_color))
+            .text_color(rgb(colors::FOREGROUND))
+    }
+
+    /// Create a heading with the specified size.
+    pub fn heading(size: Pixels) -> Div {
+        div()
+            .text_size(size)
+            .font_weight(typography::WEIGHT_SEMIBOLD)
+            .text_color(rgb(colors::FOREGROUND))
+    }
+
+    /// Create muted/secondary text.
+    pub fn muted_text() -> Div {
+        div()
+            .text_size(typography::TEXT_SM)
+            .text_color(rgb(colors::MUTED_FOREGROUND))
+    }
+}
+
+// =============================================================================
+// Theme Struct (for future dynamic theming support)
+// =============================================================================
+
+/// A theme configuration that can be used for dynamic theming.
+/// Currently provides the default dark theme, but structured to support
+/// light mode or custom themes in the future.
+#[derive(Clone)]
+pub struct Theme {
+    // Base colors
+    pub background: u32,
+    pub foreground: u32,
+    pub card: u32,
+    pub card_foreground: u32,
+    pub primary: u32,
+    pub primary_foreground: u32,
+    pub secondary: u32,
+    pub secondary_foreground: u32,
+    pub muted: u32,
+    pub muted_foreground: u32,
+    pub accent: u32,
+    pub accent_foreground: u32,
+    pub border: u32,
+    pub destructive: u32,
+    pub destructive_foreground: u32,
+
+    // State colors
+    pub state_running: u32,
+    pub state_completed: u32,
+    pub state_question: u32,
+    pub state_failed: u32,
+    pub state_pending: u32,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self::dark()
+    }
+}
+
+impl Theme {
+    /// Create the default dark theme.
+    pub fn dark() -> Self {
+        Self {
+            background: colors::BACKGROUND,
+            foreground: colors::FOREGROUND,
+            card: colors::CARD,
+            card_foreground: colors::CARD_FOREGROUND,
+            primary: colors::PRIMARY,
+            primary_foreground: colors::PRIMARY_FOREGROUND,
+            secondary: colors::SECONDARY,
+            secondary_foreground: colors::SECONDARY_FOREGROUND,
+            muted: colors::MUTED,
+            muted_foreground: colors::MUTED_FOREGROUND,
+            accent: colors::ACCENT,
+            accent_foreground: colors::ACCENT_FOREGROUND,
+            border: colors::BORDER,
+            destructive: colors::DESTRUCTIVE,
+            destructive_foreground: colors::DESTRUCTIVE_FOREGROUND,
+            state_running: colors::STATE_RUNNING,
+            state_completed: colors::STATE_COMPLETED,
+            state_question: colors::STATE_QUESTION,
+            state_failed: colors::STATE_FAILED,
+            state_pending: colors::STATE_PENDING,
+        }
+    }
+
+    /// Get the appropriate state color for a task state.
+    pub fn state_color(&self, state: &str) -> u32 {
+        match state {
+            "running" | "in_progress" => self.state_running,
+            "completed" | "done" | "merged" => self.state_completed,
+            "question" | "waiting" | "blocked" => self.state_question,
+            "failed" | "error" | "rejected" => self.state_failed,
+            _ => self.state_pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rgba_conversion() {
+        let color = rgba(0xff0000, 0.5);
+        assert!((color.r - 1.0).abs() < 0.001);
+        assert!((color.g - 0.0).abs() < 0.001);
+        assert!((color.b - 0.0).abs() < 0.001);
+        assert!((color.a - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_theme_state_colors() {
+        let theme = Theme::dark();
+        assert_eq!(theme.state_color("running"), colors::STATE_RUNNING);
+        assert_eq!(theme.state_color("completed"), colors::STATE_COMPLETED);
+        assert_eq!(theme.state_color("question"), colors::STATE_QUESTION);
+        assert_eq!(theme.state_color("failed"), colors::STATE_FAILED);
+        assert_eq!(theme.state_color("unknown"), colors::STATE_PENDING);
+    }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive theme module (`crates/desktop/src/theme.rs`) matching the web frontend's Tailwind CSS colors
- Define color palette with semantic colors and task state colors
- Create typography scale with font sizes, weights, and line heights
- Implement spacing scale (4px-based, matching Tailwind)
- Add border radius scale
- Build style helpers (extension traits and factory functions)
- Refactor main.rs to use the new theme system

## Details

### Colors
The color palette matches the web frontend's dark theme (`web/src/index.css`):
- **Base colors**: background, foreground, card, primary, secondary, muted, accent, border, destructive
- **State colors**: running (blue-600), completed (green-600), question (yellow-600), failed (red-600), pending (gray-500)
- **Chart colors**: for data visualization

### Typography
Font sizes and weights matching Tailwind's default scale:
- Sizes: TEXT_XS (12px) through TEXT_4XL (36px)
- Weights: THIN through BLACK
- Line heights: tight, snug, normal, relaxed, loose

### Spacing
4px-based scale matching Tailwind: SPACE_0 through SPACE_24 (96px)

### Style Helpers
- `StyledExt` trait: provides `.bg_theme()`, `.text_muted()`, `.text_running()`, etc.
- Factory functions: `container()`, `card()`, `badge()`, `heading()`, `muted_text()`, `status_dot()`

## Dependencies
This PR merges PR #171 (desktop crate with SSE) as a base, then adds the theme system on top.

## Test plan
- [x] `cargo check -p tasks-desktop` passes
- [ ] Visual review when desktop app is run

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)