### PR TITLE
Wire per-project max_sessions from workflow.toml

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -850,8 +850,21 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
 
             // Run dispatch with pending answers
             let answers_vec: Vec<String> = pending_answers.iter().cloned().collect();
+            // Build per-project session limits from workflow configs
+            let per_project_limits = {
+                let state = dispatch_server.state.read().await;
+                let mut limits = std::collections::HashMap::new();
+                for project_id in state.projects.keys() {
+                    let config = dispatch_config_watcher.get_config(project_id).await;
+                    if let Some(max) = config.project.max_sessions {
+                        limits.insert(project_id.clone(), max);
+                    }
+                }
+                limits
+            };
+
             match dispatch_server
-                .run_dispatch(&answers_vec, effective_max)
+                .run_dispatch_with_limits(&answers_vec, effective_max, Some(&per_project_limits))
                 .await
             {
                 Ok(plan) => {

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -439,6 +439,15 @@ impl Server {
         pending_answers: &[String],
         global_max: u32,
     ) -> Result<DispatchPlan, ServerError> {
+        self.run_dispatch_with_limits(pending_answers, global_max, None).await
+    }
+
+    pub async fn run_dispatch_with_limits(
+        &self,
+        pending_answers: &[String],
+        global_max: u32,
+        per_project_limits: Option<&HashMap<String, u32>>,
+    ) -> Result<DispatchPlan, ServerError> {
         // 1. Read current mode — if Stop, return empty plan.
         {
             let state = self.state.read().await;
@@ -476,12 +485,15 @@ impl Server {
             }
         }
 
-        // 3. Build project_limits map (for now, use global_max for all projects).
+        // 3. Build project_limits map from per-project overrides or global default.
         let project_limits = {
             let state = self.state.read().await;
             let mut limits = HashMap::new();
             for project_id in state.projects.keys() {
-                limits.insert(project_id.clone(), global_max);
+                let limit = per_project_limits
+                    .and_then(|m| m.get(project_id).copied())
+                    .unwrap_or(global_max);
+                limits.insert(project_id.clone(), limit);
             }
             limits
         };

--- a/workflow.toml
+++ b/workflow.toml
@@ -1,0 +1,2 @@
+[project]
+max_sessions = 1


### PR DESCRIPTION
## Summary
- Add `workflow.toml` to repo root with `max_sessions = 1` (one agent session per project)
- Wire the existing `WorkflowConfig.project.max_sessions` field through to the dispatcher
- Add `run_dispatch_with_limits()` to Server that accepts per-project limit overrides
- Dispatch loop reads per-project limits from the `WorkflowConfigWatcher` on each tick

The `workflow.toml` schema already supported `max_sessions` (spec §14.1) but the value was never read — every project got the global `TASKS_MAX_SESSIONS` limit. Now the dispatcher respects the per-project config.

## Test plan
- [ ] Verify with `max_sessions = 1`: only one session runs per project at a time
- [ ] Verify removing the field falls back to the global `TASKS_MAX_SESSIONS`
- [ ] Verify multiple projects each get their own independent limit