### PR TITLE
Detect GitHub issue/PR closure and update task state

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -426,6 +426,82 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
 
+            // --- 7a. Check for external closures (spec §11.3) ---
+            //
+            // For each non-terminal task sourced from a GitHub issue/PR, check
+            // if that issue/PR has been closed externally. If so, transition
+            // the task to the appropriate terminal state.
+            //
+            // This runs once per poll cycle, after importing new issues/PRs.
+            let tasks_to_check: Vec<(String, TaskSource)> = {
+                let state = poll_server.state.read().await;
+                server::scheduler::tasks_needing_closure_check(&state.tasks)
+                    .into_iter()
+                    .map(|t| (t.id.clone(), t.source.clone()))
+                    .collect()
+            };
+
+            for (task_id, source) in tasks_to_check {
+                let closure = match &source {
+                    TaskSource::GithubIssue { owner, repo, number } => {
+                        let client = GitHubClient::new(&github_token);
+                        match client.get_issue(owner, repo, *number).await {
+                            Ok(issue) => server::scheduler::check_issue_closure(&issue)
+                                .map(|(state, reason)| (state, reason)),
+                            Err(e) => {
+                                debug!(
+                                    task_id = %task_id,
+                                    owner = %owner,
+                                    repo = %repo,
+                                    number = %number,
+                                    error = %e,
+                                    "failed to fetch issue for closure check"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    TaskSource::GithubPr { owner, repo, number } => {
+                        let client = GitHubClient::new(&github_token);
+                        match client.get_pull_request(owner, repo, *number).await {
+                            Ok(pr) => server::scheduler::check_pr_closure(&pr)
+                                .map(|(state, reason)| (state, reason)),
+                            Err(e) => {
+                                debug!(
+                                    task_id = %task_id,
+                                    owner = %owner,
+                                    repo = %repo,
+                                    number = %number,
+                                    error = %e,
+                                    "failed to fetch PR for closure check"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    TaskSource::Internal => None,
+                };
+
+                if let Some((new_state, reason)) = closure {
+                    info!(
+                        task_id = %task_id,
+                        new_state = ?new_state,
+                        reason = %reason,
+                        "external closure detected, transitioning task"
+                    );
+                    if let Err(e) = poll_server
+                        .set_task_state(&task_id, new_state, Actor::Scheduler)
+                        .await
+                    {
+                        error!(
+                            task_id = %task_id,
+                            error = %e,
+                            "failed to transition task after external closure"
+                        );
+                    }
+                }
+            }
+
             // Emit scheduler tick event
             let event = Event::new(
                 EventType::SystemSchedulerTick,

--- a/crates/server/src/scheduler.rs
+++ b/crates/server/src/scheduler.rs
@@ -1,12 +1,13 @@
-//! Scheduler — spec §3.2, §12.1.
+//! Scheduler — spec §3.2, §11.3, §12.1.
 //!
 //! Discovers work from GitHub and creates tasks.
+//! Detects external closures of tracked issues/PRs (spec §11.3).
 
 use std::collections::HashMap;
 
 use thiserror::Error;
 
-use tasks_github::model::{Issue, PullRequest};
+use tasks_github::model::{Issue, IssueState as GhIssueState, PullRequest, PullRequestState};
 use crate::model::task::{Task, TaskSource, TaskState};
 use crate::workflow::LabelConfig;
 
@@ -14,6 +15,78 @@ use crate::workflow::LabelConfig;
 pub enum SchedulerError {
     #[error("github error: {0}")]
     GitHub(#[from] tasks_github::GitHubError),
+}
+
+/// Represents an externally closed issue or PR that requires a task state transition.
+///
+/// Spec §11.3: "When a GitHub issue is closed externally, the corresponding task
+/// should be cancelled or completed (depending on context)."
+#[derive(Debug, Clone)]
+pub struct ExternalClosure {
+    /// The task ID to transition.
+    pub task_id: String,
+    /// The new state for the task.
+    pub new_state: TaskState,
+    /// Human-readable reason for the closure.
+    pub reason: String,
+}
+
+/// Extract tasks that need external closure checking.
+///
+/// Returns tasks that:
+/// - Are sourced from a GitHub issue or PR
+/// - Are not in a terminal state (Completed, Failed, Cancelled)
+///
+/// The caller should then fetch the current state of each task's source
+/// from GitHub and check if it has been closed.
+pub fn tasks_needing_closure_check(tasks: &HashMap<String, Task>) -> Vec<&Task> {
+    tasks
+        .values()
+        .filter(|t| {
+            // Only check GitHub-sourced tasks
+            !matches!(t.source, TaskSource::Internal)
+            // Skip tasks already in terminal state
+            && !t.state.is_terminal()
+        })
+        .collect()
+}
+
+/// Determine if an issue closure should trigger a task state change.
+///
+/// Returns the new task state if the issue is closed, None if open.
+/// - Closed issues → Cancelled (spec §11.3)
+pub fn check_issue_closure(issue: &Issue) -> Option<(TaskState, String)> {
+    if issue.state == GhIssueState::Closed {
+        let reason = match issue.state_reason {
+            Some(tasks_github::model::IssueStateReason::Completed) => {
+                "issue closed as completed".to_string()
+            }
+            Some(tasks_github::model::IssueStateReason::NotPlanned) => {
+                "issue closed as not planned".to_string()
+            }
+            _ => "issue closed externally".to_string(),
+        };
+        Some((TaskState::Cancelled, reason))
+    } else {
+        None
+    }
+}
+
+/// Determine if a PR closure should trigger a task state change.
+///
+/// Returns the new task state if the PR is closed/merged, None if open.
+/// - Merged PRs → Completed (spec §11.3)
+/// - Closed (not merged) PRs → Cancelled (spec §11.3)
+pub fn check_pr_closure(pr: &PullRequest) -> Option<(TaskState, String)> {
+    match pr.state {
+        PullRequestState::Merged => {
+            Some((TaskState::Completed, "PR merged externally".to_string()))
+        }
+        PullRequestState::Closed => {
+            Some((TaskState::Cancelled, "PR closed without merge".to_string()))
+        }
+        PullRequestState::Open => None,
+    }
 }
 
 /// Convert a GitHub issue into a Task, if it should be imported.
@@ -303,5 +376,137 @@ mod tests {
 
         let task = issue_to_task(&issue, "proj-1", &cfg);
         assert!(task.is_none(), "closed issues should be skipped");
+    }
+
+    // --- External closure detection tests (spec §11.3) ---
+
+    fn make_issue_with_state_reason(
+        number: u64,
+        state: GhIssueState,
+        state_reason: Option<tasks_github::model::IssueStateReason>,
+    ) -> Issue {
+        let mut issue = make_issue(number, vec![], state);
+        issue.state_reason = state_reason;
+        issue
+    }
+
+    #[test]
+    fn tasks_needing_closure_check_filters_terminal_states() {
+        let cfg = LabelConfig::default();
+        let issue = make_issue(1, vec![], GhIssueState::Open);
+        let mut task = issue_to_task(&issue, "proj-1", &cfg).unwrap();
+
+        let mut tasks = HashMap::new();
+
+        // Waiting task should be checked
+        tasks.insert(task.id.clone(), task.clone());
+        assert_eq!(tasks_needing_closure_check(&tasks).len(), 1);
+
+        // Running task should be checked
+        task.state = TaskState::Running;
+        tasks.insert(task.id.clone(), task.clone());
+        assert_eq!(tasks_needing_closure_check(&tasks).len(), 1);
+
+        // Completed task should NOT be checked (terminal)
+        task.state = TaskState::Completed;
+        tasks.insert(task.id.clone(), task.clone());
+        assert_eq!(tasks_needing_closure_check(&tasks).len(), 0);
+
+        // Failed task should NOT be checked (terminal)
+        task.state = TaskState::Failed;
+        tasks.insert(task.id.clone(), task.clone());
+        assert_eq!(tasks_needing_closure_check(&tasks).len(), 0);
+
+        // Cancelled task should NOT be checked (terminal)
+        task.state = TaskState::Cancelled;
+        tasks.insert(task.id.clone(), task.clone());
+        assert_eq!(tasks_needing_closure_check(&tasks).len(), 0);
+    }
+
+    #[test]
+    fn tasks_needing_closure_check_filters_internal_tasks() {
+        let mut task = Task::new(
+            "internal-task-1",
+            TaskSource::Internal,
+            "Internal work",
+            "proj-1",
+        );
+        task.state = TaskState::Running;
+
+        let mut tasks = HashMap::new();
+        tasks.insert(task.id.clone(), task);
+
+        // Internal tasks should NOT be checked
+        assert_eq!(tasks_needing_closure_check(&tasks).len(), 0);
+    }
+
+    #[test]
+    fn check_issue_closure_open_issue() {
+        let issue = make_issue(42, vec![], GhIssueState::Open);
+        assert!(check_issue_closure(&issue).is_none());
+    }
+
+    #[test]
+    fn check_issue_closure_closed_issue() {
+        let issue = make_issue(42, vec![], GhIssueState::Closed);
+        let result = check_issue_closure(&issue);
+        assert!(result.is_some());
+        let (state, reason) = result.unwrap();
+        assert_eq!(state, TaskState::Cancelled);
+        assert!(reason.contains("closed"));
+    }
+
+    #[test]
+    fn check_issue_closure_closed_as_completed() {
+        let issue = make_issue_with_state_reason(
+            42,
+            GhIssueState::Closed,
+            Some(tasks_github::model::IssueStateReason::Completed),
+        );
+        let result = check_issue_closure(&issue);
+        assert!(result.is_some());
+        let (state, reason) = result.unwrap();
+        assert_eq!(state, TaskState::Cancelled);
+        assert!(reason.contains("completed"));
+    }
+
+    #[test]
+    fn check_issue_closure_closed_as_not_planned() {
+        let issue = make_issue_with_state_reason(
+            42,
+            GhIssueState::Closed,
+            Some(tasks_github::model::IssueStateReason::NotPlanned),
+        );
+        let result = check_issue_closure(&issue);
+        assert!(result.is_some());
+        let (state, reason) = result.unwrap();
+        assert_eq!(state, TaskState::Cancelled);
+        assert!(reason.contains("not planned"));
+    }
+
+    #[test]
+    fn check_pr_closure_open_pr() {
+        let pr = make_pr(99, vec![], PullRequestState::Open);
+        assert!(check_pr_closure(&pr).is_none());
+    }
+
+    #[test]
+    fn check_pr_closure_merged_pr() {
+        let pr = make_pr(99, vec![], PullRequestState::Merged);
+        let result = check_pr_closure(&pr);
+        assert!(result.is_some());
+        let (state, reason) = result.unwrap();
+        assert_eq!(state, TaskState::Completed);
+        assert!(reason.contains("merged"));
+    }
+
+    #[test]
+    fn check_pr_closure_closed_without_merge() {
+        let pr = make_pr(99, vec![], PullRequestState::Closed);
+        let result = check_pr_closure(&pr);
+        assert!(result.is_some());
+        let (state, reason) = result.unwrap();
+        assert_eq!(state, TaskState::Cancelled);
+        assert!(reason.contains("closed without merge"));
     }
 }


### PR DESCRIPTION
## Summary

Implements detection of external GitHub issue/PR closures (spec §11.3):

- Adds closure detection logic to the scheduler module (`crates/server/src/scheduler.rs`)
- Integrates closure checking into the poll loop (`crates/app/src/run_loop.rs`)
- During each poll cycle, checks all non-terminal tasks sourced from GitHub
- When an issue/PR is found closed, transitions the task to the appropriate state:
  - **Closed issues** → `Cancelled`
  - **Merged PRs** → `Completed`
  - **Closed PRs** (not merged) → `Cancelled`
- Emits appropriate events (`task:state:cancelled`, `task:state:completed`)
- Includes 9 new unit tests for the closure detection logic

## Test plan

- [x] New unit tests pass (`cargo test --package server scheduler`)
- [x] All existing tests pass (`cargo test`)
- [ ] Manual testing: Create a task from a GitHub issue, close the issue externally, verify task transitions to Cancelled

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)