### PR TITLE
Add 'rebuild from GitHub' command for full state reconstruction

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -71,6 +71,155 @@ fn cmd_list_projects() -> Result<(), String> {
     Ok(())
 }
 
+/// Rebuild state from GitHub (issue #256).
+///
+/// This is a standalone CLI operation that:
+/// 1. Clears tasks and merge_queue tables (preserving accounting and projects)
+/// 2. Polls all tracked projects from scratch
+/// 3. Re-creates tasks from all open issues
+/// 4. Re-creates merge queue entries from all open PRs
+async fn cmd_rebuild() -> Result<(), String> {
+    use server::workflow::LabelConfig;
+    use tasks_github::client::GitHubClient;
+    use tasks_github::poller::RepoPoller;
+
+    let github_token = std::env::var("GITHUB_TOKEN")
+        .map_err(|_| "GITHUB_TOKEN environment variable not set")?;
+
+    let store = open_store()?;
+
+    // Get list of projects before clearing
+    let projects = store
+        .list_projects()
+        .map_err(|e| format!("Failed to list projects: {e}"))?;
+
+    if projects.is_empty() {
+        eprintln!("No projects configured. Nothing to rebuild.");
+        return Ok(());
+    }
+
+    // Clear tasks and merge_queue tables
+    let tasks_cleared = store
+        .clear_tasks()
+        .map_err(|e| format!("Failed to clear tasks: {e}"))?;
+    let merge_cleared = store
+        .clear_merge_queue()
+        .map_err(|e| format!("Failed to clear merge queue: {e}"))?;
+
+    eprintln!(
+        "Cleared {} tasks and {} merge queue entries",
+        tasks_cleared, merge_cleared
+    );
+
+    let label_config = LabelConfig::default();
+    let mut total_tasks = 0;
+    let mut total_merge_entries = 0;
+
+    // Poll each project and recreate state
+    for project in &projects {
+        let parts: Vec<&str> = project.repo.split('/').collect();
+        if parts.len() != 2 {
+            eprintln!("Skipping invalid project repo format: {}", project.repo);
+            continue;
+        }
+
+        let (owner, repo_name) = (parts[0], parts[1]);
+        eprintln!("Polling {}/{}...", owner, repo_name);
+
+        let client = GitHubClient::new(&github_token);
+        let mut poller = RepoPoller::new(client, owner, repo_name);
+
+        match poller.poll().await {
+            Ok(result) => {
+                // Create tasks from issues
+                for issue in &result.issues {
+                    if let Some(task) =
+                        server::scheduler::issue_to_task(issue, &project.id, &label_config)
+                    {
+                        if let Err(e) = store.save_task(&task) {
+                            eprintln!(
+                                "  Warning: failed to save task for issue #{}: {}",
+                                issue.number, e
+                            );
+                        } else {
+                            total_tasks += 1;
+                        }
+                    }
+                }
+
+                // Create merge queue entries from open, non-draft PRs
+                for pr in &result.pull_requests {
+                    if pr.state == tasks_github::model::PullRequestState::Open && !pr.is_draft {
+                        let pr_url = format!(
+                            "https://github.com/{}/{}/pull/{}",
+                            pr.owner, pr.repo, pr.number
+                        );
+                        let entry_id = format!("mq-{}-{}-pr-{}", pr.owner, pr.repo, pr.number);
+
+                        // Try to find linked task by branch name
+                        let task_id = find_task_by_branch_in_store(&store, &pr.head_ref)
+                            .unwrap_or_default();
+
+                        let entry = server::model::merge_queue::MergeQueueEntry::new(
+                            entry_id,
+                            task_id,
+                            &pr_url,
+                        );
+
+                        if let Err(e) = store.save_merge_entry(&entry) {
+                            eprintln!(
+                                "  Warning: failed to save merge entry for PR #{}: {}",
+                                pr.number, e
+                            );
+                        } else {
+                            total_merge_entries += 1;
+                        }
+                    }
+                }
+
+                eprintln!(
+                    "  {} issues, {} PRs processed",
+                    result.issues.len(),
+                    result.pull_requests.len()
+                );
+            }
+            Err(e) => {
+                eprintln!("  Error polling {}/{}: {}", owner, repo_name, e);
+            }
+        }
+    }
+
+    eprintln!();
+    eprintln!(
+        "Rebuild complete: {} tasks, {} merge queue entries created",
+        total_tasks, total_merge_entries
+    );
+
+    Ok(())
+}
+
+/// Find a task ID by its branch name from the store.
+fn find_task_by_branch_in_store(store: &tasks_store::Store, branch: &str) -> Option<String> {
+    // Strip the "tasks/" prefix
+    let branch_suffix = branch.strip_prefix("tasks/")?;
+
+    let tasks = store.list_tasks().ok()?;
+
+    // New format: "tasks/{task_id}--{unique_suffix}"
+    if let Some((task_id, _suffix)) = branch_suffix.split_once("--") {
+        if tasks.iter().any(|t| t.id == task_id) {
+            return Some(task_id.to_string());
+        }
+    }
+
+    // Legacy format: "tasks/{task_id}" (exact match)
+    if tasks.iter().any(|t| t.id == branch_suffix) {
+        return Some(branch_suffix.to_string());
+    }
+
+    None
+}
+
 fn print_usage() {
     eprintln!("Usage: tasks-app <command>");
     eprintln!();
@@ -79,6 +228,7 @@ fn print_usage() {
     eprintln!("  add-project <owner/repo>  Add a project to track");
     eprintln!("  remove-project <id>       Remove a project");
     eprintln!("  list-projects             List configured projects");
+    eprintln!("  rebuild                   Rebuild state from GitHub (clears tasks/merge queue)");
 }
 
 #[tokio::main]
@@ -146,6 +296,7 @@ async fn main() {
             cmd_remove_project(id)
         }
         "list-projects" => cmd_list_projects(),
+        "rebuild" => cmd_rebuild().await,
         "run" => {
             let mut config = match AppConfig::from_env() {
                 Ok(c) => c,

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -317,6 +317,13 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         loop {
             interval.tick().await;
 
+            // Check if rebuild was requested (issue #256)
+            // If so, clear all pollers so they're recreated with since=None
+            if poll_server.take_rebuild_requested() {
+                info!("rebuild requested, clearing pollers for full re-fetch");
+                pollers.clear();
+            }
+
             // Sync pollers with live project list
             let projects: Vec<(String, String)> = {
                 let state = poll_server.state.read().await;

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -55,6 +55,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/merge-queue/{id}/reject", post(reject_merge))
         .route("/mode", get(get_mode))
         .route("/mode", post(set_mode))
+        .route("/rebuild", post(rebuild_from_github))
         .route("/orchestrator/chat", post(orchestrator_chat))
         .route("/accounting", get(get_accounting_summary))
         .route("/accounting/tasks", get(list_task_accounting))
@@ -414,6 +415,23 @@ async fn set_mode(
     }
 
     Ok(Json(ModeResponse { mode }))
+}
+
+/// POST /api/rebuild — Rebuild state from GitHub (issue #256).
+///
+/// Clears tasks and merge queue from both memory and database,
+/// then signals the poll loop to re-fetch all data from GitHub.
+/// Preserves: accounting data, event logs, projects table, operating mode.
+async fn rebuild_from_github(
+    State(state): State<ApiState>,
+) -> Result<Json<server::RebuildStats>, ApiError> {
+    let stats = state
+        .server
+        .rebuild_from_github()
+        .await
+        .map_err(ApiError::Server)?;
+
+    Ok(Json(stats))
 }
 
 /// POST /api/tasks/:id/chat — Send a chat message to a running session (spec §9.2).

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -76,6 +76,8 @@ pub enum EventType {
     SystemTimeLimitSoft,
     /// Session hard time limit reached (spec §17.4).
     SystemTimeLimitHard,
+    /// State rebuild from GitHub (issue #256).
+    SystemRebuild,
 
     // Accounting events (spec §16.4)
     /// Token usage accounting (input/output tokens per request).
@@ -127,6 +129,7 @@ impl EventType {
             Self::SystemMemoryEmergency => "system:memory:emergency",
             Self::SystemTimeLimitSoft => "system:time_limit:soft",
             Self::SystemTimeLimitHard => "system:time_limit:hard",
+            Self::SystemRebuild => "system:rebuild",
             Self::SystemAccountingTokens => "system:accounting:tokens",
             Self::SystemAccountingApiCall => "system:accounting:api_call",
             Self::SystemAccountingSession => "system:accounting:session",
@@ -202,6 +205,7 @@ impl TryFrom<String> for EventType {
             "system:memory:emergency" => Ok(Self::SystemMemoryEmergency),
             "system:time_limit:soft" => Ok(Self::SystemTimeLimitSoft),
             "system:time_limit:hard" => Ok(Self::SystemTimeLimitHard),
+            "system:rebuild" => Ok(Self::SystemRebuild),
             "system:accounting:tokens" => Ok(Self::SystemAccountingTokens),
             "system:accounting:api_call" => Ok(Self::SystemAccountingApiCall),
             "system:accounting:session" => Ok(Self::SystemAccountingSession),

--- a/crates/github/src/poller.rs
+++ b/crates/github/src/poller.rs
@@ -51,6 +51,12 @@ impl RepoPoller {
         self.since
     }
 
+    /// Reset the high-water mark to None (for rebuild command, issue #256).
+    /// Next poll will fetch all open items from scratch.
+    pub fn reset(&mut self) {
+        self.since = None;
+    }
+
     /// Poll for both issues and PRs updated since the last poll.
     ///
     /// On first call, fetches all open items. On subsequent calls, only items

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -18,7 +18,7 @@ mod server;
 
 pub use mode::Mode;
 pub use recovery::{RecoveryResult, DEFAULT_MAX_RETRIES};
-pub use server::{Server, ServerError, ServerState};
+pub use server::{Server, ServerError, ServerState, RebuildStats};
 pub use workflow_watcher::{WorkflowConfigCache, WorkflowConfigWatcher, RefreshResult};
 pub use workspace::{
     CleanupCandidate, CleanupConfig, CleanupReason,

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use thiserror::Error;
 use tokio::sync::RwLock;
@@ -41,6 +42,15 @@ pub enum ServerError {
     TaskNotFound(String),
     #[error("store error: {0}")]
     StoreError(String),
+}
+
+/// Statistics from a rebuild operation (issue #256).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RebuildStats {
+    /// Number of tasks cleared from memory/database.
+    pub tasks_cleared: usize,
+    /// Number of merge queue entries cleared from memory/database.
+    pub merge_entries_cleared: usize,
 }
 
 /// Shared server state.
@@ -92,6 +102,8 @@ pub struct Server {
     pub event_bus: Arc<EventBus>,
     pub presence: Arc<PresenceTracker>,
     pub(crate) store: Option<Arc<StdMutex<tasks_store::Store>>>,
+    /// Flag to signal the poll loop to reset pollers (issue #256).
+    rebuild_requested: AtomicBool,
 }
 
 impl Server {
@@ -101,6 +113,7 @@ impl Server {
             event_bus: Arc::new(event_bus),
             presence: Arc::new(PresenceTracker::new()),
             store: None,
+            rebuild_requested: AtomicBool::new(false),
         }
     }
 
@@ -111,6 +124,7 @@ impl Server {
             event_bus: Arc::new(event_bus),
             presence: Arc::new(PresenceTracker::new()),
             store: Some(Arc::new(StdMutex::new(store))),
+            rebuild_requested: AtomicBool::new(false),
         }
     }
 
@@ -1199,6 +1213,79 @@ impl Server {
         );
         self.event_bus.publish(event).await?;
         Ok(())
+    }
+
+    // --- Rebuild from GitHub (issue #256) ---
+
+    /// Request a rebuild from GitHub.
+    ///
+    /// This sets a flag that the poll loop will check. When set, the poll loop
+    /// will clear its pollers, causing them to be recreated with `since: None`
+    /// (which fetches all open items from scratch).
+    ///
+    /// The rebuild process:
+    /// 1. Clear in-memory tasks and merge queue
+    /// 2. Clear database tables (preserving accounting and projects)
+    /// 3. Set rebuild_requested flag for poll loop
+    /// 4. Emit system:rebuild event
+    /// 5. Poll loop resets pollers and re-fetches all data
+    pub async fn rebuild_from_github(&self) -> Result<RebuildStats, ServerError> {
+        let (tasks_cleared, merge_entries_cleared) = {
+            // Clear in-memory state
+            let mut state = self.state.write().await;
+            let tasks_count = state.tasks.len();
+            let merge_count = state.merge_queue.entries().len();
+            state.tasks.clear();
+            state.merge_queue = crate::merge_queue::MergeQueue::new();
+            (tasks_count, merge_count)
+        };
+
+        // Clear database tables
+        let (db_tasks, db_merge) = if let Some(ref store) = self.store {
+            let store = store.lock().unwrap();
+            let tasks = store.clear_tasks()
+                .map_err(|e| ServerError::StoreError(e.to_string()))?;
+            let merge = store.clear_merge_queue()
+                .map_err(|e| ServerError::StoreError(e.to_string()))?;
+            (tasks, merge)
+        } else {
+            (0, 0)
+        };
+
+        // Signal poll loop to reset pollers
+        self.rebuild_requested.store(true, Ordering::SeqCst);
+
+        // Emit rebuild event
+        let event = Event::new(
+            EventType::SystemRebuild,
+            "system",
+            Actor::Human,
+            serde_json::json!({
+                "tasks_cleared": tasks_cleared,
+                "merge_entries_cleared": merge_entries_cleared,
+            }),
+        );
+        self.event_bus.publish(event).await?;
+
+        tracing::info!(
+            tasks_cleared = tasks_cleared,
+            merge_entries_cleared = merge_entries_cleared,
+            db_tasks_cleared = db_tasks,
+            db_merge_cleared = db_merge,
+            "rebuild from GitHub initiated"
+        );
+
+        Ok(RebuildStats {
+            tasks_cleared,
+            merge_entries_cleared,
+        })
+    }
+
+    /// Check if a rebuild has been requested.
+    ///
+    /// Called by the poll loop. Returns true and clears the flag if set.
+    pub fn take_rebuild_requested(&self) -> bool {
+        self.rebuild_requested.swap(false, Ordering::SeqCst)
     }
 
     // --- Session failure handling (spec §13.1, §13.2) ---

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -354,6 +354,20 @@ impl Store {
         Ok(affected > 0)
     }
 
+    /// Delete all tasks from the database (for rebuild command, issue #256).
+    /// Returns the number of rows deleted.
+    pub fn clear_tasks(&self) -> Result<usize, StoreError> {
+        let affected = self.conn.execute("DELETE FROM tasks", [])?;
+        Ok(affected)
+    }
+
+    /// Delete all merge queue entries from the database (for rebuild command, issue #256).
+    /// Returns the number of rows deleted.
+    pub fn clear_merge_queue(&self) -> Result<usize, StoreError> {
+        let affected = self.conn.execute("DELETE FROM merge_queue", [])?;
+        Ok(affected)
+    }
+
     // ── Accounting (spec §16.4) ───────────────────────────────────
 
     /// Get or create accounting data for a task.


### PR DESCRIPTION
## Summary

Closes #256

When the local SQLite database drifts from GitHub reality, the only recovery was to manually delete `db.sqlite` and restart. This PR adds a `rebuild` command (CLI and API endpoint) that cleanly reconstructs task and merge queue state from GitHub.

- **CLI**: `cargo run -- rebuild`
- **API**: `POST /api/rebuild`

## Implementation

1. **Store**: Added `clear_tasks()` and `clear_merge_queue()` methods to delete all rows
2. **RepoPoller**: Added `reset()` method to clear high-water marks for full re-fetch
3. **Server**: Added `rebuild_from_github()` method that:
   - Clears in-memory tasks and merge queue
   - Clears database tables (preserving accounting and projects)
   - Sets `rebuild_requested` flag for poll loop
   - Emits `system:rebuild` event
4. **Events**: Added `SystemRebuild` event type (`system:rebuild`)
5. **Poll loop**: Checks `rebuild_requested` flag and clears pollers when set, causing full re-fetch on next tick

## What is preserved

- Accounting data (task tokens, session counts)
- Event logs
- Projects table
- Operating mode

Task IDs remain stable (`gh-{owner}-{repo}-issue-{number}`) so accounting and event history survive rebuilds.

## Test plan

- [x] Build succeeds
- [x] All tests pass
- [ ] Manual test: CLI `cargo run -- rebuild` with existing database
- [ ] Manual test: API `POST /api/rebuild` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)