### PR TITLE
Unify event data for issue vs PR closure paths

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -559,7 +559,12 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                         "detected external PR merge, transitioning task to Completed"
                                     );
                                     if let Err(e) = poll_server
-                                        .set_task_state(&task_id, TaskState::Completed, Actor::Scheduler)
+                                        .set_task_state_with_data(
+                                            &task_id,
+                                            TaskState::Completed,
+                                            Actor::Scheduler,
+                                            serde_json::json!({ "source": "reconciliation" }),
+                                        )
                                         .await
                                     {
                                         warn!(task_id = %task_id, error = %e, "failed to transition task for merged PR");
@@ -574,7 +579,12 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                             "detected external PR closure, transitioning task to Cancelled"
                                         );
                                         if let Err(e) = poll_server
-                                            .set_task_state(&task_id, TaskState::Cancelled, Actor::Scheduler)
+                                            .set_task_state_with_data(
+                                                &task_id,
+                                                TaskState::Cancelled,
+                                                Actor::Scheduler,
+                                                serde_json::json!({ "source": "reconciliation" }),
+                                            )
                                             .await
                                         {
                                             warn!(task_id = %task_id, error = %e, "failed to transition task for closed PR");

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -283,6 +283,19 @@ impl Server {
         new_state: TaskState,
         actor: Actor,
     ) -> Result<(), ServerError> {
+        self.set_task_state_with_data(task_id, new_state, actor, serde_json::json!({}))
+            .await
+    }
+
+    /// Transition a task's state and emit the corresponding event with custom data.
+    /// Update task state, persist to store, and publish an event with the provided data.
+    pub async fn set_task_state_with_data(
+        &self,
+        task_id: &str,
+        new_state: TaskState,
+        actor: Actor,
+        data: serde_json::Value,
+    ) -> Result<(), ServerError> {
         self.apply_task_state(task_id, new_state).await?;
 
         let event_type = match new_state {
@@ -298,7 +311,7 @@ impl Server {
             TaskState::Cancelled => EventType::TaskStateCancelled,
         };
 
-        let event = Event::new(event_type, task_id, actor, serde_json::json!({}));
+        let event = Event::new(event_type, task_id, actor, data);
         self.event_bus.publish(event).await?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Add `set_task_state_with_data` method to `Server` that accepts custom event data
- Update PR closure detection in run_loop to use `{ "source": "reconciliation" }` event data
- Both issue closures (from `reconcile_task`) and PR closures (from run_loop) now emit events with the same data shape

## Context

Issue closures detected via `reconcile_task()` were emitting events with `{ "source": "reconciliation" }`, while PR closures detected in the run_loop were emitting events with `{}`. Both represent the same concept (external closure detected during poll) but used different event data shapes.

This change unifies them so downstream consumers parsing these events only need to handle one format.

## Test plan

- [x] All existing tests pass (126 tests in `server`, 9 in `tasks-app`)
- [x] `set_task_state` continues to work for existing callers (uses empty data by default)
- [x] Both PR merge and PR closure paths now emit `{ "source": "reconciliation" }`

Fixes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)