### PR TITLE
Persist poller high-water mark to survive restarts

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -338,7 +338,28 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     let parts: Vec<&str> = repo.split('/').collect();
                     if parts.len() == 2 {
                         let client = GitHubClient::new(&github_token);
-                        let poller = RepoPoller::new(client, parts[0], parts[1]);
+                        // Load persisted high-water mark to avoid cold start (spec github.md §5.3)
+                        let since = match poll_server.get_last_polled_at(project_id) {
+                            Ok(ts) => {
+                                if ts.is_some() {
+                                    debug!(
+                                        project = %project_id,
+                                        since = ?ts,
+                                        "restored poller high-water mark from database"
+                                    );
+                                }
+                                ts
+                            }
+                            Err(e) => {
+                                warn!(
+                                    project = %project_id,
+                                    error = %e,
+                                    "failed to load poller high-water mark, starting cold"
+                                );
+                                None
+                            }
+                        };
+                        let poller = RepoPoller::new(client, parts[0], parts[1]).with_since(since);
                         pollers.insert(project_id.clone(), poller);
                     }
                 }
@@ -590,6 +611,17 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                     }
                                 }
                                 PullRequestState::Open => unreachable!(),
+                            }
+                        }
+
+                        // Persist the high-water mark after successful poll (spec github.md §5.3)
+                        if let Some(ts) = result.timestamp {
+                            if let Err(e) = poll_server.set_last_polled_at(project_id, ts) {
+                                warn!(
+                                    project = %project_id,
+                                    error = %e,
+                                    "failed to persist poller high-water mark"
+                                );
                             }
                         }
                     }

--- a/crates/github/src/poller.rs
+++ b/crates/github/src/poller.rs
@@ -46,6 +46,16 @@ impl RepoPoller {
         }
     }
 
+    /// Set the initial high-water mark (for restoring from persisted state).
+    ///
+    /// Call this before the first `poll()` to avoid a cold start that fetches
+    /// all open items. Typically used with a timestamp loaded from the database
+    /// after a server restart.
+    pub fn with_since(mut self, since: Option<DateTime<Utc>>) -> Self {
+        self.since = since;
+        self
+    }
+
     /// The current high-water mark.
     pub fn since(&self) -> Option<DateTime<Utc>> {
         self.since

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -186,6 +186,28 @@ impl Server {
         state.projects.get(id).cloned()
     }
 
+    /// Get the last polled timestamp for a project (poller high-water mark).
+    ///
+    /// Used to initialize the poller after server restarts (spec github.md §5.3).
+    pub fn get_last_polled_at(&self, id: &str) -> Result<Option<chrono::DateTime<chrono::Utc>>, ServerError> {
+        let store = self.store.as_ref()
+            .ok_or_else(|| ServerError::StoreError("store not available".into()))?;
+        let store = store.lock().unwrap();
+        store.get_last_polled_at(id)
+            .map_err(|e| ServerError::StoreError(e.to_string()))
+    }
+
+    /// Set the last polled timestamp for a project (poller high-water mark).
+    ///
+    /// Called after each successful poll to persist the high-water mark.
+    pub fn set_last_polled_at(&self, id: &str, timestamp: chrono::DateTime<chrono::Utc>) -> Result<(), ServerError> {
+        let store = self.store.as_ref()
+            .ok_or_else(|| ServerError::StoreError("store not available".into()))?;
+        let store = store.lock().unwrap();
+        store.set_last_polled_at(id, timestamp)
+            .map_err(|e| ServerError::StoreError(e.to_string()))
+    }
+
     // --- Mode management (spec Section 6) ---
 
     pub async fn mode(&self) -> Mode {

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -124,6 +124,45 @@ impl Store {
         Ok(affected > 0)
     }
 
+    /// Get the last polled timestamp for a project (poller high-water mark).
+    ///
+    /// Returns `None` if the project doesn't exist or hasn't been polled yet.
+    /// Used to initialize the poller after server restarts (spec github.md §5.3).
+    pub fn get_last_polled_at(&self, id: &str) -> Result<Option<DateTime<Utc>>, StoreError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT last_polled_at FROM projects WHERE id = ?1")?;
+        let mut rows = stmt.query_map(params![id], |row| row.get::<_, Option<String>>(0))?;
+        match rows.next() {
+            Some(row) => {
+                let ts_str: Option<String> = row?;
+                match ts_str {
+                    Some(s) => {
+                        let ts: DateTime<Utc> = s.parse().map_err(|e: chrono::ParseError| {
+                            serde_json::from_str::<()>(&e.to_string()).unwrap_err()
+                        })?;
+                        Ok(Some(ts))
+                    }
+                    None => Ok(None),
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Set the last polled timestamp for a project (poller high-water mark).
+    ///
+    /// Called after each successful poll to persist the high-water mark.
+    /// On restart, this value is used to avoid re-fetching all open items.
+    pub fn set_last_polled_at(&self, id: &str, timestamp: DateTime<Utc>) -> Result<(), StoreError> {
+        let ts_str = timestamp.to_rfc3339();
+        self.conn.execute(
+            "UPDATE projects SET last_polled_at = ?1 WHERE id = ?2",
+            params![ts_str, id],
+        )?;
+        Ok(())
+    }
+
     // ── Merge queue ──────────────────────────────────────────────
 
     /// Insert or replace a merge queue entry.

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -98,5 +98,27 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
         }
     }
 
+    // Migration: add last_polled_at column to projects table (spec github.md §5.3)
+    // This persists the poller high-water mark to survive server restarts.
+    match conn.execute(
+        "ALTER TABLE projects ADD COLUMN last_polled_at TEXT",
+        [],
+    ) {
+        Ok(_) => {
+            tracing::info!("added last_polled_at column to projects table");
+        }
+        Err(rusqlite::Error::SqliteFailure(e, Some(ref msg)))
+            if e.extended_code == rusqlite::ffi::SQLITE_ERROR
+                && msg.contains("duplicate column name") =>
+        {
+            // Column already exists — this is expected for existing databases
+            tracing::debug!("last_polled_at column already exists");
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "failed to add last_polled_at column");
+            return Err(e);
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Store the GitHub poller's `since` timestamp per project in SQLite to avoid expensive cold starts on server restart
- Previously, each restart would fetch ALL open issues and PRs, consuming 200-600 API rate limit points
- Now the high-water mark is persisted and restored, enabling incremental polling from the last known state

## Changes

- **`crates/store/src/schema.rs`**: Add `last_polled_at TEXT` column to the projects table via migration
- **`crates/store/src/lib.rs`**: Add `get_last_polled_at()` and `set_last_polled_at()` methods
- **`crates/github/src/poller.rs`**: Add `with_since()` builder method to initialize the poller with a persisted timestamp
- **`crates/server/src/server.rs`**: Add wrapper methods to access store from Server
- **`crates/app/src/run_loop.rs`**: Load persisted mark when creating pollers, persist after each successful poll

## Test plan

- [x] All existing tests pass (205 tests)
- [x] Build succeeds
- [ ] Manual test: Start server, let it poll, restart, verify no cold start

Implements the optimization noted in spec github.md §5.3.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)