### PR TITLE
Fix SSE presence guard dropping immediately instead of on disconnect

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -24,6 +24,7 @@ tracing-appender = "0.2"
 chrono.workspace = true
 dotenvy = "0.15"
 futures = "0.3"
+pin-project = "1"
 axum = { version = "0.8", features = ["ws"] }
 tower-http = { version = "0.6", features = ["cors", "fs"] }
 tower = "0.5"

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -5,7 +5,9 @@
 //! exposes API endpoints under `/api/`.
 
 use std::convert::Infallible;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use axum::{
     Json, Router,
@@ -26,6 +28,7 @@ use tower_http::cors::CorsLayer;
 use tasks_agent::CompletionsService;
 use events::Actor;
 use server::Server;
+use server::presence::OwnedConnectionGuard;
 use models::Mode;
 
 /// Shared state for API handlers.
@@ -524,6 +527,26 @@ async fn get_task_accounting(
     Ok(Json(accounting))
 }
 
+/// A stream wrapper that holds a presence guard until the stream ends.
+///
+/// This ensures the human presence is tracked for the entire duration
+/// of an SSE connection, not just when the handler function returns.
+#[pin_project::pin_project]
+struct PresenceStream<S> {
+    #[pin]
+    inner: S,
+    #[allow(dead_code)]
+    guard: OwnedConnectionGuard,
+}
+
+impl<S: Stream> Stream for PresenceStream<S> {
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().inner.poll_next(cx)
+    }
+}
+
 /// GET /api/events — SSE stream of live events.
 ///
 /// Supports optional query params: `pattern` and `task_id` for filtering.
@@ -531,8 +554,8 @@ async fn event_stream(
     State(state): State<ApiState>,
     Query(query): Query<EventStreamQuery>,
 ) -> Sse<impl Stream<Item = Result<SseEvent, Infallible>>> {
-    // Register presence — the connection guard will decrement on drop.
-    let _presence_guard = state.server.presence.connect();
+    // Register presence — the guard lives until the stream is dropped (client disconnects).
+    let presence_guard = state.server.presence.connect_owned();
 
     let rx = state.server.event_bus.subscribe();
     let stream = BroadcastStream::new(rx).filter_map(move |result| {
@@ -556,7 +579,13 @@ async fn event_stream(
         }
     });
 
-    Sse::new(stream).keep_alive(KeepAlive::default())
+    // Wrap the stream to keep the presence guard alive until disconnection.
+    let presence_stream = PresenceStream {
+        inner: stream,
+        guard: presence_guard,
+    };
+
+    Sse::new(presence_stream).keep_alive(KeepAlive::default())
 }
 
 // --- Completions handlers ---

--- a/crates/server/src/presence.rs
+++ b/crates/server/src/presence.rs
@@ -5,6 +5,7 @@
 //! - Disconnected = autonomous mode, orchestrator makes judgment calls.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 /// Tracks active GUI connections to determine human presence.
 pub struct PresenceTracker {
@@ -22,6 +23,18 @@ impl PresenceTracker {
     pub fn connect(&self) -> ConnectionGuard<'_> {
         self.active_connections.fetch_add(1, Ordering::SeqCst);
         ConnectionGuard { tracker: self }
+    }
+
+    /// A GUI client connected (owned version).
+    ///
+    /// Returns an owned guard that doesn't borrow the tracker.
+    /// Use this when the guard needs to outlive a function scope,
+    /// e.g., when captured by an async stream.
+    pub fn connect_owned(self: &Arc<Self>) -> OwnedConnectionGuard {
+        self.active_connections.fetch_add(1, Ordering::SeqCst);
+        OwnedConnectionGuard {
+            tracker: Arc::clone(self),
+        }
     }
 
     /// Whether any GUI client is connected (human is present).
@@ -56,6 +69,20 @@ impl Drop for ConnectionGuard<'_> {
     }
 }
 
+/// Owned RAII guard that decrements the connection count on drop.
+///
+/// Unlike [`ConnectionGuard`], this holds an `Arc` and can be moved
+/// into async streams or other contexts that outlive the function scope.
+pub struct OwnedConnectionGuard {
+    tracker: Arc<PresenceTracker>,
+}
+
+impl Drop for OwnedConnectionGuard {
+    fn drop(&mut self) {
+        self.tracker.disconnect();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,6 +104,43 @@ mod tests {
         assert_eq!(tracker.connection_count(), 1);
 
         drop(guard2);
+        assert!(!tracker.is_present());
+    }
+
+    #[test]
+    fn owned_presence_tracking() {
+        let tracker = Arc::new(PresenceTracker::new());
+        assert!(!tracker.is_present());
+
+        let guard1 = tracker.connect_owned();
+        assert!(tracker.is_present());
+        assert_eq!(tracker.connection_count(), 1);
+
+        let guard2 = tracker.connect_owned();
+        assert_eq!(tracker.connection_count(), 2);
+
+        drop(guard1);
+        assert!(tracker.is_present());
+        assert_eq!(tracker.connection_count(), 1);
+
+        drop(guard2);
+        assert!(!tracker.is_present());
+    }
+
+    #[test]
+    fn mixed_guards() {
+        let tracker = Arc::new(PresenceTracker::new());
+        assert!(!tracker.is_present());
+
+        let borrowed = tracker.connect();
+        let owned = tracker.connect_owned();
+        assert_eq!(tracker.connection_count(), 2);
+
+        drop(borrowed);
+        assert_eq!(tracker.connection_count(), 1);
+
+        drop(owned);
+        assert_eq!(tracker.connection_count(), 0);
         assert!(!tracker.is_present());
     }
 }


### PR DESCRIPTION
## Summary

- Fixes bug where the presence guard in `event_stream()` was dropped when the async function returned, not when the SSE connection ended
- Adds `OwnedConnectionGuard` that holds an `Arc<PresenceTracker>` to outlive the function scope
- Wraps the SSE stream in `PresenceStream` to keep the guard alive until client disconnects

## Test plan

- [x] All existing tests pass (137 tests)
- [x] New unit tests for `OwnedConnectionGuard` and mixed guard usage
- [ ] Manual testing: connect via SSE, verify presence is tracked correctly

Fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)