### PR TITLE
Add TASKS_MAX_SESSIONS_PER_PROJECT env var (default: 1)

### DIFF
--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -10,6 +10,8 @@ pub struct AppConfig {
     pub github_token: String,
     /// Global max concurrent sessions (default: 5).
     pub max_sessions: u32,
+    /// Default max sessions per project when no workflow.toml override exists (default: 1).
+    pub max_sessions_per_project: u32,
     /// Maximum retry attempts for failed tasks (default: 3, spec §13.2/§14.1).
     pub max_retries: u32,
     /// GitHub poll interval (default: 60s).
@@ -69,6 +71,11 @@ impl AppConfig {
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(5);
+
+        let max_sessions_per_project = std::env::var("TASKS_MAX_SESSIONS_PER_PROJECT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1);
 
         let max_retries = std::env::var("TASKS_MAX_RETRIES")
             .ok()
@@ -130,6 +137,7 @@ impl AppConfig {
             data_dir,
             github_token,
             max_sessions,
+            max_sessions_per_project,
             max_retries,
             poll_interval: Duration::from_secs(poll_interval_secs),
             dispatch_interval: Duration::from_secs(dispatch_interval_secs),

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -139,6 +139,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     info!(
         data_dir = %config.data_dir,
         max_sessions = config.max_sessions,
+        max_sessions_per_project = config.max_sessions_per_project,
         poll_interval = ?config.poll_interval,
         dispatch_interval = ?config.dispatch_interval,
         container_image = %config.container_image,
@@ -743,6 +744,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     let dispatch_session_mgr = session_manager.clone();
     let dispatch_interval = config.dispatch_interval;
     let max_sessions = config.max_sessions;
+    let max_sessions_per_project = config.max_sessions_per_project;
     let max_retries = config.max_retries;
     let dispatch_event_bus = server.event_bus.clone();
     let dispatch_memory_gate = memory_gate.clone();
@@ -850,15 +852,14 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
 
             // Run dispatch with pending answers
             let answers_vec: Vec<String> = pending_answers.iter().cloned().collect();
-            // Build per-project session limits from workflow configs
+            // Build per-project session limits: workflow.toml override > env default
             let per_project_limits = {
                 let state = dispatch_server.state.read().await;
                 let mut limits = std::collections::HashMap::new();
                 for project_id in state.projects.keys() {
                     let config = dispatch_config_watcher.get_config(project_id).await;
-                    if let Some(max) = config.project.max_sessions {
-                        limits.insert(project_id.clone(), max);
-                    }
+                    let limit = config.project.max_sessions.unwrap_or(max_sessions_per_project);
+                    limits.insert(project_id.clone(), limit);
                 }
                 limits
             };


### PR DESCRIPTION
## Summary
- Add `TASKS_MAX_SESSIONS_PER_PROJECT` env var — global default for per-project session concurrency (default: 1)
- Projects with `workflow.toml` `max_sessions` override still take precedence
- Projects without a `workflow.toml` now get 1 session instead of the global `TASKS_MAX_SESSIONS`

Previously the per-project limit fell back to the global `TASKS_MAX_SESSIONS` (default 5), so projects without a `workflow.toml` could run 5 agents concurrently. Now the default is 1 agent per project.

## Test plan
- [ ] With default config: verify only 1 session runs per project
- [ ] With `TASKS_MAX_SESSIONS_PER_PROJECT=2`: verify 2 sessions per project
- [ ] With `workflow.toml` `max_sessions = 3` in a repo: verify that repo gets 3 (override wins)