### PR TITLE
Fix spec section references and document dispatch behaviors

### DIFF
--- a/crates/server/src/dispatcher.rs
+++ b/crates/server/src/dispatcher.rs
@@ -1,4 +1,4 @@
-//! Dispatch evaluation — spec §12.
+//! Dispatch evaluation — spec §13 (Scheduling and Dispatch).
 //!
 //! Pure logic for selecting and prioritizing task candidates.
 //! No async, no sessions — just candidate selection and sorting.
@@ -33,7 +33,7 @@ fn jitter_factor(task_id: &str, retry_count: u32) -> f64 {
     ((h % 1001) as f64 / 2000.0) - 0.25
 }
 
-/// Calculate backoff duration for a given retry count (spec §13.2).
+/// Calculate backoff duration for a given retry count (spec §14.2).
 /// Base: 5s, multiplier: 2x, max: 300s, jitter: ±25%.
 ///
 /// Jitter is computed deterministically from the task ID to prevent
@@ -53,7 +53,7 @@ pub fn backoff_duration(retry_count: u32, task_id: &str) -> Duration {
     Duration::seconds(final_secs)
 }
 
-/// Evaluate which tasks should be dispatched (spec §12.6).
+/// Evaluate which tasks should be dispatched (spec §13.6).
 ///
 /// Takes current tasks, per-project session limits, and global max.
 /// Returns a DispatchPlan with resume candidates and new work in priority order.
@@ -126,7 +126,7 @@ pub fn evaluate(
         }
     }
 
-    // 5. Sort candidates by priority rules (spec §12.3).
+    // 5. Sort candidates by priority rules (spec §13.3).
     candidates.sort_by(|a, b| {
         // Explicit priority: lower number first, None sorts last.
         let pri_a = a.priority.unwrap_or(i32::MAX);

--- a/crates/server/src/workflow.rs
+++ b/crates/server/src/workflow.rs
@@ -19,7 +19,7 @@ pub struct WorkflowConfig {
 #[serde(default)]
 #[derive(Default)]
 pub struct ProjectConfig {
-    /// Per-project concurrency limit (spec §12.4).
+    /// Per-project concurrency limit (spec §13.4).
     pub max_sessions: Option<u32>,
     /// Override project default branch.
     pub default_branch: Option<String>,
@@ -28,7 +28,7 @@ pub struct ProjectConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct DispatchConfig {
-    /// Task retry limit (spec §13.2). Default: 3.
+    /// Task retry limit (spec §14.2). Default: 3.
     pub max_retries: u32,
     /// Base backoff delay in seconds (spec §13.2). Default: 5.
     pub retry_base_delay: u64,

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -870,7 +870,8 @@ Resume candidates are always processed before new work candidates. They represen
 closer to completion and are cheaper to start.
 
 **New work candidates.** Tasks in `waiting` state with no active session. These require a new
-session, container, and workspace.
+session, container, and workspace. Tasks with an unclosed pull request already in the merge queue
+are skipped — work is already in progress on that task and should not be re-dispatched.
 
 ### 13.3 Prioritization
 
@@ -896,7 +897,8 @@ Two limits control how many tasks can run simultaneously:
   the primary resource constraint — each session is a container consuming host CPU and memory.
   Default: 5.
 - **Per-project limit** (`max_sessions` on project config, optional). Prevents one project from
-  consuming all available slots. Defaults to the global limit if unset.
+  consuming all available slots. Defaults to 1 if unset, which allows multiple projects to make
+  progress concurrently. The default can be overridden via `TASKS_MAX_SESSIONS_PER_PROJECT`.
 
 ### 13.5 Slot Accounting
 
@@ -968,7 +970,8 @@ delays:
 - Base delay: 5 seconds
 - Multiplier: 2x per attempt
 - Maximum delay: 5 minutes
-- Jitter: ±25% (prevents thundering herd when multiple tasks fail simultaneously)
+- Jitter: ±25%, deterministic (derived from task ID and retry count, preventing thundering herd
+  while remaining predictable across dispatch evaluations)
 
 Sequence: ~5s, ~10s, ~20s, ~40s, ~80s, capped at ~300s.
 
@@ -1330,6 +1333,7 @@ function dispatch_tick(server):
     candidates = server.tasks
         where state == Waiting
         and retry_backoff_elapsed(task)
+        and not has_unclosed_pr_in_merge_queue(task)
         sorted by priority_sort(task)
 
     for task in candidates:


### PR DESCRIPTION
## Summary

- Fixed incorrect spec section references in code comments (§12 → §13, etc.)
- Updated spec to document the "skip tasks with unclosed PRs" dispatch behavior
- Clarified per-project concurrency default (1, not global limit)
- Documented that backoff jitter is deterministic

Closes #249

## Changes

**Code (`dispatcher.rs`, `workflow.rs`):**
- Fixed spec section references that were off by one section

**Spec (`spec/spec.md`):**
- §13.2: Document that tasks with unclosed PRs in merge queue are skipped
- §13.4: Per-project default is 1 (not global limit), can override via env var
- §14.2: Document that jitter is deterministic (not random)
- §19.1: Added `has_unclosed_pr_in_merge_queue` check to dispatch pseudocode

## Test plan

- [ ] Doc comment changes only in code - no functional changes
- [ ] Spec updates match current implementation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)