### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Get current version
         id: version
         run: |


### PR DESCRIPTION
## Summary

- Adds `actions/configure-pages@v5` step to the docs workflow to properly initialize GitHub Pages configuration

## Root cause

The GitHub Pages deployment was failing with:
```
Error: Failed to create deployment (status: 404)
Ensure GitHub Pages has been enabled: https://github.com/iamnbutler/tasks/settings/pages
```

## Required action

**This PR alone will not fix the issue.** The repository admin needs to:

1. Go to **Settings > Pages**
2. Under "Build and deployment", set **Source** to **GitHub Actions**
3. Merge this PR
4. Re-run the workflow (manually or via a push to `spec/`)

The `configure-pages` action is the recommended first step for GitHub Pages workflows and will help initialize the Pages site correctly once enabled.

## Test plan

- [ ] Enable GitHub Pages in repo settings (source: GitHub Actions)
- [ ] Merge PR
- [ ] Trigger docs workflow and verify deployment succeeds

Fixes #234

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)