### PR TITLE
Use GitHub linked_pull_requests for task-to-PR linkage

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -475,11 +475,36 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 );
 
                                 if !poll_server.has_merge_entry_for_pr(&pr_url).await {
-                                    let task_id = poll_server
+                                    // Priority 1: Branch name match (existing, fast, precise)
+                                    let mut task_id = poll_server
                                         .find_task_by_branch(&pr.head_ref)
-                                        .await
-                                        .unwrap_or_default();
+                                        .await;
 
+                                    // Priority 2: PR's linked_issues (GitHub's own linkage via
+                                    // closing keywords or manual links) — issue #258
+                                    if task_id.is_none() {
+                                        for linked_issue in &pr.linked_issues {
+                                            if let Some(id) = poll_server
+                                                .find_task_by_github_issue(
+                                                    &pr.owner,
+                                                    &pr.repo,
+                                                    linked_issue.number,
+                                                )
+                                                .await
+                                            {
+                                                debug!(
+                                                    pr = pr.number,
+                                                    issue = linked_issue.number,
+                                                    task_id = %id,
+                                                    "linked task via PR's linked_issues"
+                                                );
+                                                task_id = Some(id);
+                                                break;
+                                            }
+                                        }
+                                    }
+
+                                    let task_id = task_id.unwrap_or_default();
                                     let entry_id = format!("mq-{}-{}-pr-{}", pr.owner, pr.repo, pr.number);
                                     let entry = MergeQueueEntry::new(
                                         entry_id.clone(),
@@ -536,7 +561,33 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                 continue;
                             }
 
-                            let task_id = match poll_server.find_task_by_branch(&pr.head_ref).await {
+                            // Priority 1: Branch name match
+                            let mut task_id = poll_server.find_task_by_branch(&pr.head_ref).await;
+
+                            // Priority 2: PR's linked_issues (issue #258)
+                            if task_id.is_none() {
+                                for linked_issue in &pr.linked_issues {
+                                    if let Some(id) = poll_server
+                                        .find_task_by_github_issue(
+                                            &pr.owner,
+                                            &pr.repo,
+                                            linked_issue.number,
+                                        )
+                                        .await
+                                    {
+                                        debug!(
+                                            pr = pr.number,
+                                            issue = linked_issue.number,
+                                            task_id = %id,
+                                            "linked task via PR's linked_issues for closure"
+                                        );
+                                        task_id = Some(id);
+                                        break;
+                                    }
+                                }
+                            }
+
+                            let task_id = match task_id {
                                 Some(id) => id,
                                 None => continue,
                             };

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -421,6 +421,28 @@ impl Server {
         None
     }
 
+    /// Find a task ID by its linked GitHub issue.
+    ///
+    /// This is a fallback lookup for when branch name matching fails. It searches
+    /// for tasks whose source is the specified GitHub issue coordinates.
+    pub async fn find_task_by_github_issue(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+    ) -> Option<String> {
+        let state = self.state.read().await;
+        state.tasks.values()
+            .find(|task| {
+                matches!(
+                    &task.source,
+                    TaskSource::GithubIssue { owner: o, repo: r, number: n }
+                    if o == owner && r == repo && *n == issue_number
+                )
+            })
+            .map(|task| task.id.clone())
+    }
+
     // --- Reconciliation (issue #254, #255) ---
 
     /// Reconcile a task with fresh GitHub issue data.


### PR DESCRIPTION
## Summary

- Adds fallback task-to-PR linkage using GitHub's `linked_issues` field from PRs
- This makes linkage more robust for PRs created outside the system (manual PRs) or with different branch naming conventions
- Priority order: 1) Branch name match (existing, fast, precise), 2) PR's `linked_issues` (GitHub's closing keywords or manual links)

## Changes

- `crates/server/src/server.rs`: Add `find_task_by_github_issue()` method to find tasks by GitHub issue coordinates
- `crates/app/src/run_loop.rs`: Update PR processing and PR closure handling to use linked_issues as fallback

## Test plan

- [x] Code compiles successfully
- [x] Workspace tests pass (excluding desktop which requires X11 libraries)
- [ ] Manual test: Create a PR without the `tasks/{id}--` branch pattern but with a closing keyword like "Fixes #123"
- [ ] Verify the PR gets correctly linked to the task via the linked_issues fallback

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)