### PR TITLE
Move Awaiting Merge status to just before Completed

### DIFF
--- a/web/src/pages/tasks/columns.tsx
+++ b/web/src/pages/tasks/columns.tsx
@@ -28,13 +28,13 @@ export interface TaskStateMeta {
 
 // State priority for sorting (lower number = higher priority / shown first)
 export const stateSortOrder: Record<TaskState, number> = {
-  awaiting_merge: 0,
-  running: 1,
-  question: 2,
-  conflict: 3,
-  testing: 4,
-  waiting: 5,
-  blocked: 6,
+  running: 0,
+  question: 1,
+  conflict: 2,
+  testing: 3,
+  waiting: 4,
+  blocked: 5,
+  awaiting_merge: 6,
   completed: 7,
   failed: 8,
   cancelled: 9,


### PR DESCRIPTION
## Summary
- Reorders the task status sort order so "Awaiting Merge" appears just before "Completed" instead of first
- This better reflects the task lifecycle: active tasks first, then completed/terminal states

## Test plan
- [ ] Verify tasks are sorted with "Awaiting Merge" appearing just before "Completed" in the task list
- [ ] Confirm active tasks (Running, Question, Conflict, Testing) still appear first

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)