### PR TITLE
Refactor: Make session termination event-driven on Stop mode

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -1582,6 +1582,45 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
+    // --- 8d. Spawn stop mode listener (spec §6.1) ---
+    //
+    // When mode changes to Stop, terminate all running sessions.
+    // This is event-driven so that any mode change source (web, CLI, orchestrator)
+    // triggers session termination consistently.
+
+    let stop_session_mgr = session_manager.clone();
+    let stop_event_bus = server.event_bus.clone();
+
+    let stop_mode_handle = tokio::spawn(async move {
+        let mut rx = stop_event_bus.subscribe();
+        loop {
+            let event = match rx.recv().await {
+                Ok(e) => e,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(
+                        skipped = n,
+                        "stop mode listener lagged, some events may be missed"
+                    );
+                    continue;
+                }
+                Err(_) => break,
+            };
+
+            // Only handle SystemModeStop events
+            if event.event_type == EventType::SystemModeStop {
+                // Give sessions 5 seconds to stop gracefully before force-destroying containers
+                let timeout = std::time::Duration::from_secs(5);
+                let stopped = stop_session_mgr.stop_all_with_timeout(timeout).await;
+                if stopped > 0 {
+                    info!(
+                        stopped_sessions = stopped,
+                        "terminated sessions for Stop mode (event-driven)"
+                    );
+                }
+            }
+        }
+    });
+
     // --- 9. Optionally spawn web server ---
 
     let web_handle = if config.web {
@@ -1645,6 +1684,7 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     orchestrator_handle.abort();
     watchdog_handle.abort();
     cleanup_handle.abort();
+    stop_mode_handle.abort();
     if let Some(h) = web_handle {
         h.abort();
     }

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -386,9 +386,8 @@ async fn get_mode(State(state): State<ApiState>) -> Json<ModeResponse> {
 
 /// POST /api/mode — Set operating mode.
 ///
-/// When transitioning to Stop mode, all running sessions are terminated.
-/// Sessions get 5 seconds to stop gracefully before containers are force-destroyed.
-/// (Spec §6.1: "Running agent processes are terminated")
+/// When transitioning to Stop mode, session termination is handled by an
+/// event-driven listener in the run loop (spec §6.1).
 async fn set_mode(
     State(state): State<ApiState>,
     Json(req): Json<SetModeRequest>,
@@ -398,20 +397,6 @@ async fn set_mode(
         .set_mode(req.mode, &Actor::Human)
         .await
         .map_err(ApiError::Server)?;
-
-    // When entering Stop mode, terminate all running sessions (spec §6.1).
-    // TODO: Move to an event-driven listener (on system:mode:stop) so that
-    // non-web mode changes (CLI, orchestrator) also trigger session termination.
-    if mode == Mode::Stop {
-        if let Some(ref session_manager) = state.session_manager {
-            // Give sessions 5 seconds to stop gracefully before force-destroying containers
-            let timeout = std::time::Duration::from_secs(5);
-            let stopped = session_manager.stop_all_with_timeout(timeout).await;
-            if stopped > 0 {
-                tracing::info!(stopped_sessions = stopped, "terminated sessions for Stop mode");
-            }
-        }
-    }
 
     Ok(Json(ModeResponse { mode }))
 }


### PR DESCRIPTION
## Summary

- Moves session termination logic from the web handler to an event-driven listener in the run loop
- Ensures mode changes to Stop from any source (web, CLI, orchestrator) consistently trigger session termination
- Removes the TODO comment that identified this coupling issue

## Changes

- **crates/app/src/run_loop.rs**: Added stop mode event listener (section 8d) that subscribes to `SystemModeStop` events and calls `session_manager.stop_all_with_timeout()`
- **crates/app/src/web.rs**: Removed direct session termination from `set_mode` handler

## Test plan

- [ ] Verify changing mode to Stop via web UI terminates running sessions
- [ ] Code compiles and existing tests pass

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)