### PR TITLE
Track PR head_sha to detect new commits for re-evaluation

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -538,7 +538,8 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                         entry_id.clone(),
                                         task_id.clone(),
                                         &pr_url,
-                                    );
+                                    )
+                                    .with_head_sha(&pr.head_sha);
 
                                     if let Err(e) = poll_server.add_to_merge_queue(entry).await {
                                         warn!(
@@ -1045,6 +1046,18 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     // Problem tracker for mode lowering (spec §6.4)
     let problem_tracker = Arc::new(StdMutex::new(ProblemTracker::new()));
 
+    /// Check if a merge queue entry needs evaluation: never evaluated, or has
+    /// new commits (head_sha changed since last evaluation).
+    fn needs_eval(
+        evaluated_prs: &std::collections::HashMap<String, String>,
+        entry: &server::model::merge_queue::MergeQueueEntry,
+    ) -> bool {
+        match evaluated_prs.get(&entry.pr_url) {
+            None => true,
+            Some(last_sha) => entry.head_sha.as_ref().is_some_and(|sha| sha != last_sha),
+        }
+    }
+
     let orchestrator_handle = tokio::spawn(async move {
         let mut eval_interval = tokio::time::interval(orchestrator_eval_interval);
         let mut event_rx = orch_event_bus.subscribe();
@@ -1059,8 +1072,8 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         let mut eval_queued: std::collections::HashSet<String> = std::collections::HashSet::new();
         // Track the PR URL (used as a proxy for "which PR") that was last evaluated for
         // each entry, so we don't re-evaluate the same PR until it has new commits.
-        // Key: pr_url, Value: last evaluated head SHA (or empty if unknown).
-        let mut evaluated_prs: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // Key: pr_url, Value: last evaluated head SHA.
+        let mut evaluated_prs: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
         loop {
             // Either the eval timer fires (pop one entry) or an event arrives
@@ -1093,7 +1106,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                             // Fallback: scan for any pending entries not yet queued/evaluated
                             let state = orch_server.state.read().await;
                             for entry in state.merge_queue.pending() {
-                                if !evaluated_prs.contains(&entry.pr_url) && eval_queued.insert(entry.id.clone()) {
+                                if needs_eval(&evaluated_prs, &entry) && eval_queued.insert(entry.id.clone()) {
                                     eval_queue.push_back(entry.id.clone());
                                 }
                             }
@@ -1109,7 +1122,12 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                         // Seed the queue with pending entries not yet evaluated
                         let state = orch_server.state.read().await;
                         for entry in state.merge_queue.pending() {
-                            if !evaluated_prs.contains(&entry.pr_url) && eval_queued.insert(entry.id.clone()) {
+                            // Check if PR needs evaluation: never evaluated or has new commits
+                            let needs_eval = match evaluated_prs.get(&entry.pr_url) {
+                                None => true,
+                                Some(last_sha) => entry.head_sha.as_ref().is_some_and(|sha| sha != last_sha),
+                            };
+                            if needs_eval && eval_queued.insert(entry.id.clone()) {
                                 eval_queue.push_back(entry.id.clone());
                             }
                         }
@@ -1119,7 +1137,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     EventType::SystemModePause => {
                         let state = orch_server.state.read().await;
                         for entry in state.merge_queue.pending() {
-                            if !evaluated_prs.contains(&entry.pr_url) && eval_queued.insert(entry.id.clone()) {
+                            if !evaluated_prs.contains_key(&entry.pr_url) && eval_queued.insert(entry.id.clone()) {
                                 eval_queue.push_back(entry.id.clone());
                             }
                         }
@@ -1251,11 +1269,12 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
             // --- Eval tick: pop one entry from the FIFO queue ---
 
             // On startup or mode change, seed the queue with pending entries
-            // that haven't been evaluated yet.
+            // that haven't been evaluated yet or have new commits.
             if eval_queue.is_empty() {
                 let state = orch_server.state.read().await;
                 for entry in state.merge_queue.pending() {
-                    if !evaluated_prs.contains(&entry.pr_url) && eval_queued.insert(entry.id.clone()) {
+                    // Check if PR needs evaluation: never evaluated or has new commits
+                    if needs_eval(&evaluated_prs, &entry) && eval_queued.insert(entry.id.clone()) {
                         eval_queue.push_back(entry.id.clone());
                     }
                 }
@@ -1305,10 +1324,10 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     (task, project)
                 };
 
-                let entry = {
+                let (entry, entry_head_sha) = {
                     let state = orch_server.state.read().await;
                     match state.merge_queue.get(&entry_id) {
-                        Some(e) => e.clone(),
+                        Some(e) => (e.clone(), e.head_sha.clone()),
                         None => continue,
                     }
                 };
@@ -1361,8 +1380,13 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     error!(error = %e, "failed to emit orchestrator decision event");
                 }
 
-                // Mark this PR as evaluated so we don't re-evaluate until new commits
-                evaluated_prs.insert(pr_url.clone());
+                // Mark this PR as evaluated so we don't re-evaluate until new commits.
+                // Only record the SHA if we actually know it — if head_sha is None,
+                // don't insert so reconciliation can trigger re-evaluation once the
+                // SHA is discovered.
+                if let Some(sha) = &entry_head_sha {
+                    evaluated_prs.insert(pr_url.clone(), sha.clone());
+                }
 
                 // Act on the decision (issue #337).
                 //

--- a/crates/models/src/merge_queue.rs
+++ b/crates/models/src/merge_queue.rs
@@ -96,6 +96,10 @@ pub struct MergeQueueEntry {
     /// Set when status is ChangesRequested to guide the agent on what to fix.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub changes_requested_feedback: Option<String>,
+    /// Current head commit SHA of the PR branch.
+    /// Used to detect new commits for re-evaluation (spec Section 7.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_sha: Option<String>,
 }
 
 impl MergeQueueEntry {
@@ -108,7 +112,14 @@ impl MergeQueueEntry {
             queued_at: Utc::now(),
             conflict_info: None,
             changes_requested_feedback: None,
+            head_sha: None,
         }
+    }
+
+    /// Set the head SHA for this entry (builder pattern).
+    pub fn with_head_sha(mut self, sha: impl Into<String>) -> Self {
+        self.head_sha = Some(sha.into());
+        self
     }
 }
 

--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -171,6 +171,19 @@ impl MergeQueue {
         Ok(())
     }
 
+    /// Update the head SHA for an entry.
+    /// Returns true if the SHA was updated (i.e., it changed).
+    pub fn update_head_sha(&mut self, id: &str, head_sha: &str) -> Result<bool, MergeQueueError> {
+        let entry = self
+            .get_mut(id)
+            .ok_or_else(|| MergeQueueError::NotFound(id.to_string()))?;
+        let changed = entry.head_sha.as_ref().map_or(true, |sha| sha != head_sha);
+        if changed {
+            entry.head_sha = Some(head_sha.to_string());
+        }
+        Ok(changed)
+    }
+
     /// Get all entries with conflicts.
     pub fn conflicting(&self) -> Vec<&MergeQueueEntry> {
         self.entries

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -742,96 +742,119 @@ impl Server {
             let entry_id = entry_id.clone();
             let task_id = task_id.clone();
 
-            let action = match pr.state {
+            let (action, entry_id_for_sha_update) = match pr.state {
                 tasks_github::model::PullRequestState::Merged => {
                     if *current_status != MergeStatus::Merged {
-                        MqAction::MarkMerged { entry_id, task_id, pr_url }
+                        (Some(MqAction::MarkMerged { entry_id, task_id, pr_url }), None)
                     } else {
                         continue;
                     }
                 }
                 tasks_github::model::PullRequestState::Closed => {
-                    MqAction::Remove { entry_id, pr_url }
+                    (Some(MqAction::Remove { entry_id, pr_url }), None)
                 }
                 tasks_github::model::PullRequestState::Open => {
+                    // For open PRs, always update head_sha to detect new commits
+                    let sha_update_id = entry_id.clone();
                     // Update conflict status from GitHub's mergeable field
-                    match pr.mergeable {
+                    let conflict_action = match pr.mergeable {
                         Some(tasks_github::model::MergeableState::Conflicting)
                             if *current_status != MergeStatus::Conflict =>
                         {
-                            MqAction::MarkConflict { entry_id, pr_url }
+                            Some(MqAction::MarkConflict { entry_id, pr_url })
                         }
                         Some(tasks_github::model::MergeableState::Mergeable)
                             if *current_status == MergeStatus::Conflict =>
                         {
-                            MqAction::ClearConflict { entry_id }
+                            Some(MqAction::ClearConflict { entry_id })
                         }
-                        _ => continue,
-                    }
+                        _ => None,
+                    };
+                    (conflict_action, Some(sha_update_id))
                 }
             };
-            actions.push(action);
+            actions.push((action, entry_id_for_sha_update, pr.head_sha.clone()));
         }
 
         // Execute all actions
         let mut changes = 0u32;
-        for action in actions {
-            match action {
-                MqAction::MarkMerged { entry_id, pr_url, .. } => {
-                    tracing::info!(
-                        entry_id = %entry_id,
-                        pr_url = %pr_url,
-                        "reconciliation: PR merged externally, marking entry as merged"
-                    );
-                    // mark_entry_merged also transitions the linked task to Completed
-                    if let Err(e) = self.mark_entry_merged(&entry_id, &pr_url).await {
-                        tracing::warn!(entry_id = %entry_id, error = %e, "failed to mark entry as merged during reconciliation");
-                    } else {
-                        changes += 1;
-                    }
-                }
-                MqAction::Remove { entry_id, pr_url } => {
-                    tracing::info!(
-                        entry_id = %entry_id,
-                        pr_url = %pr_url,
-                        "reconciliation: PR closed without merge, removing entry"
-                    );
-                    let mut state = self.state.write().await;
-                    state.merge_queue.remove_by_pr_url(&pr_url);
-                    // Also remove from store
-                    if let Some(ref store) = self.store {
-                        if let Ok(store) = store.lock() {
-                            if let Err(e) = store.delete_merge_entry(&entry_id) {
-                                tracing::error!(entry_id = %entry_id, error = %e, "failed to delete merge entry from store");
-                            }
+        for (action, entry_id_for_sha_update, head_sha) in actions {
+            if let Some(action) = action {
+                match action {
+                    MqAction::MarkMerged { entry_id, pr_url, .. } => {
+                        tracing::info!(
+                            entry_id = %entry_id,
+                            pr_url = %pr_url,
+                            "reconciliation: PR merged externally, marking entry as merged"
+                        );
+                        // mark_entry_merged also transitions the linked task to Completed
+                        if let Err(e) = self.mark_entry_merged(&entry_id, &pr_url).await {
+                            tracing::warn!(entry_id = %entry_id, error = %e, "failed to mark entry as merged during reconciliation");
+                        } else {
+                            changes += 1;
                         }
                     }
-                    changes += 1;
-                }
-                MqAction::MarkConflict { entry_id, pr_url } => {
-                    tracing::debug!(
-                        entry_id = %entry_id,
-                        "reconciliation: PR has merge conflict"
-                    );
-                    let conflict_info = crate::model::merge_queue::ConflictInfo::new(
-                        crate::model::merge_queue::ConflictType::Unknown,
-                        "Conflict detected from GitHub mergeable status",
-                    );
-                    if let Err(e) = self.mark_entry_conflict(&entry_id, &pr_url, Some(conflict_info)).await {
-                        tracing::warn!(entry_id = %entry_id, error = %e, "failed to mark conflict during reconciliation");
-                    } else {
+                    MqAction::Remove { entry_id, pr_url } => {
+                        tracing::info!(
+                            entry_id = %entry_id,
+                            pr_url = %pr_url,
+                            "reconciliation: PR closed without merge, removing entry"
+                        );
+                        let mut state = self.state.write().await;
+                        state.merge_queue.remove_by_pr_url(&pr_url);
+                        // Also remove from store
+                        if let Some(ref store) = self.store {
+                            if let Ok(store) = store.lock() {
+                                if let Err(e) = store.delete_merge_entry(&entry_id) {
+                                    tracing::error!(entry_id = %entry_id, error = %e, "failed to delete merge entry from store");
+                                }
+                            }
+                        }
                         changes += 1;
                     }
+                    MqAction::MarkConflict { entry_id, pr_url } => {
+                        tracing::debug!(
+                            entry_id = %entry_id,
+                            "reconciliation: PR has merge conflict"
+                        );
+                        let conflict_info = crate::model::merge_queue::ConflictInfo::new(
+                            crate::model::merge_queue::ConflictType::Unknown,
+                            "Conflict detected from GitHub mergeable status",
+                        );
+                        if let Err(e) = self.mark_entry_conflict(&entry_id, &pr_url, Some(conflict_info)).await {
+                            tracing::warn!(entry_id = %entry_id, error = %e, "failed to mark conflict during reconciliation");
+                        } else {
+                            changes += 1;
+                        }
+                    }
+                    MqAction::ClearConflict { entry_id } => {
+                        tracing::debug!(
+                            entry_id = %entry_id,
+                            "reconciliation: conflict resolved"
+                        );
+                        if let Err(e) = self.clear_entry_conflict(&entry_id).await {
+                            tracing::warn!(entry_id = %entry_id, error = %e, "failed to clear conflict during reconciliation");
+                        } else {
+                            changes += 1;
+                        }
+                    }
                 }
-                MqAction::ClearConflict { entry_id } => {
-                    tracing::debug!(
-                        entry_id = %entry_id,
-                        "reconciliation: conflict resolved"
-                    );
-                    if let Err(e) = self.clear_entry_conflict(&entry_id).await {
-                        tracing::warn!(entry_id = %entry_id, error = %e, "failed to clear conflict during reconciliation");
-                    } else {
-                        changes += 1;
+            }
+
+            // Update head_sha for open PRs to detect new commits
+            if let Some(entry_id) = entry_id_for_sha_update {
+                let mut state = self.state.write().await;
+                match state.merge_queue.update_head_sha(&entry_id, &head_sha) {
+                    Ok(true) => {
+                        tracing::debug!(
+                            entry_id = %entry_id,
+                            head_sha = %head_sha,
+                            "reconciliation: updated head_sha for PR"
+                        );
+                    }
+                    Ok(false) => {} // No change
+                    Err(e) => {
+                        tracing::warn!(entry_id = %entry_id, error = %e, "failed to update head_sha during reconciliation");
                     }
                 }
             }

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -210,6 +210,7 @@ impl Store {
                     queued_at,
                     conflict_info: None, // Not persisted to DB yet
                     changes_requested_feedback: None, // TODO: persist to DB
+                    head_sha: None,      // Updated from GitHub on reconciliation
                 }))
             }
             None => Ok(None),
@@ -247,6 +248,7 @@ impl Store {
                 queued_at,
                 conflict_info: None, // Not persisted to DB yet
                 changes_requested_feedback: None, // TODO: persist to DB
+                head_sha: None,      // Updated from GitHub on reconciliation
             });
         }
         Ok(entries)


### PR DESCRIPTION
## Summary

- Adds `head_sha` field to `MergeQueueEntry` to track the current commit SHA
- Changes `evaluated_prs` from `HashSet<String>` to `HashMap<String, String>` (PR URL → last evaluated head SHA)
- Updates reconciliation to refresh `head_sha` from live GitHub PR data
- Re-evaluates PRs when their head SHA changes (new commits pushed)

This implements spec Section 7.1: "Once evaluated, a PR is not re-evaluated until it receives new commits."

## Test plan

- [x] All existing tests pass (174 tests in modified crates)
- [x] `cargo build` succeeds
- [ ] Manual verification: Push new commits to an evaluated PR and confirm it gets re-queued for evaluation

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)