### PR TITLE
Detect GitHub issue/PR closure and update task state

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -17,7 +17,7 @@ use server::model::merge_queue::MergeQueueEntry;
 use server::model::task::{TaskSource, TaskState};
 use server::{WorkflowConfigWatcher, RefreshResult};
 use tasks_github::client::GitHubClient;
-use tasks_github::model::IssueState;
+use tasks_github::model::{IssueState, PullRequestState};
 use tasks_github::poller::RepoPoller;
 
 use tasks_orchestrator::Orchestrator;
@@ -417,6 +417,109 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                     task_id = %task_id,
                                     "added PR to merge queue"
                                 );
+                            }
+                        }
+
+                        // --- Detect external closures (spec §11.3) ---
+                        //
+                        // When a GitHub issue or PR is closed externally, transition the
+                        // corresponding task to a terminal state:
+                        // - Closed issue → Cancelled
+                        // - Merged PR → Completed
+                        // - Closed (not merged) PR → Cancelled
+                        //
+                        // Skip if:
+                        // - Task is already in a terminal state
+                        // - Task is Running (agent may have closed PR for rework)
+
+                        // Check closed issues
+                        for issue in &result.issues {
+                            if issue.state != IssueState::Closed {
+                                continue;
+                            }
+
+                            let source = TaskSource::GithubIssue {
+                                owner: issue.owner.clone(),
+                                repo: issue.repo.clone(),
+                                number: issue.number,
+                            };
+
+                            if let Some(task) = poll_server.get_task_for_source(&source).await {
+                                // Skip if already terminal or actively running
+                                if task.state.is_terminal() || task.state == TaskState::Running {
+                                    continue;
+                                }
+
+                                info!(
+                                    project = %project_id,
+                                    issue = issue.number,
+                                    task_id = %task.id,
+                                    "issue closed externally, cancelling task"
+                                );
+
+                                if let Err(e) = poll_server
+                                    .set_task_state(&task.id, TaskState::Cancelled, Actor::Scheduler)
+                                    .await
+                                {
+                                    error!(
+                                        task_id = %task.id,
+                                        error = %e,
+                                        "failed to cancel task for closed issue"
+                                    );
+                                }
+                            }
+                        }
+
+                        // Check closed/merged PRs
+                        for pr in &result.pull_requests {
+                            let new_state = match pr.state {
+                                PullRequestState::Merged => Some(TaskState::Completed),
+                                PullRequestState::Closed => Some(TaskState::Cancelled),
+                                PullRequestState::Open => None,
+                            };
+
+                            let Some(target_state) = new_state else {
+                                continue;
+                            };
+
+                            let source = TaskSource::GithubPr {
+                                owner: pr.owner.clone(),
+                                repo: pr.repo.clone(),
+                                number: pr.number,
+                            };
+
+                            if let Some(task) = poll_server.get_task_for_source(&source).await {
+                                // Skip if already terminal or actively running
+                                if task.state.is_terminal() || task.state == TaskState::Running {
+                                    continue;
+                                }
+
+                                let action = if target_state == TaskState::Completed {
+                                    "merged"
+                                } else {
+                                    "closed"
+                                };
+
+                                info!(
+                                    project = %project_id,
+                                    pr = pr.number,
+                                    task_id = %task.id,
+                                    "PR {} externally, transitioning task to {:?}",
+                                    action,
+                                    target_state
+                                );
+
+                                if let Err(e) = poll_server
+                                    .set_task_state(&task.id, target_state, Actor::Scheduler)
+                                    .await
+                                {
+                                    error!(
+                                        task_id = %task.id,
+                                        error = %e,
+                                        "failed to update task for {} PR",
+                                        action
+                                    );
+                                }
                             }
                         }
                     }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -379,6 +379,16 @@ impl Server {
             .map(|t| t.id.clone())
     }
 
+    /// Find a task by its GitHub source, if one exists.
+    ///
+    /// Returns the full task object for state inspection.
+    pub async fn get_task_for_source(&self, source: &TaskSource) -> Option<Task> {
+        let state = self.state.read().await;
+        state.tasks.values()
+            .find(|t| t.source == *source)
+            .cloned()
+    }
+
     /// Check if a PR URL is already in the merge queue.
     pub async fn has_merge_entry_for_pr(&self, pr_url: &str) -> bool {
         let state = self.state.read().await;
@@ -1821,5 +1831,81 @@ mod tests {
             .find_task_by_branch("tasks/gh-owner-repo-issue-123--abcd1234")
             .await;
         assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn get_task_for_source_returns_task_when_exists() {
+        let server = test_server().await;
+
+        // Add project
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+
+        // Add task with GitHub issue source
+        let source = TaskSource::GithubIssue {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            number: 42,
+        };
+        let task = Task::new("gh-owner-repo-issue-42", source.clone(), "Test issue", "proj-1");
+        server.add_task(task).await.unwrap();
+
+        // Should find the task
+        let found = server.get_task_for_source(&source).await;
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.id, "gh-owner-repo-issue-42");
+        assert_eq!(found.source, source);
+    }
+
+    #[tokio::test]
+    async fn get_task_for_source_returns_none_when_not_exists() {
+        let server = test_server().await;
+
+        // Add project
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+
+        // Query for non-existent source
+        let source = TaskSource::GithubIssue {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            number: 999,
+        };
+
+        let found = server.get_task_for_source(&source).await;
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_task_for_source_distinguishes_pr_from_issue() {
+        let server = test_server().await;
+
+        // Add project
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+
+        // Add task with GitHub issue source
+        let issue_source = TaskSource::GithubIssue {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            number: 42,
+        };
+        let task = Task::new("gh-owner-repo-issue-42", issue_source.clone(), "Issue task", "proj-1");
+        server.add_task(task).await.unwrap();
+
+        // Query for PR with same number should not match
+        let pr_source = TaskSource::GithubPr {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            number: 42,
+        };
+
+        let found = server.get_task_for_source(&pr_source).await;
+        assert!(found.is_none());
+
+        // Issue source should still match
+        let found = server.get_task_for_source(&issue_source).await;
+        assert!(found.is_some());
     }
 }


### PR DESCRIPTION
## Summary

Per spec §11.3, when a GitHub issue or PR is closed externally (by human or other tooling), the corresponding task should be transitioned to an appropriate state:

- Closed issue → `Cancelled`
- Merged PR → `Completed`
- Closed (not merged) PR → `Cancelled`

## Implementation

- Adds closure detection in the GitHub poll loop (in `run_loop.rs`) after processing new issues/PRs
- Adds `get_task_for_source()` method to `Server` to find tasks by their GitHub source
- Skips tasks already in terminal states (Completed/Failed/Cancelled)
- Skips tasks in Running state to avoid cancelling tasks where the agent closed a PR for rework

## Test plan

- [x] Added unit tests for `get_task_for_source()` method (3 tests)
- [x] All existing tests pass (`cargo test --package server` - 94 tests)
- [x] All app tests pass (`cargo test --package tasks-app` - 9 tests)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)