### PR TITLE
Clarify Stop mode conflict triage behavior in spec §7.4

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -435,8 +435,9 @@ When a pending merge has conflicts:
   - In Play mode: the orchestrator resolves the conflict autonomously — typically re-engaging the
     implementor agent, or resolving it directly when the resolution is mechanical (rebases,
     trivial merge conflicts).
-  - In Pause mode or when the human is present: the orchestrator surfaces non-trivial conflicts
-    to the human for guidance. Mechanical conflicts are resolved by the orchestrator directly.
+  - In Pause or Stop mode: the orchestrator surfaces non-trivial conflicts to the human for
+    guidance. When the human is not present, mechanical conflicts are resolved directly while
+    complex conflicts wait for human input.
 
 ## 8. Reflections
 


### PR DESCRIPTION
## Summary

- Updates spec §7.4 to explicitly document Stop mode conflict triage behavior
- Stop mode is now documented as following the same pattern as Pause mode: non-trivial conflicts are surfaced to the human for guidance, mechanical conflicts are resolved directly
- Aligns spec with the existing implementation in `crates/orchestrator/src/types.rs` (`default_triage()` function)

## Test plan

- [ ] Review spec wording matches implementation behavior
- [ ] Verify spec renders correctly in markdown viewer

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)