### PR TITLE
Rename 'Awaiting Merge' status to 'Changes Submitted'

### DIFF
--- a/crates/desktop/src/api.rs
+++ b/crates/desktop/src/api.rs
@@ -31,7 +31,7 @@ pub fn task_state_display_name(state: &TaskState) -> &'static str {
         TaskState::Running => "Running",
         TaskState::Question => "Question",
         TaskState::Testing => "Testing",
-        TaskState::AwaitingMerge => "Awaiting Merge",
+        TaskState::AwaitingMerge => "Changes Submitted",
         TaskState::Conflict => "Conflict",
         TaskState::Completed => "Completed",
         TaskState::Failed => "Failed",
@@ -42,8 +42,8 @@ pub fn task_state_display_name(state: &TaskState) -> &'static str {
 /// Whether the task is actively consuming an agent slot.
 ///
 /// Matches the server definition: Running, Question, Testing.
-/// AwaitingMerge is NOT active — the agent has finished and the PR
-/// is waiting in the merge queue.
+/// "Changes Submitted" (AwaitingMerge state) is NOT active — the agent
+/// has finished and the PR is waiting in the merge queue.
 pub fn task_state_is_active(state: &TaskState) -> bool {
     matches!(
         state,
@@ -386,7 +386,7 @@ mod tests {
         assert_eq!(task_state_display_name(&TaskState::Running), "Running");
         assert_eq!(
             task_state_display_name(&TaskState::AwaitingMerge),
-            "Awaiting Merge"
+            "Changes Submitted"
         );
     }
 

--- a/crates/desktop/src/state.rs
+++ b/crates/desktop/src/state.rs
@@ -286,8 +286,9 @@ impl AppState {
 
     /// Get active tasks (Running, Question, Testing).
     ///
-    /// AwaitingMerge is NOT active — it means the agent has finished and the PR
-    /// is waiting in the merge queue. This matches the server definition.
+    /// "Changes Submitted" (AwaitingMerge state) is NOT active — it means the
+    /// agent has finished and the PR is waiting in the merge queue. This
+    /// matches the server definition.
     pub fn active_tasks(&self) -> Vec<&Task> {
         self.filtered_tasks()
             .into_iter()

--- a/crates/desktop/src/views/dashboard.rs
+++ b/crates/desktop/src/views/dashboard.rs
@@ -244,7 +244,7 @@ fn task_state_badge(state: TaskState, theme: &ComponentTheme) -> Badge {
         TaskState::Running => ("running", BadgeVariant::Default),
         TaskState::Question => ("question", BadgeVariant::Secondary),
         TaskState::Testing => ("testing", BadgeVariant::Outline),
-        TaskState::AwaitingMerge => ("awaiting merge", BadgeVariant::Secondary),
+        TaskState::AwaitingMerge => ("changes submitted", BadgeVariant::Secondary),
         TaskState::Completed => ("completed", BadgeVariant::Default),
         TaskState::Failed => ("failed", BadgeVariant::Destructive),
         TaskState::Waiting => ("waiting", BadgeVariant::Outline),

--- a/crates/models/src/task.rs
+++ b/crates/models/src/task.rs
@@ -72,7 +72,7 @@ pub enum TaskState {
     Question,
     /// Agent done, CI/deterministic testing running.
     Testing,
-    /// Implementation complete, in merge queue.
+    /// Implementation complete, changes submitted to merge queue.
     AwaitingMerge,
     /// Merge conflict needs resolution.
     Conflict,

--- a/web/src/pages/tasks/columns.tsx
+++ b/web/src/pages/tasks/columns.tsx
@@ -72,7 +72,7 @@ export const taskStateMeta: Record<TaskState, TaskStateMeta> = {
     color: "text-purple-500",
   },
   awaiting_merge: {
-    label: "Awaiting Merge",
+    label: "Changes Submitted",
     icon: GitMerge,
     className: "text-orange-500 border-orange-500/30 bg-orange-500/10",
     color: "text-orange-500",


### PR DESCRIPTION
## Summary
- Renamed the "Awaiting Merge" task status to "Changes Submitted" across all UI surfaces
- Updated display labels in web frontend (`columns.tsx`)
- Updated display labels in desktop app (`api.rs`, `dashboard.rs`)
- Updated related doc comments for clarity
- Internal enum variant remains `AwaitingMerge` for backward compatibility

The old label incorrectly implied that changes would get merged. The new label better communicates that changes have been submitted to the merge queue and are awaiting review/processing.

Fixes #224

## Test plan
- [x] Rust code compiles (`cargo check --package tasks-desktop`, `cargo test --package models`)
- [ ] Web frontend displays "Changes Submitted" instead of "Awaiting Merge"
- [ ] Desktop app displays "changes submitted" in badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)