### PR TITLE
Diff-aware two-pass PR review for orchestrator

### DIFF
--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -437,6 +437,154 @@ impl GitHubClient {
         Ok(Some(content))
     }
 
+    /// Fetch raw file content at a specific git ref (branch, tag, or SHA).
+    ///
+    /// Like `get_file_content` but targets a specific ref instead of the
+    /// default branch.
+    pub async fn get_file_content_at_ref(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        git_ref: &str,
+    ) -> Result<Option<String>, GitHubError> {
+        self.wait_for_rate_limit().await;
+
+        let url = format!(
+            "{}/repos/{}/{}/contents/{}?ref={}",
+            self.base_url, owner, repo, path, git_ref
+        );
+
+        let response = self
+            .http
+            .get(&url)
+            .header("Accept", "application/vnd.github.raw+json")
+            .send()
+            .await?;
+
+        self.update_rate_limit(&response);
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::FORBIDDEN {
+            if let Some(rl) = self.rate_limit() {
+                if rl.remaining == 0 {
+                    return Err(GitHubError::RateLimited {
+                        reset_at: rl.reset_at,
+                    });
+                }
+            }
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Decode(format!(
+                "unexpected status {status}: {text}"
+            )));
+        }
+
+        let content = response.text().await.map_err(|e| {
+            GitHubError::Decode(format!("failed to read response body: {e}"))
+        })?;
+
+        Ok(Some(content))
+    }
+
+    // -----------------------------------------------------------------------
+    // PR diff (REST API)
+    // -----------------------------------------------------------------------
+
+    /// Maximum diff size to return (100KB). Larger diffs are truncated.
+    const MAX_DIFF_SIZE: usize = 100_000;
+
+    /// Fetch the unified diff for a pull request.
+    ///
+    /// Uses the GitHub REST API with `Accept: application/vnd.github.diff`.
+    /// Large diffs (>100KB) are truncated with a notice appended.
+    pub async fn get_pr_diff(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+    ) -> Result<String, GitHubError> {
+        self.wait_for_rate_limit().await;
+
+        let url = format!(
+            "{}/repos/{}/{}/pulls/{}",
+            self.base_url, owner, repo, number
+        );
+
+        let response = self
+            .http
+            .get(&url)
+            .header("Accept", "application/vnd.github.diff")
+            .send()
+            .await?;
+
+        self.update_rate_limit(&response);
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(GitHubError::NotFound(format!(
+                "{owner}/{repo}#{number}"
+            )));
+        }
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::FORBIDDEN {
+            if let Some(rl) = self.rate_limit() {
+                if rl.remaining == 0 {
+                    return Err(GitHubError::RateLimited {
+                        reset_at: rl.reset_at,
+                    });
+                }
+            }
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Decode(format!(
+                "unexpected status {status}: {text}"
+            )));
+        }
+
+        let content = response.text().await.map_err(|e| {
+            GitHubError::Decode(format!("failed to read response body: {e}"))
+        })?;
+
+        // Truncate large diffs to avoid blowing out LLM context
+        if content.len() > Self::MAX_DIFF_SIZE {
+            let truncated = &content[..Self::MAX_DIFF_SIZE];
+            // Try to cut at a line boundary
+            let cut_at = truncated.rfind('\n').unwrap_or(Self::MAX_DIFF_SIZE);
+            Ok(format!(
+                "{}\n\n[diff truncated — showing {cut_at} of {} bytes]",
+                &content[..cut_at],
+                content.len()
+            ))
+        } else {
+            Ok(content)
+        }
+    }
+
     // -----------------------------------------------------------------------
     // PR merge (spec §7.1)
     // -----------------------------------------------------------------------

--- a/crates/github/tests/client_tests.rs
+++ b/crates/github/tests/client_tests.rs
@@ -2,7 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use serde_json::json;
-use wiremock::matchers::{body_string_contains, header, method, path};
+use wiremock::matchers::{body_string_contains, header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use tasks_github::client::GitHubClient;
@@ -815,4 +815,118 @@ async fn delete_branch_auth_error_on_protected_branch() {
 
     // 403 with remaining rate limit = auth error (protected branch)
     assert!(matches!(result, Err(GitHubError::Auth(_))));
+}
+
+// ---------------------------------------------------------------------------
+// File content at ref tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_file_content_at_ref_sends_ref_param() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/contents/src/main.rs"))
+        .and(query_param("ref", "feature-branch"))
+        .and(header("accept", "application/vnd.github.raw+json"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string("fn main() {}"),
+        )
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let content = client
+        .get_file_content_at_ref("owner", "repo", "src/main.rs", "feature-branch")
+        .await
+        .unwrap();
+
+    assert_eq!(content, Some("fn main() {}".to_string()));
+}
+
+// ---------------------------------------------------------------------------
+// PR diff tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_pr_diff_returns_unified_diff() {
+    let server = MockServer::start().await;
+
+    let diff_body = "\
+diff --git a/src/main.rs b/src/main.rs
+index abc1234..def5678 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,3 +1,4 @@
+ fn main() {
+-    println!(\"old\");
++    println!(\"new\");
++    println!(\"added\");
+ }
+";
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/pulls/10"))
+        .and(header("accept", "application/vnd.github.diff"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(diff_body))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let diff = client.get_pr_diff("owner", "repo", 10).await.unwrap();
+    assert!(diff.contains("@@"));
+    assert!(diff.contains("+    println!(\"new\")"));
+}
+
+#[tokio::test]
+async fn get_pr_diff_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/pulls/999"))
+        .and(header("accept", "application/vnd.github.diff"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let result = client.get_pr_diff("owner", "repo", 999).await;
+    assert!(matches!(result, Err(GitHubError::NotFound(_))));
+}
+
+#[tokio::test]
+async fn get_pr_diff_auth_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/pulls/10"))
+        .and(header("accept", "application/vnd.github.diff"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Bad credentials"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let result = client.get_pr_diff("owner", "repo", 10).await;
+    assert!(matches!(result, Err(GitHubError::Auth(_))));
+}
+
+#[tokio::test]
+async fn get_pr_diff_truncates_large_diffs() {
+    let server = MockServer::start().await;
+
+    // Generate a diff larger than 100KB
+    let large_diff = "a".repeat(150_000);
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/pulls/10"))
+        .and(header("accept", "application/vnd.github.diff"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(&large_diff))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let diff = client.get_pr_diff("owner", "repo", 10).await.unwrap();
+    // Should be truncated to MAX_DIFF_SIZE + truncation notice
+    assert!(diff.len() < 150_000);
+    assert!(diff.contains("[diff truncated"));
 }

--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -8,7 +8,7 @@ use tracing::{info, warn};
 
 use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
-use crate::prompt::{build_evaluation_prompt, parse_pr_url, system_prompt};
+use crate::prompt::{build_evaluation_prompt, build_deep_review_prompt, parse_pr_url, system_prompt};
 use crate::types::{EvaluationContext, QualityEvaluation};
 use models::task::{Task, TaskSource};
 use tasks_agent::{AnthropicProvider, CompletionConfig, CompletionRequest, Message, Provider};
@@ -59,9 +59,8 @@ impl ClaudeOrchestrator {
         self
     }
 
-    /// Parse the LLM response into a QualityEvaluation.
-    fn parse_evaluation_response(&self, text: &str) -> Result<QualityEvaluation, OrchestratorError> {
-        // Try to extract JSON from the response
+    /// Parse the LLM response into a ParsedEvaluation (includes triage fields).
+    fn parse_evaluation_response(&self, text: &str) -> Result<ParsedEvaluation, OrchestratorError> {
         let json_str = extract_json(text).ok_or_else(|| {
             OrchestratorError::Evaluation(format!(
                 "Could not find JSON in response: {}",
@@ -69,15 +68,16 @@ impl ClaudeOrchestrator {
             ))
         })?;
 
-        // Parse the JSON
         let parsed: EvaluationResponse = serde_json::from_str(json_str).map_err(|e| {
             OrchestratorError::Evaluation(format!("Failed to parse evaluation JSON: {}", e))
         })?;
 
-        Ok(QualityEvaluation {
+        Ok(ParsedEvaluation {
             approved: parsed.approved,
+            needs_deeper_review: parsed.needs_deeper_review,
             reasoning: parsed.reasoning,
             feedback: parsed.feedback,
+            files_to_review: parsed.files_to_review,
         })
     }
 }
@@ -86,8 +86,21 @@ impl ClaudeOrchestrator {
 #[derive(Deserialize)]
 struct EvaluationResponse {
     approved: bool,
+    #[serde(default)]
+    needs_deeper_review: bool,
     reasoning: String,
     feedback: Option<String>,
+    #[serde(default)]
+    files_to_review: Option<Vec<String>>,
+}
+
+/// Internal parsed result from the LLM (includes triage fields not in QualityEvaluation).
+struct ParsedEvaluation {
+    approved: bool,
+    needs_deeper_review: bool,
+    reasoning: String,
+    feedback: Option<String>,
+    files_to_review: Option<Vec<String>>,
 }
 
 impl Orchestrator for ClaudeOrchestrator {
@@ -110,7 +123,7 @@ impl Orchestrator for ClaudeOrchestrator {
             ))
         })?;
 
-        // Fetch the PR from GitHub
+        // Fetch the PR metadata from GitHub
         let pr = self
             .github
             .get_pull_request(&owner, &repo, pr_number)
@@ -125,7 +138,19 @@ impl Orchestrator for ClaudeOrchestrator {
             "Fetched PR details"
         );
 
-        // If the task originated from a GitHub issue, fetch it too
+        // Fetch the actual diff
+        let diff = match self.github.get_pr_diff(&owner, &repo, pr_number).await {
+            Ok(d) => {
+                info!(diff_len = d.len(), "Fetched PR diff");
+                Some(d)
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to fetch PR diff, continuing without it");
+                None
+            }
+        };
+
+        // If the task originated from a GitHub issue, fetch it
         let issue = match &context.task.source {
             TaskSource::GithubIssue {
                 owner: issue_owner,
@@ -150,19 +175,87 @@ impl Orchestrator for ClaudeOrchestrator {
             _ => None,
         };
 
-        // Build the prompt
+        // --- Pass 1: Triage with diff ---
         let system = system_prompt();
         let user_prompt = build_evaluation_prompt(
             &pr,
             issue.as_ref(),
             &context.task.title,
             context.task.description.as_deref(),
-            None, // TODO(task-4): pass actual diff for two-pass review
+            diff.as_deref(),
         );
 
-        // Call the LLM
         let config = CompletionConfig::new(&self.model).with_max_tokens(MAX_TOKENS);
         let request = CompletionRequest::new(config, vec![Message::user(user_prompt)])
+            .with_system(system.clone());
+
+        let response = self
+            .provider
+            .complete(request)
+            .await
+            .map_err(OrchestratorError::Agent)?;
+
+        let response_text = response.text();
+        info!(response_len = response_text.len(), "Pass 1 evaluation response");
+
+        let pass1 = self.parse_evaluation_response(&response_text)?;
+
+        // If pass 1 is decisive (no deeper review needed), return immediately
+        if !pass1.needs_deeper_review || pass1.files_to_review.is_none() {
+            info!(
+                approved = pass1.approved,
+                has_feedback = pass1.feedback.is_some(),
+                "Evaluation complete (pass 1 — no deeper review needed)"
+            );
+            return Ok(QualityEvaluation {
+                approved: pass1.approved,
+                reasoning: pass1.reasoning,
+                feedback: pass1.feedback,
+            });
+        }
+
+        // --- Pass 2: Deep review ---
+        let files_requested = pass1.files_to_review.unwrap_or_default();
+        info!(
+            files = ?files_requested,
+            "Pass 1 requested deeper review, fetching files"
+        );
+
+        // Fetch requested files from the PR branch
+        let mut files: Vec<(String, String)> = Vec::new();
+        for file_path in files_requested.iter().take(5) {
+            match self
+                .github
+                .get_file_content_at_ref(&owner, &repo, file_path, &pr.head_ref)
+                .await
+            {
+                Ok(Some(content)) => {
+                    info!(path = %file_path, len = content.len(), "Fetched file for deep review");
+                    files.push((file_path.clone(), content));
+                }
+                Ok(None) => {
+                    info!(path = %file_path, "File not found on PR branch");
+                    files.push((file_path.clone(), "(file not found)".to_string()));
+                }
+                Err(e) => {
+                    warn!(path = %file_path, error = %e, "Failed to fetch file for deep review");
+                    files.push((file_path.clone(), format!("(fetch error: {e})")));
+                }
+            }
+        }
+
+        let deep_prompt = build_deep_review_prompt(
+            &pr,
+            issue.as_ref(),
+            &context.task.title,
+            context.task.description.as_deref(),
+            diff.as_deref().unwrap_or("(no diff available)"),
+            &pass1.reasoning,
+            &files,
+        );
+
+        let config = CompletionConfig::new(&self.model).with_max_tokens(MAX_TOKENS);
+        let request = CompletionRequest::new(config, vec![Message::user(deep_prompt)])
             .with_system(system);
 
         let response = self
@@ -172,21 +265,21 @@ impl Orchestrator for ClaudeOrchestrator {
             .map_err(OrchestratorError::Agent)?;
 
         let response_text = response.text();
-        info!(
-            response_len = response_text.len(),
-            "Received evaluation response from LLM"
-        );
+        info!(response_len = response_text.len(), "Pass 2 evaluation response");
 
-        // Parse the response
-        let evaluation = self.parse_evaluation_response(&response_text)?;
+        let pass2 = self.parse_evaluation_response(&response_text)?;
 
         info!(
-            approved = evaluation.approved,
-            has_feedback = evaluation.feedback.is_some(),
-            "Evaluation complete"
+            approved = pass2.approved,
+            has_feedback = pass2.feedback.is_some(),
+            "Evaluation complete (pass 2 — deep review)"
         );
 
-        Ok(evaluation)
+        Ok(QualityEvaluation {
+            approved: pass2.approved,
+            reasoning: pass2.reasoning,
+            feedback: pass2.feedback,
+        })
     }
 
     async fn feedback(

--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -157,6 +157,7 @@ impl Orchestrator for ClaudeOrchestrator {
             issue.as_ref(),
             &context.task.title,
             context.task.description.as_deref(),
+            None, // TODO(task-4): pass actual diff for two-pass review
         );
 
         // Call the LLM

--- a/crates/orchestrator/src/prompt.rs
+++ b/crates/orchestrator/src/prompt.rs
@@ -12,34 +12,57 @@ use tasks_github::model::{Issue, PullRequest, MergeableState, ReviewDecision};
 pub fn system_prompt() -> String {
     r#"You are a code review orchestrator evaluating whether a pull request is ready to merge.
 
-Your job is to assess merge worthiness based on these criteria (spec §7.3):
+You review the ACTUAL CODE DIFF, not just PR metadata. Do not trust the PR description or any self-reported "test plan" — these are written by the same agent that wrote the code and may be boilerplate.
 
-1. **Issue Alignment**: Does the change address the associated issue as described?
-   - Compare the PR's changes to the issue's requirements
-   - Check if the implementation matches what was requested
-   - Note any missing functionality or scope creep
+## Review process
 
-2. **Test/CI Status**: Do tests pass?
-   - Check the CI status from GitHub
-   - Flag any failing checks or pending workflows
+**Pass 1 — Diff triage:**
+Read the diff carefully. Evaluate:
 
-3. **Merge Conflicts**: Are there conflicts that need resolution?
-   - Check the mergeable state
-   - A PR with conflicts cannot be approved
+1. **Issue alignment**: Does the diff actually address the issue? Not "does the PR description say it does" — do the actual code changes solve the problem?
+2. **Correctness**: Are there obvious bugs, missing error handling, or incomplete changes? For removals: is anything left that depends on the removed code? For additions: does the new code handle edge cases?
+3. **Completeness**: Does the diff cover all aspects of the issue, or are there gaps?
+4. **Conflicts/CI**: Check mergeable state and review status from the metadata.
 
-4. **Project Conventions**: Does the change meet quality standards?
-   - Review decisions from human reviewers
-   - Check if required reviews are present
-   - Note any requested changes
+After reading the diff, decide:
+- If the change is obviously correct and complete → approve or reject immediately
+- If you're unsure or the change is substantial → request deeper review
 
-After analysis, respond with a JSON object in exactly this format:
+**Response format for Pass 1 (JSON):**
 {
   "approved": true|false,
-  "reasoning": "A clear explanation of your decision",
-  "feedback": "Specific feedback for the implementor if rejected, or null if approved"
+  "needs_deeper_review": false,
+  "reasoning": "Explanation based on what you see in the diff",
+  "feedback": "Specific feedback if rejected, or null if approved",
+  "files_to_review": null
 }
 
-Be concise but thorough in your reasoning. If rejecting, provide actionable feedback."#.to_string()
+If you need deeper review:
+{
+  "approved": false,
+  "needs_deeper_review": true,
+  "reasoning": "What concerns you and why you need more context",
+  "feedback": null,
+  "files_to_review": ["path/to/file1.rs", "path/to/file2.rs"]
+}
+
+Request at most 5 files. Pick the ones most relevant to your concern.
+
+**Pass 2 — Deep review (if requested):**
+You'll receive the full content of the files you requested. Now evaluate with full context:
+- Does the change integrate correctly with the surrounding code?
+- Are there callers/dependents of removed or changed code that weren't updated?
+- Is the implementation approach reasonable?
+
+Response format for Pass 2 is the same, but `needs_deeper_review` must be false.
+
+## Key principles
+
+- Do not trust self-reported test plans. The agent saying "I ran cargo build" is not verification.
+- Look at what the diff actually does, not what the PR says it does.
+- For feature removals: check if anything in the diff's context still references the removed feature.
+- For large diffs: if truncated, lean toward requesting deeper review rather than approving blind.
+- Be concise but specific. If rejecting, point to exact lines/hunks in the diff."#.to_string()
 }
 
 /// Build the user prompt with PR and issue context.
@@ -48,6 +71,7 @@ pub fn build_evaluation_prompt(
     issue: Option<&Issue>,
     task_title: &str,
     task_description: Option<&str>,
+    diff: Option<&str>,
 ) -> String {
     let mut prompt = String::new();
 
@@ -80,8 +104,8 @@ pub fn build_evaluation_prompt(
         }
     }
 
-    // PR context
-    prompt.push_str("## Pull Request\n\n");
+    // PR metadata (no body — we don't trust the agent's self-reported description)
+    prompt.push_str("## Pull Request Metadata\n\n");
     prompt.push_str(&format!("**PR #{}: {}**\n\n", pr.number, pr.title));
     prompt.push_str(&format!("- **Branch**: {} -> {}\n", pr.head_ref, pr.base_ref));
     prompt.push_str(&format!("- **Author**: @{}\n", pr.author.login));
@@ -119,14 +143,6 @@ pub fn build_evaluation_prompt(
 
     prompt.push('\n');
 
-    // PR body
-    if let Some(body) = &pr.body {
-        if !body.is_empty() {
-            prompt.push_str("### PR Description\n\n");
-            prompt.push_str(&format!("{}\n\n", truncate_text(body, 2000)));
-        }
-    }
-
     // Reviews
     if !pr.reviews.is_empty() {
         prompt.push_str("### Reviews\n\n");
@@ -145,18 +161,6 @@ pub fn build_evaluation_prompt(
         prompt.push('\n');
     }
 
-    // PR comments
-    if !pr.comments.is_empty() {
-        prompt.push_str("### PR Comments\n\n");
-        for comment in pr.comments.iter().take(5) {
-            prompt.push_str(&format!(
-                "**@{}**: {}\n\n",
-                comment.author.login,
-                truncate_text(&comment.body, 500)
-            ));
-        }
-    }
-
     // Linked issues
     if !pr.linked_issues.is_empty() {
         prompt.push_str("### Linked Issues\n\n");
@@ -169,10 +173,61 @@ pub fn build_evaluation_prompt(
         prompt.push('\n');
     }
 
+    // The diff — this is what the review is actually about
+    if let Some(diff) = diff {
+        prompt.push_str("## Diff\n\n");
+        prompt.push_str("```diff\n");
+        prompt.push_str(diff);
+        if !diff.ends_with('\n') {
+            prompt.push('\n');
+        }
+        prompt.push_str("```\n\n");
+    } else {
+        prompt.push_str("## Diff\n\n");
+        prompt.push_str("**No diff available.** Evaluate based on metadata only, and lean toward requesting deeper review.\n\n");
+    }
+
     prompt.push_str("## Evaluation Request\n\n");
-    prompt.push_str("Based on the above context, evaluate whether this PR is ready to merge. ");
-    prompt.push_str("Consider issue alignment, test status, merge conflicts, and code quality. ");
-    prompt.push_str("Respond with your evaluation in the JSON format specified.");
+    prompt.push_str("Review the diff above against the issue requirements. ");
+    prompt.push_str("Evaluate correctness, completeness, and whether this actually solves the issue. ");
+    prompt.push_str("Respond with your evaluation in the JSON format specified in your instructions.");
+
+    prompt
+}
+
+/// Build the follow-up prompt for pass 2 (deep review).
+///
+/// Includes the original context plus the requested file contents.
+pub fn build_deep_review_prompt(
+    pr: &PullRequest,
+    issue: Option<&Issue>,
+    task_title: &str,
+    task_description: Option<&str>,
+    diff: &str,
+    review_reasoning: &str,
+    files: &[(String, String)],
+) -> String {
+    // Start with the same base prompt
+    let mut prompt = build_evaluation_prompt(pr, issue, task_title, task_description, Some(diff));
+
+    // Add the reviewer's reasoning from pass 1
+    prompt.push_str("\n## Previous Review Notes\n\n");
+    prompt.push_str(review_reasoning);
+    prompt.push_str("\n\n");
+
+    // Add requested file contents
+    prompt.push_str("## Requested Files\n\n");
+    for (path, content) in files {
+        prompt.push_str(&format!("### `{}`\n\n", path));
+        prompt.push_str("```\n");
+        prompt.push_str(&truncate_text(content, 10_000));
+        prompt.push_str("\n```\n\n");
+    }
+
+    prompt.push_str("## Deep Review Request\n\n");
+    prompt.push_str("You now have the file context you requested. ");
+    prompt.push_str("Make your final evaluation — approve or reject. ");
+    prompt.push_str("You cannot request more files. Respond with your evaluation JSON.");
 
     prompt
 }
@@ -329,17 +384,17 @@ mod tests {
     #[test]
     fn test_system_prompt_contains_criteria() {
         let prompt = system_prompt();
-        assert!(prompt.contains("Issue Alignment"));
-        assert!(prompt.contains("Test/CI Status"));
-        assert!(prompt.contains("Merge Conflicts"));
-        assert!(prompt.contains("Project Conventions"));
+        assert!(prompt.contains("Issue alignment"));
+        assert!(prompt.contains("Correctness"));
+        assert!(prompt.contains("Completeness"));
+        assert!(prompt.contains("Conflicts/CI"));
         assert!(prompt.contains("JSON"));
     }
 
     #[test]
     fn test_build_evaluation_prompt_basic() {
         let pr = test_pr();
-        let prompt = build_evaluation_prompt(&pr, None, "Fix auth bug", None);
+        let prompt = build_evaluation_prompt(&pr, None, "Fix auth bug", None, None);
 
         // Should contain task info
         assert!(prompt.contains("Fix auth bug"));
@@ -366,6 +421,7 @@ mod tests {
             Some(&issue),
             "Fix auth bug",
             Some("Fix the timeout issue"),
+            None,
         );
 
         // Should contain issue info
@@ -382,7 +438,7 @@ mod tests {
         let mut pr = test_pr();
         pr.mergeable = Some(MergeableState::Conflicting);
 
-        let prompt = build_evaluation_prompt(&pr, None, "Test", None);
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None);
         assert!(prompt.contains("has conflicts"));
     }
 
@@ -391,17 +447,68 @@ mod tests {
         let mut pr = test_pr();
         pr.review_decision = Some(ReviewDecision::ChangesRequested);
 
-        let prompt = build_evaluation_prompt(&pr, None, "Test", None);
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None);
         assert!(prompt.contains("Changes requested"));
     }
 
     #[test]
     fn test_build_evaluation_prompt_with_reviews() {
         let pr = test_pr();
-        let prompt = build_evaluation_prompt(&pr, None, "Test", None);
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None);
 
         // Should contain review info
         assert!(prompt.contains("@testuser"));
         assert!(prompt.contains("LGTM"));
+    }
+
+    #[test]
+    fn test_system_prompt_is_skeptical() {
+        let prompt = system_prompt();
+        assert!(prompt.contains("diff"));
+        assert!(prompt.contains("Do not trust"));
+        assert!(prompt.contains("needs_deeper_review"));
+    }
+
+    #[test]
+    fn test_build_evaluation_prompt_includes_diff() {
+        let pr = test_pr();
+        let prompt = build_evaluation_prompt(
+            &pr,
+            None,
+            "Fix auth bug",
+            None,
+            Some("diff --git a/src/auth.rs b/src/auth.rs\n-old\n+new"),
+        );
+        assert!(prompt.contains("## Diff"));
+        assert!(prompt.contains("-old"));
+        assert!(prompt.contains("+new"));
+    }
+
+    #[test]
+    fn test_build_evaluation_prompt_no_diff_notes_absence() {
+        let pr = test_pr();
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None);
+        assert!(prompt.contains("No diff available"));
+    }
+
+    #[test]
+    fn test_build_deep_review_prompt() {
+        let pr = test_pr();
+        let files = vec![
+            ("src/auth.rs".to_string(), "fn login() { todo!() }".to_string()),
+        ];
+        let prompt = build_deep_review_prompt(
+            &pr,
+            None,
+            "Fix auth bug",
+            None,
+            "diff content here",
+            "I need to see src/auth.rs to verify the login flow is complete",
+            &files,
+        );
+        assert!(prompt.contains("## Requested Files"));
+        assert!(prompt.contains("src/auth.rs"));
+        assert!(prompt.contains("fn login()"));
+        assert!(prompt.contains("Previous Review Notes"));
     }
 }

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -392,15 +392,31 @@ or drop into a task to give feedback. The mode controls the default flow, not th
 
 ### 7.3 Quality Evaluation
 
-Before approving a merge, the orchestrator evaluates the pull request:
+Before approving a merge, the orchestrator reviews the actual code diff:
 
-- Does the change address the associated issue as described?
-- Do tests pass (CI/testing state)?
-- Are there conflicts that need resolution?
-- Does the change meet project conventions and quality standards?
+**Pass 1 — Diff triage.** The orchestrator fetches the unified diff from GitHub and evaluates it
+against the associated issue. It checks:
 
-If the work isn't ready, the orchestrator rejects the entry. If the PR originated from a task,
-that task may be re-engaged with specific feedback rather than queuing a bad merge.
+- Does the diff actually address the issue? (Not "does the PR description say it does.")
+- Are there obvious correctness issues — missing error handling, incomplete removals, broken
+  dependents?
+- Is the change complete relative to the issue scope?
+- Are there merge conflicts or failing CI checks?
+
+Self-reported "test plans" in PR descriptions are ignored — these are written by the same agent
+that wrote the code and are not verification.
+
+If the change is obviously correct and complete, the orchestrator approves or rejects immediately.
+
+**Pass 2 — Deep review (conditional).** If the diff is substantial, ambiguous, or the orchestrator
+isn't confident the change is correct, it requests up to 5 specific files from the PR branch for
+deeper context. With the full file contents, it evaluates whether the change integrates correctly
+with the surrounding code — checking for broken callers, missed dependents, and incomplete
+migrations.
+
+If the work isn't ready, the orchestrator rejects the entry with specific, actionable feedback
+referencing the actual code. If the PR originated from a task, that task may be re-engaged with
+the feedback rather than queuing a bad merge.
 
 ### 7.4 Conflicts
 


### PR DESCRIPTION
## Summary

- **Fixes the orchestrator rubber-stamping PRs** — it now fetches and reviews the actual code diff instead of trusting PR descriptions and self-reported test plans
- **Two-pass review flow**: Pass 1 triages the diff against the issue. If the change isn't obviously correct, pass 2 fetches up to 5 files from the PR branch for deeper context
- **Also fixes** broken GraphQL queries that referenced non-existent `MARKED_AS_BLOCKED_BY_EVENT` / `UNMARKED_AS_BLOCKED_BY_EVENT` timeline types

### Changes

- `get_pr_diff()` — new GitHub client method fetching unified diffs via REST API (truncates >100KB)
- `get_file_content_at_ref()` — new GitHub client method for fetching files at a specific git ref
- Rewrote evaluation prompt to be skeptical of PR descriptions and focused on actual code changes
- `ClaudeOrchestrator::evaluate()` now does pass 1 (diff triage) → conditional pass 2 (deep file review)
- Updated spec §7.3 to describe the new behavior

## Test plan

- [x] 5 new GitHub client tests (diff fetch, truncation, errors, ref-based file fetch)
- [x] 4 new prompt tests (skeptical system prompt, diff inclusion, deep review prompt)
- [x] All 260 workspace tests pass
- [x] Clean `cargo build`