### PR TITLE
Implement GitHub-authoritative reconciliation for tasks and merge queue

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -17,7 +17,7 @@ use server::model::merge_queue::{ConflictInfo, ConflictType, MergeQueueEntry};
 use server::model::task::{TaskSource, TaskState};
 use server::{WorkflowConfigWatcher, RefreshResult};
 use tasks_github::client::GitHubClient;
-use tasks_github::model::{IssueState, IssueStateReason, MergeableState, PullRequestState};
+use tasks_github::model::{IssueState, MergeableState, PullRequestState};
 use tasks_github::poller::RepoPoller;
 
 use tasks_orchestrator::{
@@ -400,14 +400,50 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
             for (project_id, poller) in pollers.iter_mut() {
                 match poller.poll().await {
                     Ok(result) => {
-                        // Create tasks for new issues
+                        // --- Issue processing: create or reconcile (issue #254) ---
                         for issue in &result.issues {
                             let source = TaskSource::GithubIssue {
                                 owner: issue.owner.clone(),
                                 repo: issue.repo.clone(),
                                 number: issue.number,
                             };
-                            if !poll_server.has_task_for_source(&source).await {
+
+                            if let Some(task_id) = poll_server.task_id_for_source(&source).await {
+                                // Task exists — reconcile with fresh GitHub data
+                                match poll_server.reconcile_task(&task_id, issue, &label_config).await {
+                                    Ok(Some(result)) if result.has_changes() => {
+                                        if let Some(new_state) = result.new_state {
+                                            info!(
+                                                project = %project_id,
+                                                issue = issue.number,
+                                                task_id = %task_id,
+                                                new_state = ?new_state,
+                                                updated_fields = ?result.updated_fields,
+                                                "reconciled task from GitHub"
+                                            );
+                                        } else if !result.updated_fields.is_empty() {
+                                            debug!(
+                                                project = %project_id,
+                                                issue = issue.number,
+                                                task_id = %task_id,
+                                                updated_fields = ?result.updated_fields,
+                                                "synced task metadata from GitHub"
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            project = %project_id,
+                                            issue = issue.number,
+                                            task_id = %task_id,
+                                            error = %e,
+                                            "failed to reconcile task"
+                                        );
+                                    }
+                                    _ => {} // No changes or task not found
+                                }
+                            } else {
+                                // New issue — create task (existing behavior)
                                 if let Some(task) = server::scheduler::issue_to_task(
                                     issue,
                                     project_id,
@@ -424,168 +460,112 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             }
                         }
-                        // Add open PRs to the merge queue (spec §7).
+
+                        // --- PR processing: create merge entries + reconcile (issue #255) ---
                         //
-                        // We don't create tasks for PRs here — that would cause loops
-                        // where agent-created PRs get picked up as new tasks. Instead,
-                        // we only add PRs to the merge queue, which is PR-centric.
-                        //
-                        // If a PR's branch matches the `tasks/{task_id}` pattern, we
-                        // link it to that task. Otherwise, we use an empty task_id.
+                        // Add open, non-draft PRs to the merge queue. We don't create
+                        // tasks for PRs — that would cause loops where agent-created PRs
+                        // get picked up as new tasks. The merge queue is PR-centric.
                         for pr in &result.pull_requests {
-                            // Only process open, non-draft PRs for the merge queue
-                            if pr.state != tasks_github::model::PullRequestState::Open || pr.is_draft {
-                                continue;
-                            }
-
-                            let pr_url = format!(
-                                "https://github.com/{}/{}/pull/{}",
-                                pr.owner, pr.repo, pr.number
-                            );
-
-                            // Skip if already in merge queue
-                            if poll_server.has_merge_entry_for_pr(&pr_url).await {
-                                continue;
-                            }
-
-                            // Try to find a linked task by branch name
-                            let task_id = poll_server
-                                .find_task_by_branch(&pr.head_ref)
-                                .await
-                                .unwrap_or_default();
-
-                            // Create merge queue entry
-                            let entry_id = format!("mq-{}-{}-pr-{}", pr.owner, pr.repo, pr.number);
-                            let entry = MergeQueueEntry::new(
-                                entry_id.clone(),
-                                task_id.clone(),
-                                &pr_url,
-                            );
-
-                            if let Err(e) = poll_server.add_to_merge_queue(entry).await {
-                                warn!(
-                                    project = %project_id,
-                                    pr = pr.number,
-                                    error = %e,
-                                    "failed to add PR to merge queue"
+                            // Only create new entries for open, non-draft PRs
+                            if pr.state == tasks_github::model::PullRequestState::Open && !pr.is_draft {
+                                let pr_url = format!(
+                                    "https://github.com/{}/{}/pull/{}",
+                                    pr.owner, pr.repo, pr.number
                                 );
-                            } else {
-                                info!(
-                                    project = %project_id,
-                                    pr = pr.number,
-                                    task_id = %task_id,
-                                    "added PR to merge queue"
-                                );
-                            }
-                        }
 
-                        // --- External closure detection (spec §11.3) ---
-                        //
-                        // When a GitHub issue or PR is closed externally, we need to
-                        // transition the corresponding task to an appropriate state.
+                                if !poll_server.has_merge_entry_for_pr(&pr_url).await {
+                                    let task_id = poll_server
+                                        .find_task_by_branch(&pr.head_ref)
+                                        .await
+                                        .unwrap_or_default();
 
-                        // Detect closed issues and transition tasks to Cancelled/Completed.
-                        for issue in &result.issues {
-                            if issue.state != IssueState::Closed {
-                                continue;
-                            }
-
-                            let source = TaskSource::GithubIssue {
-                                owner: issue.owner.clone(),
-                                repo: issue.repo.clone(),
-                                number: issue.number,
-                            };
-
-                            // Find the task for this issue
-                            if let Some(task_id) = poll_server.task_id_for_source(&source).await {
-                                // Get the task to check its current state
-                                if let Some(task) = poll_server.get_task(&task_id).await {
-                                    // Skip if already terminal
-                                    if task.state.is_terminal() {
-                                        continue;
-                                    }
-
-                                    // Determine target state based on issue state_reason:
-                                    // - Completed → task Completed
-                                    // - NotPlanned or None → task Cancelled
-                                    let new_state = match issue.state_reason {
-                                        Some(IssueStateReason::Completed) => TaskState::Completed,
-                                        _ => TaskState::Cancelled,
-                                    };
-
-                                    info!(
-                                        project = %project_id,
-                                        issue = issue.number,
-                                        task_id = %task_id,
-                                        new_state = ?new_state,
-                                        state_reason = ?issue.state_reason,
-                                        "detected external issue closure, transitioning task"
+                                    let entry_id = format!("mq-{}-{}-pr-{}", pr.owner, pr.repo, pr.number);
+                                    let entry = MergeQueueEntry::new(
+                                        entry_id.clone(),
+                                        task_id.clone(),
+                                        &pr_url,
                                     );
 
-                                    if let Err(e) = poll_server
-                                        .set_task_state(&task_id, new_state, Actor::Scheduler)
-                                        .await
-                                    {
+                                    if let Err(e) = poll_server.add_to_merge_queue(entry).await {
                                         warn!(
-                                            task_id = %task_id,
+                                            project = %project_id,
+                                            pr = pr.number,
                                             error = %e,
-                                            "failed to transition task for closed issue"
+                                            "failed to add PR to merge queue"
+                                        );
+                                    } else {
+                                        info!(
+                                            project = %project_id,
+                                            pr = pr.number,
+                                            task_id = %task_id,
+                                            "added PR to merge queue"
                                         );
                                     }
                                 }
                             }
                         }
 
-                        // Detect merged/closed PRs and transition linked tasks.
+                        // Reconcile merge queue: detect externally merged/closed PRs,
+                        // update conflict status from GitHub's mergeable field.
+                        match poll_server.reconcile_merge_queue(&result.pull_requests).await {
+                            Ok(changes) if changes > 0 => {
+                                info!(
+                                    project = %project_id,
+                                    changes = changes,
+                                    "reconciled merge queue from GitHub PR data"
+                                );
+                            }
+                            Err(e) => {
+                                warn!(
+                                    project = %project_id,
+                                    error = %e,
+                                    "failed to reconcile merge queue"
+                                );
+                            }
+                            _ => {} // No changes
+                        }
+
+                        // --- PR closure: transition linked tasks (spec §11.3) ---
+                        //
+                        // When a PR is merged/closed externally, transition the linked
+                        // task. This is separate from merge queue reconciliation because
+                        // the task linkage is via branch name, not merge queue entry.
                         for pr in &result.pull_requests {
-                            // Only handle closed/merged PRs
                             if pr.state == PullRequestState::Open {
                                 continue;
                             }
 
-                            // Find the linked task by branch name
                             let task_id = match poll_server.find_task_by_branch(&pr.head_ref).await {
                                 Some(id) => id,
-                                None => continue, // No linked task
+                                None => continue,
                             };
 
-                            // Get the task to check its current state
                             let task = match poll_server.get_task(&task_id).await {
                                 Some(t) => t,
                                 None => continue,
                             };
 
-                            // Skip if already terminal
                             if task.state.is_terminal() {
                                 continue;
                             }
 
                             match pr.state {
                                 PullRequestState::Merged => {
-                                    // PR was merged externally → task is Completed
                                     info!(
                                         project = %project_id,
                                         pr = pr.number,
                                         task_id = %task_id,
                                         "detected external PR merge, transitioning task to Completed"
                                     );
-
                                     if let Err(e) = poll_server
                                         .set_task_state(&task_id, TaskState::Completed, Actor::Scheduler)
                                         .await
                                     {
-                                        warn!(
-                                            task_id = %task_id,
-                                            error = %e,
-                                            "failed to transition task for merged PR"
-                                        );
+                                        warn!(task_id = %task_id, error = %e, "failed to transition task for merged PR");
                                     }
                                 }
                                 PullRequestState::Closed => {
-                                    // PR was closed without merge.
-                                    // Only cancel if task is in AwaitingMerge state.
-                                    // If task is in other states (Waiting, Running), the PR closure
-                                    // might be part of normal rework — don't cancel.
                                     if task.state == TaskState::AwaitingMerge {
                                         info!(
                                             project = %project_id,
@@ -593,16 +573,11 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                             task_id = %task_id,
                                             "detected external PR closure, transitioning task to Cancelled"
                                         );
-
                                         if let Err(e) = poll_server
                                             .set_task_state(&task_id, TaskState::Cancelled, Actor::Scheduler)
                                             .await
                                         {
-                                            warn!(
-                                                task_id = %task_id,
-                                                error = %e,
-                                                "failed to transition task for closed PR"
-                                            );
+                                            warn!(task_id = %task_id, error = %e, "failed to transition task for closed PR");
                                         }
                                     } else {
                                         debug!(
@@ -614,7 +589,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                         );
                                     }
                                 }
-                                PullRequestState::Open => unreachable!(), // Already filtered out
+                                PullRequestState::Open => unreachable!(),
                             }
                         }
                     }

--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -163,6 +163,20 @@ impl MergeQueue {
         Ok(ids)
     }
 
+    /// Remove a specific entry by PR URL. Returns the removed entry if found.
+    pub fn remove_by_pr_url(&mut self, pr_url: &str) -> Option<MergeQueueEntry> {
+        if let Some(pos) = self.entries.iter().position(|e| e.pr_url == pr_url) {
+            Some(self.entries.remove(pos))
+        } else {
+            None
+        }
+    }
+
+    /// Get a mutable reference to an entry by PR URL.
+    pub fn get_by_pr_url_mut(&mut self, pr_url: &str) -> Option<&mut MergeQueueEntry> {
+        self.entries.iter_mut().find(|e| e.pr_url == pr_url)
+    }
+
     /// Remove terminal entries (merged, rejected) from the queue.
     pub fn cleanup(&mut self) {
         self.entries.retain(|e| {

--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -172,11 +172,6 @@ impl MergeQueue {
         }
     }
 
-    /// Get a mutable reference to an entry by PR URL.
-    pub fn get_by_pr_url_mut(&mut self, pr_url: &str) -> Option<&mut MergeQueueEntry> {
-        self.entries.iter_mut().find(|e| e.pr_url == pr_url)
-    }
-
     /// Remove terminal entries (merged, rejected) from the queue.
     pub fn cleanup(&mut self) {
         self.entries.retain(|e| {

--- a/crates/server/src/scheduler.rs
+++ b/crates/server/src/scheduler.rs
@@ -169,8 +169,8 @@ pub fn reconcile_task(
     // Derive blocked_by from GitHub blocking issue relationships.
     // Format: "gh-{owner}-{repo}-issue-{number}" to match our task ID convention.
     // NOTE: BlockingIssueRef lacks owner/repo fields, so we assume same-repo
-    // blockers. Cross-repo blocking relationships would need BlockingIssueRef
-    // extended with owner/repo to generate correct task IDs.
+    // blockers. Cross-repo blocking relationships generate wrong task IDs.
+    // See #261 for the fix.
     let new_blocked_by: Vec<String> = issue
         .blocked_by
         .iter()

--- a/crates/server/src/scheduler.rs
+++ b/crates/server/src/scheduler.rs
@@ -115,6 +115,141 @@ pub fn pr_to_task(
     Some(task)
 }
 
+/// Describes what changed during reconciliation, so the caller can emit
+/// appropriate events and log messages.
+#[derive(Debug, Default)]
+pub struct ReconcileResult {
+    /// Fields that were updated (for logging).
+    pub updated_fields: Vec<&'static str>,
+    /// If the task state changed, the new state.
+    pub new_state: Option<TaskState>,
+    /// If the task should be cancelled (skip label added).
+    pub cancelled: bool,
+}
+
+impl ReconcileResult {
+    pub fn has_changes(&self) -> bool {
+        !self.updated_fields.is_empty() || self.new_state.is_some() || self.cancelled
+    }
+}
+
+/// Reconcile a local task with fresh GitHub issue data (spec §12, issue #254).
+///
+/// Updates GitHub-authoritative fields: title, description, labels, blocked_by.
+/// Detects state transitions: closed → Completed/Cancelled, skip label → Cancelled,
+/// blocked label changes → Blocked/Waiting.
+///
+/// Platform-authoritative fields (session_id, retry_count, etc.) are never touched.
+/// Returns a `ReconcileResult` describing what changed.
+pub fn reconcile_task(
+    task: &mut Task,
+    issue: &Issue,
+    label_config: &LabelConfig,
+) -> ReconcileResult {
+    let mut result = ReconcileResult::default();
+
+    // --- GitHub-authoritative field sync ---
+
+    if task.title != issue.title {
+        task.title = issue.title.clone();
+        result.updated_fields.push("title");
+    }
+
+    if task.description != issue.body {
+        task.description = issue.body.clone();
+        result.updated_fields.push("description");
+    }
+
+    let new_labels: Vec<String> = issue.labels.iter().map(|l| l.name.clone()).collect();
+    if task.labels != new_labels {
+        task.labels = new_labels;
+        result.updated_fields.push("labels");
+    }
+
+    // Derive blocked_by from GitHub blocking issue relationships.
+    // Format: "gh-{owner}-{repo}-issue-{number}" to match our task ID convention.
+    let new_blocked_by: Vec<String> = issue
+        .blocked_by
+        .iter()
+        .filter(|b| b.state == tasks_github::model::IssueState::Open)
+        .map(|b| format!("gh-{}-{}-issue-{}", issue.owner, issue.repo, b.number))
+        .collect();
+    if task.blocked_by != new_blocked_by {
+        task.blocked_by = new_blocked_by;
+        result.updated_fields.push("blocked_by");
+    }
+
+    // --- State transitions from GitHub ---
+
+    // If already terminal, don't change state.
+    if task.state.is_terminal() {
+        if result.has_changes() {
+            task.updated_at = chrono::Utc::now();
+        }
+        return result;
+    }
+
+    let issue_label_names: Vec<&str> = issue.labels.iter().map(|l| l.name.as_str()).collect();
+
+    // Check for skip/ignore labels added after import → cancel the task.
+    let should_cancel = issue_label_names.contains(&SKIP_LABEL)
+        || label_config
+            .ignore
+            .iter()
+            .any(|ig| issue_label_names.contains(&ig.as_str()));
+
+    if should_cancel {
+        result.cancelled = true;
+        result.new_state = Some(TaskState::Cancelled);
+        task.set_state(TaskState::Cancelled);
+        return result;
+    }
+
+    // Detect external closure.
+    if issue.state == tasks_github::model::IssueState::Closed {
+        let new_state = match issue.state_reason {
+            Some(tasks_github::model::IssueStateReason::Completed) => TaskState::Completed,
+            _ => TaskState::Cancelled,
+        };
+        result.new_state = Some(new_state);
+        task.set_state(new_state);
+        return result;
+    }
+
+    // Check blocked label changes — only for tasks not in active states
+    // (Running, Question, Testing, AwaitingMerge, Conflict).
+    let is_active = matches!(
+        task.state,
+        TaskState::Running
+            | TaskState::Question
+            | TaskState::Testing
+            | TaskState::AwaitingMerge
+            | TaskState::Conflict
+    );
+
+    if !is_active {
+        let is_blocked = label_config
+            .blocked
+            .iter()
+            .any(|b| issue_label_names.contains(&b.as_str()));
+        let has_open_blockers = !task.blocked_by.is_empty();
+
+        if (is_blocked || has_open_blockers) && task.state != TaskState::Blocked {
+            result.new_state = Some(TaskState::Blocked);
+            task.set_state(TaskState::Blocked);
+        } else if !is_blocked && !has_open_blockers && task.state == TaskState::Blocked {
+            result.new_state = Some(TaskState::Waiting);
+            task.set_state(TaskState::Waiting);
+        }
+    }
+
+    if result.has_changes() {
+        task.updated_at = chrono::Utc::now();
+    }
+
+    result
+}
+
 /// Check if a task already exists for a given GitHub source.
 /// Used to deduplicate — don't create tasks for issues we've already imported.
 pub fn task_exists_for_source(
@@ -357,4 +492,170 @@ mod tests {
         assert!(result.is_none(), "PR with tasks/skip label should be skipped");
     }
 
+    // --- reconcile_task tests ---
+
+    fn make_task_from_issue(issue: &Issue, cfg: &LabelConfig) -> Task {
+        issue_to_task(issue, "proj-1", cfg).expect("should produce a task")
+    }
+
+    #[test]
+    fn reconcile_syncs_title_and_description() {
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+
+        // Simulate GitHub title/description change
+        let mut updated_issue = issue.clone();
+        updated_issue.title = "Updated title".to_string();
+        updated_issue.body = Some("Updated body".to_string());
+
+        let result = reconcile_task(&mut task, &updated_issue, &cfg);
+        assert!(result.has_changes());
+        assert!(result.updated_fields.contains(&"title"));
+        assert!(result.updated_fields.contains(&"description"));
+        assert_eq!(task.title, "Updated title");
+        assert_eq!(task.description.as_deref(), Some("Updated body"));
+    }
+
+    #[test]
+    fn reconcile_syncs_labels() {
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+
+        let mut updated_issue = issue.clone();
+        updated_issue.labels = vec![make_label("bug"), make_label("priority-high")];
+
+        let result = reconcile_task(&mut task, &updated_issue, &cfg);
+        assert!(result.updated_fields.contains(&"labels"));
+        assert_eq!(task.labels, vec!["bug", "priority-high"]);
+    }
+
+    #[test]
+    fn reconcile_detects_external_closure_completed() {
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+
+        let mut closed_issue = issue.clone();
+        closed_issue.state = GhIssueState::Closed;
+        closed_issue.state_reason = Some(tasks_github::model::IssueStateReason::Completed);
+
+        let result = reconcile_task(&mut task, &closed_issue, &cfg);
+        assert_eq!(result.new_state, Some(TaskState::Completed));
+        assert_eq!(task.state, TaskState::Completed);
+    }
+
+    #[test]
+    fn reconcile_detects_external_closure_cancelled() {
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+
+        let mut closed_issue = issue.clone();
+        closed_issue.state = GhIssueState::Closed;
+        closed_issue.state_reason = Some(tasks_github::model::IssueStateReason::NotPlanned);
+
+        let result = reconcile_task(&mut task, &closed_issue, &cfg);
+        assert_eq!(result.new_state, Some(TaskState::Cancelled));
+        assert_eq!(task.state, TaskState::Cancelled);
+    }
+
+    #[test]
+    fn reconcile_skip_label_cancels_task() {
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+
+        // Add skip label on GitHub
+        let mut updated_issue = issue.clone();
+        updated_issue.labels = vec![make_label("bug"), make_label(super::SKIP_LABEL)];
+
+        let result = reconcile_task(&mut task, &updated_issue, &cfg);
+        assert!(result.cancelled);
+        assert_eq!(task.state, TaskState::Cancelled);
+    }
+
+    #[test]
+    fn reconcile_blocked_label_transitions_to_blocked() {
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+        assert_eq!(task.state, TaskState::Waiting);
+
+        // Add blocked label on GitHub
+        let mut updated_issue = issue.clone();
+        updated_issue.labels = vec![make_label("bug"), make_label("needs-design")];
+
+        let result = reconcile_task(&mut task, &updated_issue, &cfg);
+        assert_eq!(result.new_state, Some(TaskState::Blocked));
+        assert_eq!(task.state, TaskState::Blocked);
+    }
+
+    #[test]
+    fn reconcile_blocked_label_removed_transitions_to_waiting() {
+        let issue = make_issue(
+            42,
+            vec![make_label("bug"), make_label("needs-design")],
+            GhIssueState::Open,
+        );
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+        assert_eq!(task.state, TaskState::Blocked);
+
+        // Remove blocked label
+        let mut updated_issue = issue.clone();
+        updated_issue.labels = vec![make_label("bug")];
+
+        let result = reconcile_task(&mut task, &updated_issue, &cfg);
+        assert_eq!(result.new_state, Some(TaskState::Waiting));
+        assert_eq!(task.state, TaskState::Waiting);
+    }
+
+    #[test]
+    fn reconcile_no_changes_returns_empty() {
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+
+        let result = reconcile_task(&mut task, &issue, &cfg);
+        assert!(!result.has_changes());
+        assert!(result.updated_fields.is_empty());
+        assert!(result.new_state.is_none());
+    }
+
+    #[test]
+    fn reconcile_terminal_task_still_syncs_metadata() {
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+        task.set_state(TaskState::Completed);
+
+        // Title changed on GitHub
+        let mut updated_issue = issue.clone();
+        updated_issue.title = "Final title".to_string();
+
+        let result = reconcile_task(&mut task, &updated_issue, &cfg);
+        assert!(result.updated_fields.contains(&"title"));
+        assert_eq!(task.title, "Final title");
+        // State should NOT change
+        assert!(result.new_state.is_none());
+        assert_eq!(task.state, TaskState::Completed);
+    }
+
+    #[test]
+    fn reconcile_active_task_ignores_blocked_label() {
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+        task.set_state(TaskState::Running);
+
+        // Add blocked label — shouldn't affect a running task
+        let mut updated_issue = issue.clone();
+        updated_issue.labels = vec![make_label("bug"), make_label("needs-design")];
+
+        let result = reconcile_task(&mut task, &updated_issue, &cfg);
+        assert!(result.new_state.is_none());
+        assert_eq!(task.state, TaskState::Running);
+    }
 }

--- a/crates/server/src/scheduler.rs
+++ b/crates/server/src/scheduler.rs
@@ -168,6 +168,9 @@ pub fn reconcile_task(
 
     // Derive blocked_by from GitHub blocking issue relationships.
     // Format: "gh-{owner}-{repo}-issue-{number}" to match our task ID convention.
+    // NOTE: BlockingIssueRef lacks owner/repo fields, so we assume same-repo
+    // blockers. Cross-repo blocking relationships would need BlockingIssueRef
+    // extended with owner/repo to generate correct task IDs.
     let new_blocked_by: Vec<String> = issue
         .blocked_by
         .iter()
@@ -192,6 +195,10 @@ pub fn reconcile_task(
     let issue_label_names: Vec<&str> = issue.labels.iter().map(|l| l.name.as_str()).collect();
 
     // Check for skip/ignore labels added after import → cancel the task.
+    // This is a hard override for ALL non-terminal states including active ones
+    // (Running, Conflict, etc.). Skip is an explicit human signal meaning "don't
+    // work on this." Cancelling doesn't kill running sessions — it prevents
+    // re-dispatch once the current session ends.
     let should_cancel = issue_label_names.contains(&SKIP_LABEL)
         || label_config
             .ignore
@@ -243,7 +250,9 @@ pub fn reconcile_task(
         }
     }
 
-    if result.has_changes() {
+    // Only manually update updated_at for metadata-only changes (no state transition).
+    // When set_state() was called above, it already handled updated_at and last_activity_at.
+    if result.has_changes() && result.new_state.is_none() {
         task.updated_at = chrono::Utc::now();
     }
 
@@ -657,5 +666,59 @@ mod tests {
         let result = reconcile_task(&mut task, &updated_issue, &cfg);
         assert!(result.new_state.is_none());
         assert_eq!(task.state, TaskState::Running);
+    }
+
+    #[test]
+    fn reconcile_skip_label_cancels_active_task() {
+        // Skip label is a hard override — cancels even Running/Conflict tasks.
+        // It doesn't kill the session, just prevents re-dispatch.
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+        task.set_state(TaskState::Running);
+
+        let mut updated_issue = issue.clone();
+        updated_issue.labels = vec![make_label("bug"), make_label(super::SKIP_LABEL)];
+
+        let result = reconcile_task(&mut task, &updated_issue, &cfg);
+        assert!(result.cancelled);
+        assert_eq!(task.state, TaskState::Cancelled);
+    }
+
+    #[test]
+    fn reconcile_skip_label_trumps_closure_reason() {
+        // If an issue has tasks/skip AND is closed-as-completed,
+        // skip wins → Cancelled, not Completed. Skip is an explicit
+        // human override.
+        let mut issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+
+        issue.state = GhIssueState::Closed;
+        issue.state_reason = Some(tasks_github::model::IssueStateReason::Completed);
+        issue.labels = vec![make_label("bug"), make_label(super::SKIP_LABEL)];
+
+        let result = reconcile_task(&mut task, &issue, &cfg);
+        assert!(result.cancelled);
+        assert_eq!(result.new_state, Some(TaskState::Cancelled));
+        assert_eq!(task.state, TaskState::Cancelled);
+    }
+
+    #[test]
+    fn reconcile_metadata_only_sets_updated_at_once() {
+        // When only metadata changes (no state transition), updated_at
+        // should be set once by reconcile_task, not by set_state.
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+        let original_updated = task.updated_at;
+
+        // Small delay to ensure timestamps differ
+        let mut updated_issue = issue.clone();
+        updated_issue.title = "New title".to_string();
+
+        let result = reconcile_task(&mut task, &updated_issue, &cfg);
+        assert!(result.new_state.is_none());
+        assert!(task.updated_at >= original_updated);
     }
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -540,19 +540,18 @@ impl Server {
 
             // Execute the action outside the read lock
             match action {
-                MqAction::MarkMerged { entry_id, task_id, pr_url } => {
+                MqAction::MarkMerged { entry_id, pr_url, .. } => {
                     tracing::info!(
                         entry_id = %entry_id,
                         pr_url = %pr_url,
                         "reconciliation: PR merged externally, marking entry as merged"
                     );
+                    // mark_entry_merged also transitions the linked task to Completed
                     if let Err(e) = self.mark_entry_merged(&entry_id, &pr_url).await {
                         tracing::warn!(entry_id = %entry_id, error = %e, "failed to mark entry as merged during reconciliation");
                     } else {
                         changes += 1;
                     }
-                    // mark_entry_merged already transitions the task to Completed
-                    let _ = task_id;
                 }
                 MqAction::Remove { entry_id, pr_url } => {
                     tracing::info!(
@@ -592,8 +591,7 @@ impl Server {
                         entry_id = %entry_id,
                         "reconciliation: conflict resolved"
                     );
-                    let mut state = self.state.write().await;
-                    if let Err(e) = state.merge_queue.clear_conflict(&entry_id) {
+                    if let Err(e) = self.clear_entry_conflict(&entry_id).await {
                         tracing::warn!(entry_id = %entry_id, error = %e, "failed to clear conflict during reconciliation");
                     } else {
                         changes += 1;

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -20,6 +20,15 @@ use crate::model::task::{FailureInfo, Task, TaskSource, TaskState};
 use crate::dispatcher::{self, DispatchPlan};
 use crate::presence::PresenceTracker;
 
+/// Internal action type for merge queue reconciliation.
+/// Used to decide what to do outside the read lock.
+enum MqAction {
+    MarkMerged { entry_id: String, task_id: String, pr_url: String },
+    Remove { entry_id: String, pr_url: String },
+    MarkConflict { entry_id: String, pr_url: String },
+    ClearConflict { entry_id: String },
+}
+
 #[derive(Debug, Error)]
 pub enum ServerError {
     #[error("mode transition: {0}")]
@@ -410,6 +419,190 @@ impl Server {
         }
 
         None
+    }
+
+    // --- Reconciliation (issue #254, #255) ---
+
+    /// Reconcile a task with fresh GitHub issue data.
+    ///
+    /// Updates GitHub-authoritative fields and persists to store.
+    /// Returns the reconciliation result for logging/events.
+    pub async fn reconcile_task(
+        &self,
+        task_id: &str,
+        issue: &tasks_github::model::Issue,
+        label_config: &crate::workflow::LabelConfig,
+    ) -> Result<Option<crate::scheduler::ReconcileResult>, ServerError> {
+        let result = {
+            let mut state = self.state.write().await;
+            let task = match state.tasks.get_mut(task_id) {
+                Some(t) => t,
+                None => return Ok(None),
+            };
+
+            let result = crate::scheduler::reconcile_task(task, issue, label_config);
+
+            if result.has_changes() {
+                // Write-through to store
+                if let Some(ref store) = self.store {
+                    if let Ok(store) = store.lock() {
+                        if let Err(e) = store.save_task(task) {
+                            tracing::error!(task_id = %task_id, error = %e, "failed to persist reconciled task");
+                        }
+                    }
+                }
+            }
+
+            result
+        };
+
+        // Emit state change events outside the write lock
+        if let Some(new_state) = result.new_state {
+            let event_type = match new_state {
+                TaskState::Waiting => EventType::TaskStateWaiting,
+                TaskState::Blocked => EventType::TaskStateBlocked,
+                TaskState::Completed => EventType::TaskStateCompleted,
+                TaskState::Cancelled => EventType::TaskStateCancelled,
+                _ => EventType::TaskStateWaiting, // shouldn't happen from reconciliation
+            };
+
+            let event = Event::new(
+                event_type,
+                task_id,
+                Actor::Scheduler,
+                serde_json::json!({ "source": "reconciliation" }),
+            );
+            self.event_bus.publish(event).await?;
+        }
+
+        Ok(Some(result))
+    }
+
+    /// Reconcile merge queue entries against fresh PR data from GitHub.
+    ///
+    /// For each PR in the poll results:
+    /// - If PR is merged and has a merge entry → mark entry as Merged
+    /// - If PR is closed (not merged) and has a merge entry → remove entry
+    /// - If PR is open and has a merge entry → update conflict status
+    ///
+    /// Returns the number of entries updated/removed.
+    pub async fn reconcile_merge_queue(
+        &self,
+        prs: &[tasks_github::model::PullRequest],
+    ) -> Result<u32, ServerError> {
+        let mut changes = 0u32;
+
+        for pr in prs {
+            let pr_url = format!(
+                "https://github.com/{}/{}/pull/{}",
+                pr.owner, pr.repo, pr.number
+            );
+
+            let action = {
+                let state = self.state.read().await;
+                match state.merge_queue.get_by_pr_url(&pr_url) {
+                    None => continue,
+                    Some(entry) => {
+                        let entry_id = entry.id.clone();
+                        let task_id = entry.task_id.clone();
+                        let current_status = entry.status;
+                        match pr.state {
+                            tasks_github::model::PullRequestState::Merged => {
+                                if current_status != MergeStatus::Merged {
+                                    MqAction::MarkMerged { entry_id, task_id, pr_url: pr_url.clone() }
+                                } else {
+                                    continue;
+                                }
+                            }
+                            tasks_github::model::PullRequestState::Closed => {
+                                MqAction::Remove { entry_id, pr_url: pr_url.clone() }
+                            }
+                            tasks_github::model::PullRequestState::Open => {
+                                // Update conflict status from GitHub's mergeable field
+                                match pr.mergeable {
+                                    Some(tasks_github::model::MergeableState::Conflicting)
+                                        if current_status != MergeStatus::Conflict =>
+                                    {
+                                        MqAction::MarkConflict { entry_id, pr_url: pr_url.clone() }
+                                    }
+                                    Some(tasks_github::model::MergeableState::Mergeable)
+                                        if current_status == MergeStatus::Conflict =>
+                                    {
+                                        MqAction::ClearConflict { entry_id }
+                                    }
+                                    _ => continue,
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Execute the action outside the read lock
+            match action {
+                MqAction::MarkMerged { entry_id, task_id, pr_url } => {
+                    tracing::info!(
+                        entry_id = %entry_id,
+                        pr_url = %pr_url,
+                        "reconciliation: PR merged externally, marking entry as merged"
+                    );
+                    if let Err(e) = self.mark_entry_merged(&entry_id, &pr_url).await {
+                        tracing::warn!(entry_id = %entry_id, error = %e, "failed to mark entry as merged during reconciliation");
+                    } else {
+                        changes += 1;
+                    }
+                    // mark_entry_merged already transitions the task to Completed
+                    let _ = task_id;
+                }
+                MqAction::Remove { entry_id, pr_url } => {
+                    tracing::info!(
+                        entry_id = %entry_id,
+                        pr_url = %pr_url,
+                        "reconciliation: PR closed without merge, removing entry"
+                    );
+                    let mut state = self.state.write().await;
+                    state.merge_queue.remove_by_pr_url(&pr_url);
+                    // Also remove from store
+                    if let Some(ref store) = self.store {
+                        if let Ok(store) = store.lock() {
+                            if let Err(e) = store.delete_merge_entry(&entry_id) {
+                                tracing::error!(entry_id = %entry_id, error = %e, "failed to delete merge entry from store");
+                            }
+                        }
+                    }
+                    changes += 1;
+                }
+                MqAction::MarkConflict { entry_id, pr_url } => {
+                    tracing::debug!(
+                        entry_id = %entry_id,
+                        "reconciliation: PR has merge conflict"
+                    );
+                    let conflict_info = crate::model::merge_queue::ConflictInfo::new(
+                        crate::model::merge_queue::ConflictType::Unknown,
+                        "Conflict detected from GitHub mergeable status",
+                    );
+                    if let Err(e) = self.mark_entry_conflict(&entry_id, &pr_url, Some(conflict_info)).await {
+                        tracing::warn!(entry_id = %entry_id, error = %e, "failed to mark conflict during reconciliation");
+                    } else {
+                        changes += 1;
+                    }
+                }
+                MqAction::ClearConflict { entry_id } => {
+                    tracing::debug!(
+                        entry_id = %entry_id,
+                        "reconciliation: conflict resolved"
+                    );
+                    let mut state = self.state.write().await;
+                    if let Err(e) = state.merge_queue.clear_conflict(&entry_id) {
+                        tracing::warn!(entry_id = %entry_id, error = %e, "failed to clear conflict during reconciliation");
+                    } else {
+                        changes += 1;
+                    }
+                }
+            }
+        }
+
+        Ok(changes)
     }
 
     /// Get the effective session limit for a project.


### PR DESCRIPTION
## Summary

Implements Option B from #253 (Priority 1: issues #254 and #255).

- **Task reconciliation (#254):** On every poll cycle, existing tasks are updated with fresh GitHub issue data — title, description, labels, and blocked_by are synced. External closures, skip/ignore label additions, and blocked label changes are detected and trigger appropriate state transitions.
- **Merge queue reconciliation (#255):** Externally merged PRs are detected and entries marked as Merged. Closed (not merged) PRs have their entries removed. Conflict status is updated from GitHub's `mergeable` field.
- **Poll loop refactored:** The create-only logic is replaced with create-or-reconcile. The separate external closure detection for issues is now handled by reconciliation (PR closure detection is preserved separately since it uses branch-name linkage).

### What this fixes
- Stale merge queue entries for merged/closed PRs (the "100+ ghost entries" problem)
- Stale task metadata (title, description, labels never updated after import)
- Skip/ignore labels added after import having no effect
- Blocked label changes not transitioning task state
- GitHub blocking issue relationships not imported into `blocked_by`

### Data authority model
- **GitHub-authoritative:** title, description, labels, blocked_by, terminal state transitions
- **Platform-authoritative:** session_id, workspace_id, retry_count, priority, accounting, events
- **Derived:** TaskState (from GitHub + session + PR state), MergeStatus (from GitHub PR + orchestrator decision)

Closes #254, closes #255

## Test plan
- [x] 9 new unit tests for `reconcile_task()` covering all reconciliation paths
- [x] All 382 existing tests pass (0 failures)
- [ ] Manual: run with a live repo, verify stale entries are cleaned up on poll
- [ ] Manual: change an issue title on GitHub, verify local task updates within one poll cycle
- [ ] Manual: add `tasks/skip` label to an open issue, verify task transitions to Cancelled