### PR TITLE
Add blocking event types to GraphQL timeline query

### DIFF
--- a/crates/github/src/queries.rs
+++ b/crates/github/src/queries.rs
@@ -44,7 +44,7 @@ const ISSUE_FIELDS: &str = r#"
             id
         }
     }
-    timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT]) {
+    timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT, MARKED_AS_BLOCKED_BY_EVENT, UNMARKED_AS_BLOCKED_BY_EVENT]) {
         nodes {
             ... on CrossReferencedEvent {
                 source {
@@ -54,6 +54,22 @@ const ISSUE_FIELDS: &str = r#"
                         state
                         id
                     }
+                }
+            }
+            ... on MarkedAsBlockedByEvent {
+                blockingIssue {
+                    number
+                    title
+                    state
+                    id
+                }
+            }
+            ... on UnmarkedAsBlockedByEvent {
+                blockingIssue {
+                    number
+                    title
+                    state
+                    id
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Adds `MARKED_AS_BLOCKED_BY_EVENT` and `UNMARKED_AS_BLOCKED_BY_EVENT` to the issue timeline query's `itemTypes` filter
- Adds GraphQL fragment spreads to extract `blockingIssue` data from these events
- Enables the response parser's existing `blocked_by` relationship logic to actually receive data

## Context

The GraphQL query in `queries.rs` only requested `CROSS_REFERENCED_EVENT` timeline items, but the response parsing code in `response.rs` (`extract_timeline_relationships`) expects to also handle blocking events. Without the blocking event types in the query, the `blocked_by` field on issues was always empty.

## Test plan

- [x] `cargo check --package tasks-github` passes
- [x] All 45 existing tests pass (`cargo test --package tasks-github`)
- [x] `blocking_relationships_from_timeline` test validates the parsing logic

Fixes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)