### PR TITLE
Change default page size to 50 for tasks and merge queue tables

### DIFF
--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -66,6 +66,9 @@ export function MergeQueuePage() {
     columns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    initialState: {
+      pagination: { pageSize: 50 },
+    },
     state: {
       // Hide project column when a specific project is selected
       columnVisibility: selectedProject ? { project: false } : {},

--- a/web/src/pages/tasks/data-table.tsx
+++ b/web/src/pages/tasks/data-table.tsx
@@ -64,6 +64,9 @@ export function DataTable<TData extends Task, TValue>({
   const table = useReactTable({
     data,
     columns,
+    initialState: {
+      pagination: { pageSize: 50 },
+    },
     state: {
       sorting,
       columnFilters,


### PR DESCRIPTION
## Summary

- Sets the default page size to 50 (from 10) for the tasks data table
- Sets the default page size to 50 (from 10) for the merge queue table
- Users can still change the page size using the dropdown (10, 20, 50 options)

Closes #190

## Test plan

- [ ] Open the tasks page and verify it shows 50 rows by default
- [ ] Open the merge queue page and verify it shows 50 rows by default
- [ ] Change page size using the dropdown and verify it works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)