### PR TITLE
Check operating mode in dispatch loop to skip dispatch in Stop mode

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -809,6 +809,12 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
 
+            // Check operating mode — no dispatch in Stop mode (spec §6.1)
+            let mode = dispatch_server.mode().await;
+            if mode == server::Mode::Stop {
+                continue;
+            }
+
             // Check memory pressure before dispatching new work.
             // When paused, pass global_max=0 so the dispatcher won't select
             // new work (which would transition tasks to Running prematurely),


### PR DESCRIPTION
## Summary

- Adds a mode check to the dispatch loop in `crates/app/src/run_loop.rs` before running dispatch
- When in Stop mode, the loop now skips dispatch entirely (per spec §6.1)
- This is consistent with the orchestrator loop which already has this check

## Problem

When mode transitions to Stop:
1. `SystemModeStop` event is emitted
2. Sessions are terminated, emitting `TaskStateWaiting` events
3. The dispatch loop triggers on `TaskStateWaiting` events
4. Without a mode check, the dispatcher could select tasks and start new sessions

## Fix

Added a mode check after the debounce period:
```rust
let mode = dispatch_server.mode().await;
if mode == server::Mode::Stop {
    continue;
}
```

## Test plan

- [x] Code compiles successfully
- [x] All existing tests pass (`cargo test --package tasks-app`)
- [ ] Manual testing: verify dispatch does not run when mode is Stop

Fixes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)