### PR TITLE
Fix pagination reset when SSE events arrive

### DIFF
--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import {
+  type PaginationState,
   useReactTable,
   getCoreRowModel,
   getPaginationRowModel,
@@ -45,6 +46,10 @@ function modeBadge(mode: Mode) {
 export function MergeQueuePage() {
   const { snapshot, refreshSnapshot, filteredMergeQueue, selectedProject } = useAppState();
   const [flushing, setFlushing] = useState(false);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 50,
+  });
 
   const entries = filteredMergeQueue;
 
@@ -66,13 +71,13 @@ export function MergeQueuePage() {
     columns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    initialState: {
-      pagination: { pageSize: 50 },
-    },
     state: {
+      pagination,
       // Hide project column when a specific project is selected
       columnVisibility: selectedProject ? { project: false } : {},
     },
+    autoResetPageIndex: false,
+    onPaginationChange: setPagination,
     meta: {
       refreshSnapshot,
       tasks: snapshot?.tasks ?? [],

--- a/web/src/pages/tasks/data-table.tsx
+++ b/web/src/pages/tasks/data-table.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import {
   type ColumnDef,
   type ColumnFiltersState,
+  type PaginationState,
   type SortingState,
   type VisibilityState,
   flexRender,
@@ -45,6 +46,10 @@ export function DataTable<TData extends Task, TValue>({
   ]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [rowSelection, setRowSelection] = useState({});
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 50,
+  });
 
   const singleProject = useMemo(() => {
     const projects = new Set(data.map((t) => t.project));
@@ -64,20 +69,20 @@ export function DataTable<TData extends Task, TValue>({
   const table = useReactTable({
     data,
     columns,
-    initialState: {
-      pagination: { pageSize: 50 },
-    },
     state: {
       sorting,
       columnFilters,
       columnVisibility: mergedVisibility,
       rowSelection,
+      pagination,
     },
     enableRowSelection: true,
+    autoResetPageIndex: false,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     onColumnVisibilityChange: setColumnVisibility,
     onRowSelectionChange: setRowSelection,
+    onPaginationChange: setPagination,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),


### PR DESCRIPTION
## Summary
- Fixes pagination state being reset to page 1 when SSE events trigger data refreshes
- Uses controlled pagination state with `useState` instead of TanStack Table's `initialState`
- Sets `autoResetPageIndex: false` to prevent automatic resets when data changes

## Root Cause
When SSE events arrived, they triggered `refreshSnapshot()` which updated the global app state. This caused `filteredTasks` and `filteredMergeQueue` to be recalculated with new array references. TanStack Table's default behavior resets pagination state when the data prop changes, causing the view to jump back to page 1.

## Changes
- `web/src/pages/tasks/data-table.tsx`: Add controlled pagination state with `autoResetPageIndex: false`
- `web/src/pages/merge-queue/page.tsx`: Same fix for the merge queue table

## Test plan
- [ ] Navigate to Tasks page with >50 tasks, go to page 2+
- [ ] Wait for SSE events to arrive (or trigger them by making changes)
- [ ] Verify page stays on current page instead of resetting to page 1
- [ ] Same test for Merge Queue page

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)