### PR TITLE
Polish merge queue and table styling for consistency

### DIFF
--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -70,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        "h-8 px-2 text-left align-middle font-medium whitespace-nowrap text-muted-foreground text-xs [&:has([role=checkbox])]:pr-0",
         className
       )}
       {...props}

--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -14,15 +14,15 @@ import type { MergeQueueEntry, MergeStatus, Project, Task } from "@/lib/types";
 function statusBadge(status: MergeStatus) {
   switch (status) {
     case "pending":
-      return <Badge className="bg-yellow-600 text-white">{status}</Badge>;
+      return <Badge variant="outline" className="bg-yellow-500/15 text-yellow-400 border-yellow-500/30">{status}</Badge>;
     case "approved":
-      return <Badge className="bg-green-600 text-white">{status}</Badge>;
+      return <Badge variant="outline" className="bg-green-500/15 text-green-400 border-green-500/30">{status}</Badge>;
     case "rejected":
-      return <Badge className="bg-red-600 text-white">{status}</Badge>;
+      return <Badge variant="outline" className="bg-red-500/15 text-red-400 border-red-500/30">{status}</Badge>;
     case "merged":
-      return <Badge className="bg-blue-600 text-white">{status}</Badge>;
+      return <Badge variant="outline" className="bg-blue-500/15 text-blue-400 border-blue-500/30">{status}</Badge>;
     case "conflict":
-      return <Badge className="bg-orange-600 text-white">{status}</Badge>;
+      return <Badge variant="outline" className="bg-orange-500/15 text-orange-400 border-orange-500/30">{status}</Badge>;
     default:
       return <Badge variant="outline">{status}</Badge>;
   }


### PR DESCRIPTION
## Summary

- Update merge queue status badges to use softer styling (`bg-color-500/15` with matching border) consistent with the events page badges
- Make table headers more compact (`h-8` vs `h-10`) with muted text color and consistent `text-xs` sizing for a cleaner Linear-style appearance

## Changes

### Merge Queue Badges
Before: Solid color backgrounds (`bg-yellow-600 text-white`)
After: Softer semi-transparent styling (`bg-yellow-500/15 text-yellow-400 border-yellow-500/30`)

### Table Headers  
Before: `h-10` height with `text-foreground`
After: `h-8` height with `text-muted-foreground text-xs` for more compact, subtle headers

## Test plan

- [ ] Verify merge queue page renders correctly with new badge styling
- [ ] Verify events page table headers match the new compact style
- [ ] Confirm visual consistency across merge queue, events, and orchestrator pages

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)