### PR TITLE
Add owner/repo fields to BlockingIssueRef for cross-repo blocking

### DIFF
--- a/crates/github/src/model.rs
+++ b/crates/github/src/model.rs
@@ -250,6 +250,8 @@ pub struct ParentIssueRef {
 /// Reference to an issue that blocks another issue.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlockingIssueRef {
+    pub owner: String,
+    pub repo: String,
     pub number: u64,
     pub title: String,
     pub state: IssueState,

--- a/crates/github/src/queries.rs
+++ b/crates/github/src/queries.rs
@@ -44,7 +44,7 @@ const ISSUE_FIELDS: &str = r#"
             id
         }
     }
-    timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT]) {
+    timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT, MARKED_AS_BLOCKED_BY_EVENT, UNMARKED_AS_BLOCKED_BY_EVENT]) {
         nodes {
             ... on CrossReferencedEvent {
                 source {
@@ -54,6 +54,24 @@ const ISSUE_FIELDS: &str = r#"
                         state
                         id
                     }
+                }
+            }
+            ... on MarkedAsBlockedByEvent {
+                blockingIssue {
+                    repository { owner { login } name }
+                    number
+                    title
+                    state
+                    id
+                }
+            }
+            ... on UnmarkedAsBlockedByEvent {
+                blockingIssue {
+                    repository { owner { login } name }
+                    number
+                    title
+                    state
+                    id
                 }
             }
         }

--- a/crates/github/src/response.rs
+++ b/crates/github/src/response.rs
@@ -218,10 +218,24 @@ pub(crate) struct GqlTimelineSource {
 /// Blocking issue reference from timeline events.
 #[derive(Debug, Default, Deserialize)]
 pub(crate) struct GqlBlockingIssue {
+    pub repository: Option<GqlBlockingIssueRepo>,
     pub number: u64,
     pub title: String,
     pub state: String,
     pub id: String,
+}
+
+/// Repository info for a blocking issue.
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct GqlBlockingIssueRepo {
+    pub owner: GqlBlockingIssueOwner,
+    pub name: String,
+}
+
+/// Owner info for a blocking issue.
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct GqlBlockingIssueOwner {
+    pub login: String,
 }
 
 impl GqlIssue {
@@ -656,7 +670,13 @@ fn extract_timeline_relationships(
         .into_values()
         .filter_map(|(issue, is_blocked)| {
             if is_blocked {
+                let (owner, repo) = issue.repository.map_or_else(
+                    || (String::new(), String::new()),
+                    |r| (r.owner.login, r.name),
+                );
                 Some(model::BlockingIssueRef {
+                    owner,
+                    repo,
                     number: issue.number,
                     title: issue.title,
                     state: parse_issue_state(&issue.state),
@@ -967,16 +987,24 @@ mod tests {
             GqlTimelineItem {
                 source: None,
                 blocking_issue: Some(GqlBlockingIssue {
+                    repository: Some(GqlBlockingIssueRepo {
+                        owner: GqlBlockingIssueOwner { login: "acme".into() },
+                        name: "widgets".into(),
+                    }),
                     number: 10,
                     title: "Blocker issue".into(),
                     state: "OPEN".into(),
                     id: "I_10".into(),
                 }),
             },
-            // Issue 20 blocks this issue (marked).
+            // Issue 20 blocks this issue (marked) — from a different repo.
             GqlTimelineItem {
                 source: None,
                 blocking_issue: Some(GqlBlockingIssue {
+                    repository: Some(GqlBlockingIssueRepo {
+                        owner: GqlBlockingIssueOwner { login: "acme".into() },
+                        name: "backend".into(),
+                    }),
                     number: 20,
                     title: "Another blocker".into(),
                     state: "CLOSED".into(),
@@ -987,6 +1015,10 @@ mod tests {
             GqlTimelineItem {
                 source: None,
                 blocking_issue: Some(GqlBlockingIssue {
+                    repository: Some(GqlBlockingIssueRepo {
+                        owner: GqlBlockingIssueOwner { login: "acme".into() },
+                        name: "widgets".into(),
+                    }),
                     number: 10,
                     title: "Blocker issue".into(),
                     state: "OPEN".into(),
@@ -1000,6 +1032,8 @@ mod tests {
         // Only issue 20 should remain as a blocker (issue 10 was unmarked).
         assert_eq!(blocked_by.len(), 1);
         assert_eq!(blocked_by[0].number, 20);
+        assert_eq!(blocked_by[0].owner, "acme");
+        assert_eq!(blocked_by[0].repo, "backend");
         assert_eq!(blocked_by[0].state, model::IssueState::Closed);
     }
 
@@ -1033,6 +1067,7 @@ mod tests {
                         "timelineItems": {
                             "nodes": [{
                                 "blockingIssue": {
+                                    "repository": { "owner": { "login": "other-org" }, "name": "core" },
                                     "number": 5,
                                     "title": "Must fix first",
                                     "state": "OPEN",
@@ -1061,8 +1096,10 @@ mod tests {
         assert_eq!(parent.title, "Epic issue");
         assert_eq!(parent.state, model::IssueState::Open);
 
-        // Check blocked_by is populated.
+        // Check blocked_by is populated with cross-repo info.
         assert_eq!(model.blocked_by.len(), 1);
+        assert_eq!(model.blocked_by[0].owner, "other-org");
+        assert_eq!(model.blocked_by[0].repo, "core");
         assert_eq!(model.blocked_by[0].number, 5);
         assert_eq!(model.blocked_by[0].title, "Must fix first");
     }

--- a/crates/server/src/scheduler.rs
+++ b/crates/server/src/scheduler.rs
@@ -168,14 +168,11 @@ pub fn reconcile_task(
 
     // Derive blocked_by from GitHub blocking issue relationships.
     // Format: "gh-{owner}-{repo}-issue-{number}" to match our task ID convention.
-    // NOTE: BlockingIssueRef lacks owner/repo fields, so we assume same-repo
-    // blockers. Cross-repo blocking relationships generate wrong task IDs.
-    // See #261 for the fix.
     let new_blocked_by: Vec<String> = issue
         .blocked_by
         .iter()
         .filter(|b| b.state == tasks_github::model::IssueState::Open)
-        .map(|b| format!("gh-{}-{}-issue-{}", issue.owner, issue.repo, b.number))
+        .map(|b| format!("gh-{}-{}-issue-{}", b.owner, b.repo, b.number))
         .collect();
     if task.blocked_by != new_blocked_by {
         task.blocked_by = new_blocked_by;
@@ -720,5 +717,34 @@ mod tests {
         let result = reconcile_task(&mut task, &updated_issue, &cfg);
         assert!(result.new_state.is_none());
         assert!(task.updated_at >= original_updated);
+    }
+
+    #[test]
+    fn reconcile_cross_repo_blocking() {
+        // Test that cross-repo blocking issues generate correct task IDs.
+        // Issue acme/frontend#10 is blocked by acme/backend#5.
+        let mut issue = make_issue(10, vec![make_label("feature")], GhIssueState::Open);
+        issue.owner = "acme".to_string();
+        issue.repo = "frontend".to_string();
+        issue.blocked_by = vec![
+            tasks_github::model::BlockingIssueRef {
+                owner: "acme".to_string(),
+                repo: "backend".to_string(),
+                number: 5,
+                title: "Backend API".to_string(),
+                state: GhIssueState::Open,
+                node_id: "I_5".to_string(),
+            },
+        ];
+
+        let cfg = default_label_config();
+        let mut task = issue_to_task(&issue, "proj-1", &cfg).expect("should produce a task");
+
+        let result = reconcile_task(&mut task, &issue, &cfg);
+        assert!(result.has_changes() || !task.blocked_by.is_empty());
+
+        // The blocked_by should point to acme/backend#5, not acme/frontend#5.
+        assert_eq!(task.blocked_by.len(), 1);
+        assert_eq!(task.blocked_by[0], "gh-acme-backend-issue-5");
     }
 }

--- a/spec/github.md
+++ b/spec/github.md
@@ -108,7 +108,7 @@ Dismissed), `body` (string or null), `submitted_at` (timestamp)
 
 **SubIssueRef:** `number` (u64), `title` (string), `state` (Open | Closed), `node_id` (string)
 
-**BlockingIssueRef:** `number` (u64), `title` (string), `state` (Open | Closed), `node_id` (string)
+**BlockingIssueRef:** `owner` (string), `repo` (string), `number` (u64), `title` (string), `state` (Open | Closed), `node_id` (string)
 
 **LinkedPR:** `number` (u64), `title` (string), `state` (Open | Closed | Merged),
 `node_id` (string)


### PR DESCRIPTION
## Summary

- Adds `owner` and `repo` fields to `BlockingIssueRef` in `crates/github/src/model.rs`
- Updates the GraphQL query to fetch blocking events (`MARKED_AS_BLOCKED_BY_EVENT`, `UNMARKED_AS_BLOCKED_BY_EVENT`) with repository information
- Uses the blocking issue's own `owner` and `repo` when generating task IDs in `reconcile_task()`, fixing cross-repo blocking relationships

## Problem

When issue `acme/frontend#10` was blocked by `acme/backend#5`, the system would generate the task ID `gh-acme-frontend-issue-5` instead of the correct `gh-acme-backend-issue-5`, because `BlockingIssueRef` only had `number` and `reconcile_task()` used the current issue's owner/repo.

## Test plan

- [x] All existing tests pass (172 tests)
- [x] New test `reconcile_cross_repo_blocking` validates cross-repo blocking generates correct task IDs
- [x] Updated `blocking_relationships_from_timeline` test validates owner/repo extraction from GraphQL response
- [x] Updated `deserialize_issue_with_parent_and_blockers` test validates cross-repo JSON deserialization

Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)