### PR TITLE
Remove redundant UI elements and reduce visual clutter

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -1,14 +1,5 @@
 import { NavLink, Outlet } from "react-router-dom";
-import {
-  ListTodo,
-  GitMerge,
-  Radio,
-  MonitorDot,
-  Clock,
-  CircleHelp,
-  Layers,
-  Brain,
-} from "lucide-react";
+import { ListTodo, GitMerge, Radio, Brain } from "lucide-react";
 import { useAppState } from "@/hooks/use-app-state";
 import { ModeControl } from "@/components/mode-control";
 import { ProjectSwitcher } from "@/components/project-switcher";
@@ -22,45 +13,25 @@ const navItems = [
 ];
 
 export function Layout() {
-  const { snapshot, connected, filteredTasks, filteredMergeQueue } = useAppState();
-
-  const runningCount = filteredTasks.filter((t) => t.state === "running").length;
-  const waitingCount = filteredTasks.filter((t) => t.state === "waiting").length;
-  const questionCount = filteredTasks.filter((t) => t.state === "question").length;
-  const mergeQueueCount = filteredMergeQueue.length;
-  const slotActive = snapshot?.slot_utilization?.active ?? 0;
-  const slotMax = snapshot?.slot_utilization?.max ?? 0;
+  const { connected } = useAppState();
 
   return (
     <div className="flex h-screen bg-background text-foreground">
       {/* Sidebar */}
-      <aside className="flex w-60 flex-col border-r border-border bg-background">
-        {/* App title */}
-        <div className="border-b border-border px-4 py-4">
+      <aside className="flex w-52 flex-col border-r border-border bg-background">
+        {/* Header: title + mode control */}
+        <div className="flex items-center justify-between border-b border-border px-3 py-3">
           <h1 className="text-base font-bold tracking-tight">Tasks</h1>
-        </div>
-
-        {/* Project switcher */}
-        <div className="border-b border-border px-3 py-3">
-          <ProjectSwitcher />
-        </div>
-
-        {/* Mode control */}
-        <div className="border-b border-border px-4 py-3">
           <ModeControl />
         </div>
 
-        {/* Status section */}
-        <div className="border-b border-border px-4 py-3 space-y-1.5 text-sm">
-          <StatusRow icon={MonitorDot} label="Sessions" value={`${slotActive}/${slotMax}`} />
-          <StatusRow icon={Layers} label="Running" value={runningCount} />
-          <StatusRow icon={Clock} label="Waiting" value={waitingCount} />
-          <StatusRow icon={CircleHelp} label="Questions" value={questionCount} />
-          <StatusRow icon={GitMerge} label="Merge Queue" value={mergeQueueCount} />
+        {/* Project switcher */}
+        <div className="border-b border-border px-3 py-2">
+          <ProjectSwitcher />
         </div>
 
         {/* Navigation */}
-        <nav className="flex-1 px-2 py-3 space-y-0.5">
+        <nav className="flex-1 px-2 py-2 space-y-0.5">
           {navItems.map(({ to, label, icon: Icon }) => (
             <NavLink
               key={to}
@@ -82,11 +53,11 @@ export function Layout() {
         </nav>
 
         {/* Connection status */}
-        <div className="border-t border-border px-4 py-3 text-sm text-muted-foreground">
-          <div className="flex items-center gap-2">
+        <div className="border-t border-border px-3 py-2 text-xs text-muted-foreground">
+          <div className="flex items-center gap-1.5">
             <span
               className={cn(
-                "inline-block h-2 w-2 rounded-full",
+                "inline-block h-1.5 w-1.5 rounded-full",
                 connected ? "bg-green-500" : "bg-red-500"
               )}
             />
@@ -103,22 +74,3 @@ export function Layout() {
   );
 }
 
-function StatusRow({
-  icon: Icon,
-  label,
-  value,
-}: {
-  icon: typeof MonitorDot;
-  label: string;
-  value: string | number;
-}) {
-  return (
-    <div className="flex items-center justify-between text-muted-foreground">
-      <span className="flex items-center gap-2">
-        <Icon className="h-3.5 w-3.5" />
-        {label}
-      </span>
-      <span className="font-mono text-foreground">{value}</span>
-    </div>
-  );
-}

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -7,8 +7,6 @@ import {
 } from "@tanstack/react-table";
 import { useAppState } from "@/hooks/use-app-state";
 import { flushMergeQueue } from "@/lib/api";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -19,24 +17,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { columns } from "./columns";
-import type { Mode } from "@/lib/types";
-
-// ---------------------------------------------------------------------------
-// Mode badge
-// ---------------------------------------------------------------------------
-
-function modeBadge(mode: Mode) {
-  switch (mode) {
-    case "play":
-      return <Badge className="bg-green-600 text-white">Play</Badge>;
-    case "pause":
-      return <Badge className="bg-yellow-600 text-white">Pause</Badge>;
-    case "stop":
-      return <Badge className="bg-red-600 text-white">Stop</Badge>;
-    default:
-      return <Badge variant="outline">{mode}</Badge>;
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Merge Queue Page
@@ -53,13 +33,7 @@ export function MergeQueuePage() {
     [entries],
   );
 
-  const mode = snapshot?.mode;
-  const isPaused = mode === "pause";
-
-  // Find the selected project name for display
-  const selectedProjectName = selectedProject
-    ? snapshot?.projects.find((p) => p.id === selectedProject)?.repo
-    : null;
+  const isPaused = snapshot?.mode === "pause";
 
   const table = useReactTable({
     data: entries,
@@ -107,45 +81,27 @@ export function MergeQueuePage() {
   // -------------------------------------------------------------------------
 
   return (
-    <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-3">
-            <h1 className="text-base font-bold">Merge Queue</h1>
-            {mode && modeBadge(mode)}
-          </div>
-          {selectedProjectName && (
-            <p className="text-sm text-muted-foreground">
-              Showing entries for {selectedProjectName}
-            </p>
+    <div className="p-4">
+      {/* Toolbar */}
+      {isPaused && (
+        <div className="flex items-center justify-end gap-3 mb-4">
+          {approvedCount > 0 && (
+            <span className="text-sm text-muted-foreground">
+              {approvedCount} approved
+            </span>
           )}
+          <Button
+            size="sm"
+            onClick={handleFlush}
+            disabled={flushing || approvedCount === 0}
+          >
+            {flushing ? "Flushing..." : "Flush Queue"}
+          </Button>
         </div>
-        {isPaused && (
-          <div className="flex items-center gap-3">
-            {approvedCount > 0 && (
-              <span className="text-sm text-muted-foreground">
-                {approvedCount} approved {approvedCount === 1 ? "entry" : "entries"} ready to flush
-              </span>
-            )}
-            <Button
-              onClick={handleFlush}
-              disabled={flushing || approvedCount === 0}
-            >
-              {flushing ? "Flushing..." : "Flush Queue"}
-            </Button>
-          </div>
-        )}
-      </div>
+      )}
 
       {/* Table */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-sm font-medium text-muted-foreground">
-            {entries.length} {entries.length === 1 ? "entry" : "entries"}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
+      <div className="rounded-md border">
           {entries.length === 0 ? (
             <p className="text-sm text-muted-foreground py-8 text-center">
               No entries in the merge queue.
@@ -189,7 +145,7 @@ export function MergeQueuePage() {
 
               {/* Pagination */}
               {table.getPageCount() > 1 && (
-                <div className="flex items-center justify-between pt-4">
+                <div className="flex items-center justify-between px-4 py-3 border-t">
                   <span className="text-sm text-muted-foreground">
                     Page {table.getState().pagination.pageIndex + 1} of{" "}
                     {table.getPageCount()}
@@ -216,8 +172,7 @@ export function MergeQueuePage() {
               )}
             </>
           )}
-        </CardContent>
-      </Card>
+      </div>
     </div>
   );
 }

--- a/web/src/pages/orchestrator/page.tsx
+++ b/web/src/pages/orchestrator/page.tsx
@@ -437,16 +437,7 @@ export function OrchestratorPage() {
   }
 
   return (
-    <div className="flex flex-col h-full p-6 gap-4">
-      {/* Header */}
-      <div className="shrink-0">
-        <h1 className="text-xl font-bold">Orchestrator</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          View orchestrator activity and send commands
-        </p>
-      </div>
-
-      {/* Orchestrator view */}
+    <div className="flex flex-col h-full p-4">
       <OrchestratorView />
     </div>
   );

--- a/web/src/pages/tasks/page.tsx
+++ b/web/src/pages/tasks/page.tsx
@@ -7,11 +7,6 @@ export function TasksPage() {
   const { filteredTasks, selectedProject, snapshot } = useAppState();
   const projects = snapshot?.projects ?? [];
 
-  // Find the selected project name for display
-  const selectedProjectName = selectedProject
-    ? snapshot?.projects.find((p) => p.id === selectedProject)?.repo
-    : null;
-
   // Create a map from project ID to repo name for display
   const projectIdToRepo = useMemo(() => {
     const map: Record<string, string> = {};
@@ -22,15 +17,7 @@ export function TasksPage() {
   }, [projects]);
 
   return (
-    <div className="flex flex-1 flex-col gap-4 p-4 md:p-8">
-      <div>
-        <h2 className="text-base font-bold tracking-tight">Tasks</h2>
-        <p className="text-muted-foreground">
-          {selectedProjectName
-            ? `Tasks for ${selectedProjectName}`
-            : "Manage and monitor your coding tasks."}
-        </p>
-      </div>
+    <div className="flex flex-1 flex-col p-4">
       <DataTable columns={columns} data={filteredTasks} hideProjectColumn={!!selectedProject} projectIdToRepo={projectIdToRepo} />
     </div>
   );


### PR DESCRIPTION
## Summary

- Remove status section from sidebar (Sessions/Running/Waiting/Questions/Merge Queue counts are already visible on their respective pages)
- Consolidate sidebar header by combining title and mode control into a single row
- Remove page headers on Tasks, Merge Queue, and Orchestrator pages (navigation already indicates the current view)
- Reduce padding from p-6/p-8 to consistent p-4 across all pages
- Narrow sidebar from w-60 (240px) to w-52 (208px)
- Remove unused imports (Card, Badge, Mode type, unused lucide icons)

Net effect: **-115 lines** while preserving all functionality.

## Test plan

- [ ] Verify sidebar displays correctly with combined title + mode control
- [ ] Verify project switcher still works
- [ ] Verify navigation between pages works
- [ ] Verify Tasks page table renders correctly
- [ ] Verify Merge Queue page functions (including flush button in pause mode)
- [ ] Verify Orchestrator page chat interface works
- [ ] Verify Events page displays correctly
- [ ] Verify responsive behavior at different window sizes

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)