### PR TITLE
Terminate running sessions when mode changes to Stop

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -399,7 +399,9 @@ async fn set_mode(
         .await
         .map_err(ApiError::Server)?;
 
-    // When entering Stop mode, terminate all running sessions (spec §6.1)
+    // When entering Stop mode, terminate all running sessions (spec §6.1).
+    // TODO: Move to an event-driven listener (on system:mode:stop) so that
+    // non-web mode changes (CLI, orchestrator) also trigger session termination.
     if mode == Mode::Stop {
         if let Some(ref session_manager) = state.session_manager {
             // Give sessions 5 seconds to stop gracefully before force-destroying containers

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -385,6 +385,10 @@ async fn get_mode(State(state): State<ApiState>) -> Json<ModeResponse> {
 }
 
 /// POST /api/mode — Set operating mode.
+///
+/// When transitioning to Stop mode, all running sessions are terminated.
+/// Sessions get 5 seconds to stop gracefully before containers are force-destroyed.
+/// (Spec §6.1: "Running agent processes are terminated")
 async fn set_mode(
     State(state): State<ApiState>,
     Json(req): Json<SetModeRequest>,
@@ -394,6 +398,19 @@ async fn set_mode(
         .set_mode(req.mode, &Actor::Human)
         .await
         .map_err(ApiError::Server)?;
+
+    // When entering Stop mode, terminate all running sessions (spec §6.1)
+    if mode == Mode::Stop {
+        if let Some(ref session_manager) = state.session_manager {
+            // Give sessions 5 seconds to stop gracefully before force-destroying containers
+            let timeout = std::time::Duration::from_secs(5);
+            let stopped = session_manager.stop_all_with_timeout(timeout).await;
+            if stopped > 0 {
+                tracing::info!(stopped_sessions = stopped, "terminated sessions for Stop mode");
+            }
+        }
+    }
+
     Ok(Json(ModeResponse { mode }))
 }
 

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -224,6 +224,30 @@ impl<R: ContainerRuntime + Send + Sync + 'static> SessionManager<R> {
             "stopping all sessions with timeout"
         );
 
+        // Phase 0: Emit TaskStateWaiting for all sessions BEFORE stopping them.
+        // This ensures tasks return to Waiting state for re-dispatch when mode resumes,
+        // regardless of whether the agent exits gracefully (which would otherwise emit
+        // TaskStateFailed and consume a retry slot — see spec §6.1).
+        for (task_id, container_id, _) in &session_info {
+            let event = events::Event::new(
+                events::EventType::TaskStateWaiting,
+                task_id,
+                events::Actor::System,
+                serde_json::json!({
+                    "reason": "stop_mode",
+                    "message": "Session terminated due to Stop mode",
+                    "container_id": container_id,
+                }),
+            );
+            if let Err(e) = self.event_bus.publish(event).await {
+                tracing::error!(
+                    task_id = %task_id,
+                    error = %e,
+                    "failed to publish TaskStateWaiting before stop"
+                );
+            }
+        }
+
         // Phase 1: Send stop command to all sessions (graceful shutdown attempt)
         for (task_id, _, command_tx) in &session_info {
             if let Err(e) = command_tx.send(SessionCommand::Stop).await {
@@ -282,26 +306,8 @@ impl<R: ContainerRuntime + Send + Sync + 'static> SessionManager<R> {
             // Abort the monitor task so it doesn't double-destroy
             monitor_handle.abort();
 
-            // Emit event to reset task state back to waiting (spec §6.1)
-            // This allows the task to be re-dispatched when mode returns to Pause/Play.
-            let event = events::Event::new(
-                events::EventType::TaskStateWaiting,
-                &task_id,
-                events::Actor::System,
-                serde_json::json!({
-                    "reason": "stop_mode",
-                    "message": "Session terminated due to Stop mode",
-                    "container_id": container_id,
-                }),
-            );
-            if let Err(e) = self.event_bus.publish(event).await {
-                tracing::error!(
-                    task_id = %task_id,
-                    error = %e,
-                    "failed to publish task state event after force-stop"
-                );
-            }
-
+            // TaskStateWaiting was already emitted in Phase 0 for all sessions.
+            // Just force-destroy the container here.
             if let Err(e) = self.runtime.destroy(&container_id).await {
                 tracing::error!(
                     task_id = %task_id,

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -193,6 +193,133 @@ impl<R: ContainerRuntime + Send + Sync + 'static> SessionManager<R> {
             }
         }
     }
+
+    /// Stop all sessions with a timeout, then forcibly destroy remaining containers.
+    ///
+    /// Spec §6.1: When mode changes to Stop, running agent processes are terminated.
+    /// This method first attempts graceful shutdown by sending stop commands to all
+    /// sessions, then waits up to `timeout` for them to exit. Any sessions still
+    /// running after the timeout are forcibly destroyed.
+    ///
+    /// Returns the number of sessions that were stopped (both graceful and forced).
+    pub async fn stop_all_with_timeout(&self, timeout: Duration) -> usize {
+        // Get all session task IDs and their command channels
+        let session_info: Vec<(String, String, tokio::sync::mpsc::Sender<SessionCommand>)> = {
+            let sessions = self.sessions.read().await;
+            sessions
+                .values()
+                .map(|h| (h.task_id.clone(), h.container_id.clone(), h.command_tx.clone()))
+                .collect()
+        };
+
+        let count = session_info.len();
+        if count == 0 {
+            tracing::debug!("no sessions to stop");
+            return 0;
+        }
+
+        tracing::info!(
+            session_count = count,
+            timeout_secs = timeout.as_secs(),
+            "stopping all sessions with timeout"
+        );
+
+        // Phase 1: Send stop command to all sessions (graceful shutdown attempt)
+        for (task_id, _, command_tx) in &session_info {
+            if let Err(e) = command_tx.send(SessionCommand::Stop).await {
+                tracing::warn!(
+                    task_id = %task_id,
+                    error = %e,
+                    "failed to send stop command (session may already be ending)"
+                );
+            } else {
+                tracing::debug!(task_id = %task_id, "sent stop command to session");
+            }
+        }
+
+        // Phase 2: Wait for sessions to exit gracefully, with timeout
+        let deadline = tokio::time::Instant::now() + timeout;
+        let poll_interval = Duration::from_millis(100);
+
+        loop {
+            let remaining = {
+                let sessions = self.sessions.read().await;
+                sessions.len()
+            };
+
+            if remaining == 0 {
+                tracing::info!("all sessions stopped gracefully");
+                break;
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                tracing::warn!(
+                    remaining_sessions = remaining,
+                    "timeout reached, forcibly destroying remaining containers"
+                );
+                break;
+            }
+
+            tokio::time::sleep(poll_interval).await;
+        }
+
+        // Phase 3: Force-destroy any remaining sessions
+        let remaining_entries: Vec<(String, String, JoinHandle<()>)> = {
+            let mut sessions = self.sessions.write().await;
+            sessions
+                .drain()
+                .map(|(_, h)| (h.task_id, h.container_id, h.monitor_handle))
+                .collect()
+        };
+
+        for (task_id, container_id, monitor_handle) in remaining_entries {
+            tracing::warn!(
+                task_id = %task_id,
+                container_id = %container_id,
+                "forcibly destroying container after timeout"
+            );
+
+            // Abort the monitor task so it doesn't double-destroy
+            monitor_handle.abort();
+
+            // Emit event to reset task state back to waiting (spec §6.1)
+            // This allows the task to be re-dispatched when mode returns to Pause/Play.
+            let event = events::Event::new(
+                events::EventType::TaskStateWaiting,
+                &task_id,
+                events::Actor::System,
+                serde_json::json!({
+                    "reason": "stop_mode",
+                    "message": "Session terminated due to Stop mode",
+                    "container_id": container_id,
+                }),
+            );
+            if let Err(e) = self.event_bus.publish(event).await {
+                tracing::error!(
+                    task_id = %task_id,
+                    error = %e,
+                    "failed to publish task state event after force-stop"
+                );
+            }
+
+            if let Err(e) = self.runtime.destroy(&container_id).await {
+                tracing::error!(
+                    task_id = %task_id,
+                    container_id = %container_id,
+                    error = %e,
+                    "failed to force-destroy container"
+                );
+            } else {
+                tracing::info!(
+                    task_id = %task_id,
+                    container_id = %container_id,
+                    "force-destroyed container"
+                );
+            }
+        }
+
+        count
+    }
 }
 
 /// Methods that require `Clone` on the runtime (needed to create `runtime::Session`).


### PR DESCRIPTION
## Summary

- Fixes Stop mode not stopping running agent sessions (spec §6.1)
- Adds `SessionManager::stop_all_with_timeout()` method for graceful shutdown with 5-second timeout
- Updates `set_mode` API handler to terminate sessions when entering Stop mode
- Emits `TaskStateWaiting` events for force-stopped tasks so they can be re-dispatched when mode returns to Pause/Play

## Changes

**`crates/session/src/manager.rs`**
- Added `stop_all_with_timeout()` method that implements a three-phase shutdown:
  1. Sends stop command to all sessions (graceful shutdown attempt)
  2. Waits up to timeout for sessions to exit
  3. Force-destroys any remaining containers after timeout
- Emits events to update task state back to "waiting" for force-stopped sessions

**`crates/app/src/web.rs`**
- Updated `set_mode` handler to call `stop_all_with_timeout(5s)` when entering Stop mode

## Test plan

- [ ] Verify mode transition to Stop terminates running sessions
- [ ] Verify sessions that exit within 5 seconds are stopped gracefully
- [ ] Verify sessions that don't exit within 5 seconds are force-destroyed
- [ ] Verify tasks return to "waiting" state after force-stop
- [ ] Verify tasks can be re-dispatched when mode returns to Pause/Play

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)