### PR TITLE
Add UI for orchestrator escalation events

### DIFF
--- a/web/src/pages/dashboard/page.tsx
+++ b/web/src/pages/dashboard/page.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Cell, Pie, PieChart, Bar, BarChart, XAxis, YAxis } from "recharts";
-import { AlertTriangle, RefreshCw, Sparkles, Bell } from "lucide-react";
+import { AlertTriangle, RefreshCw, Sparkles, Bell, ExternalLink } from "lucide-react";
 import { useAppState } from "@/hooks/use-app-state";
 import { complete } from "@/lib/api";
-import type { Task, TaskState, MergeQueueEntry, MergeStatus } from "@/lib/types";
+import type { Task, TaskState, MergeQueueEntry, MergeStatus, Event, Project } from "@/lib/types";
+import { formatRelativeTime, projectLabel } from "@/lib/utils";
 import {
   Card,
   CardContent,
@@ -387,34 +388,166 @@ Be concise and helpful. Don't use bullet points - write in natural sentences.`;
 }
 
 // ---------------------------------------------------------------------------
-// Orchestrator Alerts Placeholder
+// Escalation event parsing helper
 // ---------------------------------------------------------------------------
 
-function OrchestratorAlerts() {
+interface EscalationAlert {
+  id: string;
+  timestamp: string;
+  action: string;
+  reasoning?: string;
+  prUrl?: string;
+  taskId?: string;
+  fromMode?: string;
+  toMode?: string;
+}
+
+function parseEscalationEvents(events: Event[]): EscalationAlert[] {
+  return events
+    .filter((e) => e.type === "orchestrator:escalation")
+    .map((event) => ({
+      id: event.id,
+      timestamp: event.ts,
+      action: typeof event.data?.action === "string" ? event.data.action : "unknown",
+      reasoning:
+        typeof event.data?.reasoning === "string" ? event.data.reasoning :
+        typeof event.data?.reason === "string" ? event.data.reason :
+        undefined,
+      prUrl: typeof event.data?.pr_url === "string" ? event.data.pr_url : undefined,
+      taskId: event.task,
+      fromMode: typeof event.data?.from === "string" ? event.data.from : undefined,
+      toMode: typeof event.data?.to === "string" ? event.data.to : undefined,
+    }))
+    .sort((a, b) => b.timestamp.localeCompare(a.timestamp)); // Most recent first
+}
+
+function taskLabel(taskId: string | undefined, tasks: Task[], projects: Project[]): string | null {
+  if (!taskId) return null;
+  const task = tasks.find((t) => t.id === taskId);
+  if (!task) return taskId.slice(0, 8);
+  const { source } = task;
+  const issueNum =
+    (source.type === "github_issue" || source.type === "github_pr")
+      ? `#${source.number}`
+      : taskId.slice(0, 8);
+  const proj = projectLabel(task.project, projects);
+  const repoName = proj.includes("/") ? proj.split("/")[1] : proj;
+  return `${issueNum} (${repoName})`;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator Alerts Component
+// ---------------------------------------------------------------------------
+
+function OrchestratorAlerts({
+  events,
+  tasks,
+  projects,
+}: {
+  events: Event[];
+  tasks: Task[];
+  projects: Project[];
+}) {
+  const escalations = useMemo(() => parseEscalationEvents(events), [events]);
+
+  // Show at most 5 recent escalations
+  const recentEscalations = escalations.slice(0, 5);
+
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Bell className="h-4 w-4" />
           Orchestrator Notifications
+          {escalations.length > 0 && (
+            <span className="ml-auto rounded-full bg-yellow-500/20 px-2 py-0.5 text-xs font-medium text-yellow-500">
+              {escalations.length}
+            </span>
+          )}
         </CardTitle>
         <CardDescription>
           System alerts and concerns will appear here
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="flex flex-col items-center justify-center py-8 text-center">
-          <div className="rounded-full bg-muted p-3">
-            <Bell className="h-6 w-6 text-muted-foreground" />
+        {recentEscalations.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <div className="rounded-full bg-muted p-3">
+              <Bell className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <p className="mt-3 text-sm text-muted-foreground">
+              No alerts at this time
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground/70">
+              The orchestrator will notify you of conflicts, failures, or items
+              needing attention
+            </p>
           </div>
-          <p className="mt-3 text-sm text-muted-foreground">
-            No alerts at this time
-          </p>
-          <p className="mt-1 text-xs text-muted-foreground/70">
-            The orchestrator will notify you of conflicts, failures, or items
-            needing attention
-          </p>
-        </div>
+        ) : (
+          <div className="space-y-3">
+            {recentEscalations.map((alert) => {
+              const label = taskLabel(alert.taskId, tasks, projects);
+              let title = "Alert";
+              if (alert.action === "conflict_needs_human") {
+                title = "Conflict Needs Review";
+              } else if (alert.action === "mode_lowered") {
+                title = "Mode Lowered";
+              }
+
+              return (
+                <div
+                  key={alert.id}
+                  className="rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3"
+                >
+                  <div className="flex items-start gap-2">
+                    <AlertTriangle className="h-4 w-4 text-yellow-500 mt-0.5 shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-medium text-sm text-yellow-400">
+                          {title}
+                        </span>
+                        {label && (
+                          <span className="rounded border border-border px-1.5 py-0.5 font-mono text-xs">
+                            {label}
+                          </span>
+                        )}
+                        {alert.action === "mode_lowered" && alert.fromMode && alert.toMode && (
+                          <span className="rounded border border-yellow-500/30 bg-yellow-500/10 px-1.5 py-0.5 text-xs">
+                            {alert.fromMode} → {alert.toMode}
+                          </span>
+                        )}
+                        {alert.prUrl && (
+                          <a
+                            href={alert.prUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-xs text-blue-400 hover:underline"
+                          >
+                            View PR
+                            <ExternalLink className="h-3 w-3" />
+                          </a>
+                        )}
+                        <span className="text-xs text-muted-foreground">
+                          {formatRelativeTime(alert.timestamp)}
+                        </span>
+                      </div>
+                      {alert.reasoning && (
+                        <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
+                          {alert.reasoning}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+            {escalations.length > 5 && (
+              <p className="text-center text-xs text-muted-foreground">
+                +{escalations.length - 5} more alerts
+              </p>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );
@@ -497,9 +630,10 @@ function StatsCards({
 // ---------------------------------------------------------------------------
 
 export function DashboardPage() {
-  const { filteredTasks, filteredMergeQueue, selectedProject, snapshot } =
+  const { filteredTasks, filteredMergeQueue, selectedProject, snapshot, events } =
     useAppState();
   const projects = snapshot?.projects ?? [];
+  const tasks = snapshot?.tasks ?? [];
 
   const projectName = selectedProject
     ? projects.find((p) => p.id === selectedProject)?.repo ?? "Project"
@@ -555,7 +689,7 @@ export function DashboardPage() {
         {/* AI Summary and Alerts */}
         <div className="grid gap-6 md:grid-cols-2">
           <AISummary tasks={filteredTasks} mergeQueue={filteredMergeQueue} />
-          <OrchestratorAlerts />
+          <OrchestratorAlerts events={events} tasks={tasks} projects={projects} />
         </div>
       </div>
     </ScrollArea>

--- a/web/src/pages/orchestrator/page.tsx
+++ b/web/src/pages/orchestrator/page.tsx
@@ -49,6 +49,11 @@ interface OrchestratorBlock {
   entryId?: string;
   content?: string;
   actor?: string;
+  /** Escalation-specific fields */
+  escalationAction?: "conflict_needs_human" | "mode_lowered" | string;
+  prUrl?: string;
+  fromMode?: string;
+  toMode?: string;
 }
 
 function parseOrchestratorEvents(events: Event[]): OrchestratorBlock[] {
@@ -74,12 +79,24 @@ function parseOrchestratorEvents(events: Event[]): OrchestratorBlock[] {
         content: typeof event.data?.context === "string" ? event.data.context : undefined,
       });
     } else if (event.type === "orchestrator:escalation") {
+      const action = typeof event.data?.action === "string" ? event.data.action : undefined;
+      // Extract reasoning - backend sends "reasoning" for conflicts, "reason" for mode changes
+      const reasoning =
+        typeof event.data?.reasoning === "string" ? event.data.reasoning :
+        typeof event.data?.reason === "string" ? event.data.reason :
+        undefined;
+
       blocks.push({
         kind: "escalation",
         id: event.id,
         timestamp: event.ts,
-        content: typeof event.data?.reason === "string" ? event.data.reason : JSON.stringify(event.data),
+        content: reasoning,
         taskId: event.task,
+        entryId: typeof event.data?.entry_id === "string" ? event.data.entry_id : undefined,
+        escalationAction: action,
+        prUrl: typeof event.data?.pr_url === "string" ? event.data.pr_url : undefined,
+        fromMode: typeof event.data?.from === "string" ? event.data.from : undefined,
+        toMode: typeof event.data?.to === "string" ? event.data.to : undefined,
       });
     } else if (event.type === "orchestrator:message") {
       // Human message to orchestrator
@@ -181,21 +198,57 @@ function FeedbackBlock({ block, tasks, projects }: { block: OrchestratorBlock; t
 }
 
 function EscalationBlock({ block, tasks, projects }: { block: OrchestratorBlock; tasks: Task[]; projects: Project[] }) {
+  const [collapsed, setCollapsed] = useState(false);
   const label = taskLabel(block.taskId, tasks, projects);
+
+  // Determine escalation type label
+  let escalationLabel = "Escalation";
+  if (block.escalationAction === "conflict_needs_human") {
+    escalationLabel = "Conflict Needs Review";
+  } else if (block.escalationAction === "mode_lowered") {
+    escalationLabel = "Mode Lowered";
+  }
+
   return (
     <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3">
       <div className="flex items-start gap-2">
         <AlertTriangle className="h-4 w-4 text-yellow-500 mt-0.5 shrink-0" />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="font-medium text-sm text-yellow-400">Escalation</span>
+            <span className="font-medium text-sm text-yellow-400">{escalationLabel}</span>
             {label && (
               <Badge variant="outline" className="font-mono text-xs">{label}</Badge>
+            )}
+            {block.escalationAction === "mode_lowered" && block.fromMode && block.toMode && (
+              <Badge variant="outline" className="text-xs bg-yellow-500/10">
+                {block.fromMode} → {block.toMode}
+              </Badge>
+            )}
+            {block.prUrl && (
+              <a
+                href={block.prUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-blue-400 hover:underline"
+              >
+                View PR
+              </a>
             )}
             <span className="text-xs text-muted-foreground">{formatRelativeTime(block.timestamp)}</span>
           </div>
           {block.content && (
-            <p className="mt-2 text-sm text-muted-foreground whitespace-pre-wrap">{block.content}</p>
+            <>
+              <button
+                onClick={() => setCollapsed(!collapsed)}
+                className="mt-1 text-sm text-muted-foreground hover:text-foreground flex items-center gap-1"
+              >
+                <ChevronDown className={cn("h-3 w-3 transition-transform", collapsed && "-rotate-90")} />
+                {collapsed ? "Show" : "Hide"} details
+              </button>
+              {!collapsed && (
+                <p className="mt-2 text-sm text-muted-foreground whitespace-pre-wrap">{block.content}</p>
+              )}
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Fix data mismatch in `parseOrchestratorEvents`: backend sends `reasoning` for conflicts and `reason` for mode changes, frontend now handles both field names
- Update `EscalationBlock` component with action-specific labels ("Conflict Needs Review", "Mode Lowered"), PR links, mode change badges, and collapsible details
- Replace `OrchestratorAlerts` placeholder in dashboard with real escalation event display showing up to 5 recent events

## Changes

### Orchestrator Page (`web/src/pages/orchestrator/page.tsx`)
- Extended `OrchestratorBlock` interface with escalation-specific fields: `escalationAction`, `prUrl`, `fromMode`, `toMode`
- Updated `parseOrchestratorEvents` to extract both `reasoning` (for conflicts) and `reason` (for mode changes)
- Enhanced `EscalationBlock` with:
  - Action-specific labels
  - Mode transition badges for `mode_lowered` events
  - Clickable PR links for conflict events
  - Collapsible reasoning/details section

### Dashboard Page (`web/src/pages/dashboard/page.tsx`)
- Added `parseEscalationEvents` helper and `EscalationAlert` interface
- Replaced placeholder `OrchestratorAlerts` with functional component that:
  - Displays up to 5 recent escalation events
  - Shows event count badge in header
  - Links to PRs for conflict escalations
  - Shows task labels and timestamps

## Test plan
- [ ] Verify escalation events appear in the Orchestrator page with correct labels
- [ ] Verify PR links are clickable and open in new tab
- [ ] Verify mode_lowered events show from/to mode badges
- [ ] Verify dashboard shows recent escalations in Orchestrator Notifications card
- [ ] Verify "No alerts" placeholder shows when no escalation events exist

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)