### PR TITLE
Fix duplicate Completed events when issue closure and PR merge overlap

### DIFF
--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -277,12 +277,36 @@ impl Server {
 
     /// Transition a task's state and emit the corresponding event.
     /// Update task state, persist to store, and publish an event.
+    ///
+    /// If the task is already in a terminal state, this is a no-op to prevent
+    /// duplicate events when multiple paths detect the same completion
+    /// (e.g., issue closure + PR merge in the same poll cycle).
     pub async fn set_task_state(
         &self,
         task_id: &str,
         new_state: TaskState,
         actor: Actor,
     ) -> Result<(), ServerError> {
+        // Check if task is already terminal to prevent duplicate events
+        let current_state = {
+            let state = self.state.read().await;
+            state
+                .tasks
+                .get(task_id)
+                .map(|t| t.state)
+                .ok_or_else(|| ServerError::TaskNotFound(task_id.to_string()))?
+        };
+
+        if current_state.is_terminal() {
+            tracing::debug!(
+                task_id = %task_id,
+                current_state = ?current_state,
+                requested_state = ?new_state,
+                "skipping state transition: task already in terminal state"
+            );
+            return Ok(());
+        }
+
         self.apply_task_state(task_id, new_state).await?;
 
         let event_type = match new_state {


### PR DESCRIPTION
## Summary

- Adds a terminal state guard to `set_task_state()` in `crates/server/src/server.rs`
- When a task is already in a terminal state (Completed, Failed, Cancelled), the function returns early without emitting another event
- This prevents duplicate `task:state:completed` events when multiple code paths detect the same completion in a single poll cycle

## Problem

When an issue is closed AND its linked PR is merged in the same poll cycle, up to 3 `task:state:completed` events could be emitted:
1. `reconcile_task()` detects issue closed → sets Completed
2. `reconcile_merge_queue()` → `mark_entry_merged()` → sets Completed  
3. PR closure loop → `set_task_state(Completed)`

While the `is_terminal()` guard in `reconcile_task()` prevents state corruption, duplicate events were still emitted from paths 2 and 3.

## Solution

The fix adds a terminal state check at the beginning of `set_task_state()`. If the task is already terminal, it logs a debug message and returns early without modifying state or emitting events.

This approach:
- Is a single point of change that handles all paths using `set_task_state()`
- Complements the existing guard in `reconcile_task()` (scheduler.rs line 187-193)
- Uses the same `is_terminal()` method already defined on `TaskState`

## Test plan

- [x] Verified all existing tests pass (`cargo test --package server` - 126 tests pass)
- [x] Verified all app tests pass (`cargo test --package tasks-app` - 9 tests pass)

Fixes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)