### PR TITLE
Fix pagination reset on SSE events in paginated views

### DIFF
--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import {
+  type PaginationState,
   useReactTable,
   getCoreRowModel,
   getPaginationRowModel,
@@ -45,6 +46,10 @@ function modeBadge(mode: Mode) {
 export function MergeQueuePage() {
   const { snapshot, refreshSnapshot, filteredMergeQueue, selectedProject } = useAppState();
   const [flushing, setFlushing] = useState(false);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
 
   const entries = filteredMergeQueue;
 
@@ -66,10 +71,13 @@ export function MergeQueuePage() {
     columns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    autoResetPageIndex: false,
     state: {
+      pagination,
       // Hide project column when a specific project is selected
       columnVisibility: selectedProject ? { project: false } : {},
     },
+    onPaginationChange: setPagination,
     meta: {
       refreshSnapshot,
       tasks: snapshot?.tasks ?? [],

--- a/web/src/pages/tasks/data-table.tsx
+++ b/web/src/pages/tasks/data-table.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import {
   type ColumnDef,
   type ColumnFiltersState,
+  type PaginationState,
   type SortingState,
   type VisibilityState,
   flexRender,
@@ -45,6 +46,10 @@ export function DataTable<TData extends Task, TValue>({
   ]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [rowSelection, setRowSelection] = useState({});
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
 
   const singleProject = useMemo(() => {
     const projects = new Set(data.map((t) => t.project));
@@ -69,12 +74,15 @@ export function DataTable<TData extends Task, TValue>({
       columnFilters,
       columnVisibility: mergedVisibility,
       rowSelection,
+      pagination,
     },
     enableRowSelection: true,
+    autoResetPageIndex: false,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     onColumnVisibilityChange: setColumnVisibility,
     onRowSelectionChange: setRowSelection,
+    onPaginationChange: setPagination,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),


### PR DESCRIPTION
## Summary

- Pagination state is now explicitly managed in React component state instead of being managed internally by TanStack Table
- Added `autoResetPageIndex: false` to prevent automatic pagination resets when data changes
- Fixed both the Tasks page (DataTable component) and the Merge Queue page

## Problem

When SSE events arrived (especially frequent in dev mode), the snapshot data was refreshed, causing TanStack Table to recreate its internal pagination state and reset to page 0. This made it frustrating to browse paginated data while the app was actively receiving updates.

## Solution

The fix manages pagination state explicitly in React with `useState<PaginationState>()` and passes it to TanStack Table via the `state.pagination` and `onPaginationChange` props. Combined with `autoResetPageIndex: false`, this ensures pagination state survives data updates.

## Test plan

- [ ] Navigate to Tasks page with more than 10 tasks
- [ ] Go to page 2 or 3
- [ ] Trigger an SSE event (or wait in dev mode)
- [ ] Confirm pagination stays on the same page
- [ ] Repeat test for Merge Queue page

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)