### PR TITLE
Detect GitHub issue/PR closure and update task state

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -17,7 +17,7 @@ use server::model::merge_queue::{ConflictInfo, ConflictType, MergeQueueEntry};
 use server::model::task::{TaskSource, TaskState};
 use server::{WorkflowConfigWatcher, RefreshResult};
 use tasks_github::client::GitHubClient;
-use tasks_github::model::{IssueState, MergeableState};
+use tasks_github::model::{IssueState, IssueStateReason, MergeableState, PullRequestState};
 use tasks_github::poller::RepoPoller;
 
 use tasks_orchestrator::{ConflictContext, ConflictResolution, OperatingMode, Orchestrator};
@@ -457,6 +457,145 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                     task_id = %task_id,
                                     "added PR to merge queue"
                                 );
+                            }
+                        }
+
+                        // --- External closure detection (spec §11.3) ---
+                        //
+                        // When a GitHub issue or PR is closed externally, we need to
+                        // transition the corresponding task to an appropriate state.
+
+                        // Detect closed issues and transition tasks to Cancelled/Completed.
+                        for issue in &result.issues {
+                            if issue.state != IssueState::Closed {
+                                continue;
+                            }
+
+                            let source = TaskSource::GithubIssue {
+                                owner: issue.owner.clone(),
+                                repo: issue.repo.clone(),
+                                number: issue.number,
+                            };
+
+                            // Find the task for this issue
+                            if let Some(task_id) = poll_server.task_id_for_source(&source).await {
+                                // Get the task to check its current state
+                                if let Some(task) = poll_server.get_task(&task_id).await {
+                                    // Skip if already terminal
+                                    if task.state.is_terminal() {
+                                        continue;
+                                    }
+
+                                    // Determine target state based on issue state_reason:
+                                    // - Completed → task Completed
+                                    // - NotPlanned or None → task Cancelled
+                                    let new_state = match issue.state_reason {
+                                        Some(IssueStateReason::Completed) => TaskState::Completed,
+                                        _ => TaskState::Cancelled,
+                                    };
+
+                                    info!(
+                                        project = %project_id,
+                                        issue = issue.number,
+                                        task_id = %task_id,
+                                        new_state = ?new_state,
+                                        state_reason = ?issue.state_reason,
+                                        "detected external issue closure, transitioning task"
+                                    );
+
+                                    if let Err(e) = poll_server
+                                        .set_task_state(&task_id, new_state, Actor::Scheduler)
+                                        .await
+                                    {
+                                        warn!(
+                                            task_id = %task_id,
+                                            error = %e,
+                                            "failed to transition task for closed issue"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+
+                        // Detect merged/closed PRs and transition linked tasks.
+                        for pr in &result.pull_requests {
+                            // Only handle closed/merged PRs
+                            if pr.state == PullRequestState::Open {
+                                continue;
+                            }
+
+                            // Find the linked task by branch name
+                            let task_id = match poll_server.find_task_by_branch(&pr.head_ref).await {
+                                Some(id) => id,
+                                None => continue, // No linked task
+                            };
+
+                            // Get the task to check its current state
+                            let task = match poll_server.get_task(&task_id).await {
+                                Some(t) => t,
+                                None => continue,
+                            };
+
+                            // Skip if already terminal
+                            if task.state.is_terminal() {
+                                continue;
+                            }
+
+                            match pr.state {
+                                PullRequestState::Merged => {
+                                    // PR was merged externally → task is Completed
+                                    info!(
+                                        project = %project_id,
+                                        pr = pr.number,
+                                        task_id = %task_id,
+                                        "detected external PR merge, transitioning task to Completed"
+                                    );
+
+                                    if let Err(e) = poll_server
+                                        .set_task_state(&task_id, TaskState::Completed, Actor::Scheduler)
+                                        .await
+                                    {
+                                        warn!(
+                                            task_id = %task_id,
+                                            error = %e,
+                                            "failed to transition task for merged PR"
+                                        );
+                                    }
+                                }
+                                PullRequestState::Closed => {
+                                    // PR was closed without merge.
+                                    // Only cancel if task is in AwaitingMerge state.
+                                    // If task is in other states (Waiting, Running), the PR closure
+                                    // might be part of normal rework — don't cancel.
+                                    if task.state == TaskState::AwaitingMerge {
+                                        info!(
+                                            project = %project_id,
+                                            pr = pr.number,
+                                            task_id = %task_id,
+                                            "detected external PR closure, transitioning task to Cancelled"
+                                        );
+
+                                        if let Err(e) = poll_server
+                                            .set_task_state(&task_id, TaskState::Cancelled, Actor::Scheduler)
+                                            .await
+                                        {
+                                            warn!(
+                                                task_id = %task_id,
+                                                error = %e,
+                                                "failed to transition task for closed PR"
+                                            );
+                                        }
+                                    } else {
+                                        debug!(
+                                            project = %project_id,
+                                            pr = pr.number,
+                                            task_id = %task_id,
+                                            task_state = ?task.state,
+                                            "PR closed but task not in AwaitingMerge, skipping (likely rework)"
+                                        );
+                                    }
+                                }
+                                PullRequestState::Open => unreachable!(), // Already filtered out
                             }
                         }
                     }

--- a/crates/github/src/poller.rs
+++ b/crates/github/src/poller.rs
@@ -123,8 +123,13 @@ impl RepoPoller {
     // -----------------------------------------------------------------------
 
     async fn poll_issues_inner(&self) -> Result<Vec<Issue>, GitHubError> {
+        // Include both Open and Closed states so we can detect external closures.
+        // When an issue is closed, its updated_at changes and we'll see it in the poll.
         let filters = IssueFilters {
-            states: Some(vec![crate::model::IssueState::Open]),
+            states: Some(vec![
+                crate::model::IssueState::Open,
+                crate::model::IssueState::Closed,
+            ]),
             since: self.since,
             ..Default::default()
         };
@@ -134,8 +139,14 @@ impl RepoPoller {
     }
 
     async fn poll_pull_requests_inner(&self) -> Result<Vec<PullRequest>, GitHubError> {
+        // Include all states (Open, Closed, Merged) so we can detect external closures.
+        // When a PR is closed or merged, its updated_at changes and we'll see it in the poll.
         let filters = PullRequestFilters {
-            states: Some(vec![crate::model::PullRequestState::Open]),
+            states: Some(vec![
+                crate::model::PullRequestState::Open,
+                crate::model::PullRequestState::Closed,
+                crate::model::PullRequestState::Merged,
+            ]),
             since: self.since,
         };
         self.client

--- a/crates/github/tests/poller_tests.rs
+++ b/crates/github/tests/poller_tests.rs
@@ -356,3 +356,243 @@ async fn empty_poll_does_not_clear_high_water_mark() {
     // Mark should not have regressed.
     assert_eq!(poller.since(), first_mark);
 }
+
+// ---------------------------------------------------------------------------
+// Closure detection tests (spec §11.3)
+// ---------------------------------------------------------------------------
+
+fn sample_closed_issue(number: u64, updated_at: &str, state_reason: Option<&str>) -> serde_json::Value {
+    json!({
+        "number": number,
+        "id": format!("I_{number}"),
+        "title": format!("Issue {number}"),
+        "body": null,
+        "state": "CLOSED",
+        "stateReason": state_reason,
+        "author": { "login": "alice", "id": "U_alice" },
+        "labels": { "nodes": [] },
+        "assignees": { "nodes": [] },
+        "milestone": null,
+        "comments": {
+            "pageInfo": { "hasNextPage": false, "endCursor": null },
+            "nodes": []
+        },
+        "subIssues": { "nodes": [] },
+        "timelineItems": { "nodes": [] },
+        "createdAt": "2025-01-01T00:00:00Z",
+        "updatedAt": updated_at,
+        "closedAt": updated_at
+    })
+}
+
+fn sample_merged_pr(number: u64, updated_at: &str) -> serde_json::Value {
+    json!({
+        "number": number,
+        "id": format!("PR_{number}"),
+        "title": format!("PR {number}"),
+        "body": null,
+        "state": "MERGED",
+        "headRefName": "branch",
+        "headRefOid": "abc123",
+        "baseRefName": "main",
+        "isDraft": false,
+        "mergeable": "UNKNOWN",
+        "author": { "login": "alice", "id": "U_alice" },
+        "labels": { "nodes": [] },
+        "assignees": { "nodes": [] },
+        "reviewDecision": null,
+        "reviews": {
+            "pageInfo": { "hasNextPage": false, "endCursor": null },
+            "nodes": []
+        },
+        "comments": {
+            "pageInfo": { "hasNextPage": false, "endCursor": null },
+            "nodes": []
+        },
+        "closingIssuesReferences": { "nodes": [] },
+        "createdAt": "2025-01-01T00:00:00Z",
+        "updatedAt": updated_at,
+        "closedAt": updated_at,
+        "mergedAt": updated_at
+    })
+}
+
+fn sample_closed_pr(number: u64, updated_at: &str) -> serde_json::Value {
+    json!({
+        "number": number,
+        "id": format!("PR_{number}"),
+        "title": format!("PR {number}"),
+        "body": null,
+        "state": "CLOSED",
+        "headRefName": "branch",
+        "headRefOid": "abc123",
+        "baseRefName": "main",
+        "isDraft": false,
+        "mergeable": "UNKNOWN",
+        "author": { "login": "alice", "id": "U_alice" },
+        "labels": { "nodes": [] },
+        "assignees": { "nodes": [] },
+        "reviewDecision": null,
+        "reviews": {
+            "pageInfo": { "hasNextPage": false, "endCursor": null },
+            "nodes": []
+        },
+        "comments": {
+            "pageInfo": { "hasNextPage": false, "endCursor": null },
+            "nodes": []
+        },
+        "closingIssuesReferences": { "nodes": [] },
+        "createdAt": "2025-01-01T00:00:00Z",
+        "updatedAt": updated_at,
+        "closedAt": updated_at,
+        "mergedAt": null
+    })
+}
+
+#[tokio::test]
+async fn poll_includes_closed_issues() {
+    // Verify that the poller fetches both open and closed issues
+    // so we can detect external closures (spec §11.3).
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(issue_response(json!([
+                    sample_issue(1, "2025-01-10T00:00:00Z"),
+                    sample_closed_issue(2, "2025-01-11T00:00:00Z", Some("COMPLETED")),
+                    sample_closed_issue(3, "2025-01-12T00:00:00Z", Some("NOT_PLANNED")),
+                ]))),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(pr_response(json!([]))),
+        )
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let mut poller = RepoPoller::new(client, "owner", "repo");
+
+    let result = poller.poll().await.unwrap();
+
+    // Should include both open and closed issues
+    assert_eq!(result.issues.len(), 3);
+
+    // Verify we can distinguish closed issues
+    use tasks_github::model::IssueState;
+    let open_issues: Vec<_> = result.issues.iter()
+        .filter(|i| i.state == IssueState::Open)
+        .collect();
+    let closed_issues: Vec<_> = result.issues.iter()
+        .filter(|i| i.state == IssueState::Closed)
+        .collect();
+
+    assert_eq!(open_issues.len(), 1);
+    assert_eq!(closed_issues.len(), 2);
+}
+
+#[tokio::test]
+async fn poll_includes_merged_prs() {
+    // Verify that the poller fetches merged PRs so we can detect
+    // external merges (spec §11.3).
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(issue_response(json!([]))),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(pr_response(json!([
+                    sample_pr(10, "2025-01-10T00:00:00Z"),
+                    sample_merged_pr(11, "2025-01-11T00:00:00Z"),
+                ]))),
+        )
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let mut poller = RepoPoller::new(client, "owner", "repo");
+
+    let result = poller.poll().await.unwrap();
+
+    // Should include both open and merged PRs
+    assert_eq!(result.pull_requests.len(), 2);
+
+    // Verify we can distinguish merged PRs
+    use tasks_github::model::PullRequestState;
+    let open_prs: Vec<_> = result.pull_requests.iter()
+        .filter(|p| p.state == PullRequestState::Open)
+        .collect();
+    let merged_prs: Vec<_> = result.pull_requests.iter()
+        .filter(|p| p.state == PullRequestState::Merged)
+        .collect();
+
+    assert_eq!(open_prs.len(), 1);
+    assert_eq!(merged_prs.len(), 1);
+}
+
+#[tokio::test]
+async fn poll_includes_closed_prs() {
+    // Verify that the poller fetches closed (not merged) PRs so we can
+    // detect external closures (spec §11.3).
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(issue_response(json!([]))),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(pr_response(json!([
+                    sample_pr(10, "2025-01-10T00:00:00Z"),
+                    sample_closed_pr(11, "2025-01-11T00:00:00Z"),
+                ]))),
+        )
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let mut poller = RepoPoller::new(client, "owner", "repo");
+
+    let result = poller.poll().await.unwrap();
+
+    // Should include both open and closed PRs
+    assert_eq!(result.pull_requests.len(), 2);
+
+    // Verify we can distinguish closed PRs
+    use tasks_github::model::PullRequestState;
+    let open_prs: Vec<_> = result.pull_requests.iter()
+        .filter(|p| p.state == PullRequestState::Open)
+        .collect();
+    let closed_prs: Vec<_> = result.pull_requests.iter()
+        .filter(|p| p.state == PullRequestState::Closed)
+        .collect();
+
+    assert_eq!(open_prs.len(), 1);
+    assert_eq!(closed_prs.len(), 1);
+}


### PR DESCRIPTION
## Summary

Per spec §11.3 (Issue Tracker Integration), implements detection of external GitHub issue/PR closures and transitions the corresponding tasks to appropriate states.

- Modified `RepoPoller` to fetch both open and closed issues/PRs (previously only fetched open items)
- Added closure detection logic to the poll loop
- For closed issues: transitions task to `Cancelled` (or `Completed` if issue's state_reason is "Completed")
- For merged PRs: transitions linked task to `Completed`
- For closed (not merged) PRs: transitions linked task to `Cancelled` only if task is in `AwaitingMerge` state (to avoid cancelling tasks during rework)
- Added tests for closure detection in the poller

## Test plan

- [x] Poller tests pass with new closure detection tests
- [x] All existing tests continue to pass
- [x] Build succeeds

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)