### PR TITLE
Add task creation from frontend UI

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -49,6 +49,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/projects", get(list_projects))
         .route("/projects", post(add_project))
         .route("/projects/{id}", axum::routing::delete(delete_project))
+        .route("/issues", post(create_issue))
         .route("/merge-queue", get(list_merge_queue))
         .route("/merge-queue/flush", post(flush_merge_queue))
         .route("/merge-queue/{id}/approve", post(approve_merge))
@@ -104,6 +105,27 @@ struct SetModeRequest {
 #[derive(Deserialize)]
 struct AddProjectRequest {
     repo: String,
+}
+
+#[derive(Deserialize)]
+struct CreateIssueRequest {
+    /// Project ID to create the issue in.
+    project_id: String,
+    /// Issue title.
+    title: String,
+    /// Issue body (markdown).
+    body: Option<String>,
+    /// Labels to add to the issue.
+    #[serde(default)]
+    labels: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct CreateIssueResponse {
+    /// Created issue number.
+    number: u64,
+    /// Issue URL.
+    url: String,
 }
 
 #[derive(Deserialize)]
@@ -300,6 +322,61 @@ async fn delete_project(
     } else {
         Err(ApiError::BadRequest(format!("Project not found: {id}")))
     }
+}
+
+/// POST /api/issues — Create a new GitHub issue.
+///
+/// Creates an issue in the GitHub repository associated with the given project.
+/// The poller will pick up the new issue on its next cycle and create a task from it.
+async fn create_issue(
+    State(state): State<ApiState>,
+    Json(req): Json<CreateIssueRequest>,
+) -> Result<Json<CreateIssueResponse>, ApiError> {
+    // Validate title
+    if req.title.trim().is_empty() {
+        return Err(ApiError::BadRequest("title cannot be empty".to_string()));
+    }
+
+    // Look up the project to get owner/repo
+    let (owner, repo) = {
+        let server_state = state.server.state.read().await;
+        let project = server_state
+            .projects
+            .get(&req.project_id)
+            .ok_or_else(|| ApiError::NotFound(format!("project not found: {}", req.project_id)))?;
+
+        // Parse owner/repo from project.repo
+        let parts: Vec<&str> = project.repo.split('/').collect();
+        if parts.len() != 2 {
+            return Err(ApiError::BadRequest(format!(
+                "invalid repo format in project: {}",
+                project.repo
+            )));
+        }
+        (parts[0].to_string(), parts[1].to_string())
+    };
+
+    // Create GitHub client and issue
+    let github_token = std::env::var("GITHUB_TOKEN")
+        .map_err(|_| ApiError::BadRequest("GITHUB_TOKEN not configured".to_string()))?;
+
+    let client = tasks_github::GitHubClient::new(&github_token);
+
+    let labels: Option<&[String]> = if req.labels.is_empty() {
+        None
+    } else {
+        Some(&req.labels)
+    };
+
+    let created = client
+        .create_issue(&owner, &repo, &req.title, req.body.as_deref(), labels)
+        .await
+        .map_err(|e| ApiError::GitHub(e.to_string()))?;
+
+    Ok(Json(CreateIssueResponse {
+        number: created.number,
+        url: created.html_url,
+    }))
 }
 
 /// GET /api/merge-queue — List merge queue entries.
@@ -704,6 +781,7 @@ enum ApiError {
     NotFound(String),
     CompletionsUnavailable(String),
     CompletionsError(String),
+    GitHub(String),
 }
 
 impl IntoResponse for ApiError {
@@ -716,6 +794,7 @@ impl IntoResponse for ApiError {
             ApiError::NotFound(e) => (StatusCode::NOT_FOUND, e),
             ApiError::CompletionsUnavailable(e) => (StatusCode::SERVICE_UNAVAILABLE, e),
             ApiError::CompletionsError(e) => (StatusCode::INTERNAL_SERVER_ERROR, e),
+            ApiError::GitHub(e) => (StatusCode::BAD_GATEWAY, e),
         };
         (status, Json(serde_json::json!({ "error": message }))).into_response()
     }

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -358,7 +358,7 @@ async fn create_issue(
 
     // Create GitHub client and issue
     let github_token = std::env::var("GITHUB_TOKEN")
-        .map_err(|_| ApiError::BadRequest("GITHUB_TOKEN not configured".to_string()))?;
+        .map_err(|_| ApiError::GitHub("GITHUB_TOKEN not configured on server".to_string()))?;
 
     let client = tasks_github::GitHubClient::new(&github_token);
 

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -4,6 +4,7 @@ use std::sync::RwLock;
 
 use chrono::{DateTime, Utc};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, USER_AGENT};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::error::GitHubError;
@@ -13,6 +14,21 @@ use crate::model::{
 };
 use crate::queries;
 use crate::response::*;
+
+/// Response from GitHub REST API when creating an issue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreatedIssue {
+    /// Issue number.
+    pub number: u64,
+    /// Issue title.
+    pub title: String,
+    /// Issue body (markdown).
+    pub body: Option<String>,
+    /// Issue URL (HTML).
+    pub html_url: String,
+    /// Issue state.
+    pub state: String,
+}
 
 /// Maximum items per page (GitHub's limit).
 const DEFAULT_PAGE_SIZE: u32 = 100;
@@ -219,6 +235,78 @@ impl GitHubClient {
         }
 
         Ok(issue)
+    }
+
+    /// Create a new issue in a repository.
+    ///
+    /// Uses the GitHub REST API to create an issue. Returns the created issue
+    /// with its assigned number and other populated fields.
+    pub async fn create_issue(
+        &self,
+        owner: &str,
+        repo: &str,
+        title: &str,
+        body: Option<&str>,
+        labels: Option<&[String]>,
+    ) -> Result<CreatedIssue, GitHubError> {
+        self.wait_for_rate_limit().await;
+
+        let url = format!("{}/repos/{}/{}/issues", self.base_url, owner, repo);
+
+        let mut request_body = json!({
+            "title": title,
+        });
+
+        if let Some(b) = body {
+            request_body["body"] = json!(b);
+        }
+
+        if let Some(l) = labels {
+            request_body["labels"] = json!(l);
+        }
+
+        let response = self.http.post(&url).json(&request_body).send().await?;
+        self.update_rate_limit(&response);
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::CREATED {
+            let created: CreatedIssue = response.json().await.map_err(|e| {
+                GitHubError::Decode(format!("failed to parse created issue: {e}"))
+            })?;
+            return Ok(created);
+        }
+
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(GitHubError::NotFound(format!("{owner}/{repo}")));
+        }
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::FORBIDDEN {
+            if let Some(rl) = self.rate_limit() {
+                if rl.remaining == 0 {
+                    return Err(GitHubError::RateLimited {
+                        reset_at: rl.reset_at,
+                    });
+                }
+            }
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::UNPROCESSABLE_ENTITY {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Validation(text));
+        }
+
+        let text = response.text().await.unwrap_or_default();
+        Err(GitHubError::Decode(format!(
+            "unexpected create issue status {status}: {text}"
+        )))
     }
 
     // -----------------------------------------------------------------------

--- a/crates/github/src/error.rs
+++ b/crates/github/src/error.rs
@@ -31,6 +31,10 @@ pub enum GitHubError {
     /// Response did not match expected shape.
     #[error("decode error: {0}")]
     Decode(String),
+
+    /// Validation error (422) — invalid input parameters.
+    #[error("validation error: {0}")]
+    Validation(String),
 }
 
 /// A single error from a GraphQL response.

--- a/crates/github/src/lib.rs
+++ b/crates/github/src/lib.rs
@@ -14,6 +14,6 @@ pub mod poller;
 mod queries;
 mod response;
 
-pub use client::GitHubClient;
+pub use client::{CreatedIssue, GitHubClient};
 pub use error::GitHubError;
 pub use poller::{PollResult, RepoPoller};

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -102,6 +102,26 @@ export function sendOrchestratorChat(message: string): Promise<void> {
   });
 }
 
+export interface CreateIssueRequest {
+  project_id: string;
+  title: string;
+  body?: string;
+  labels?: string[];
+}
+
+export interface CreateIssueResponse {
+  number: number;
+  url: string;
+}
+
+export function createIssue(req: CreateIssueRequest): Promise<CreateIssueResponse> {
+  return request<CreateIssueResponse>("/api/issues", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(req),
+  });
+}
+
 export function subscribeEvents(opts?: {
   pattern?: string;
   task_id?: string;

--- a/web/src/pages/tasks/page.tsx
+++ b/web/src/pages/tasks/page.tsx
@@ -402,7 +402,9 @@ export function TasksPage() {
       </ScrollArea>
 
       {/* New Task Dialog */}
-      <Dialog open={newTaskOpen} onOpenChange={setNewTaskOpen}>
+      <Dialog open={newTaskOpen} onOpenChange={(open) => {
+          if (!creating) setNewTaskOpen(open);
+        }}>
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>Create new task</DialogTitle>

--- a/web/src/pages/tasks/page.tsx
+++ b/web/src/pages/tasks/page.tsx
@@ -6,14 +6,33 @@ import {
   ArrowUp,
   ChevronRight,
   Minus,
+  Plus,
   Search,
 } from "lucide-react";
 import { useAppState } from "@/hooks/use-app-state";
 import { cn, formatRelativeTime } from "@/lib/utils";
+import { createIssue } from "@/lib/api";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import type { Task, TaskState } from "@/lib/types";
 import { taskStateMeta, stateSortOrder } from "./columns";
 
@@ -217,9 +236,18 @@ function TaskGroupSection({
 // ---------------------------------------------------------------------------
 
 export function TasksPage() {
-  const { filteredTasks, selectedProject, snapshot } = useAppState();
+  const { filteredTasks, selectedProject, snapshot, refreshSnapshot } = useAppState();
   const [activeTab, setActiveTab] = useState<TabKey>("all");
   const [search, setSearch] = useState("");
+
+  // New task dialog state
+  const [newTaskOpen, setNewTaskOpen] = useState(false);
+  const [newTaskProjectId, setNewTaskProjectId] = useState<string>("");
+  const [newTaskTitle, setNewTaskTitle] = useState("");
+  const [newTaskBody, setNewTaskBody] = useState("");
+  const [newTaskLabels, setNewTaskLabels] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
 
   const projects = snapshot?.projects ?? [];
   const projectIdToRepo = useMemo(() => {
@@ -254,6 +282,52 @@ export function TasksPage() {
     return { all, active, completed };
   }, [filteredTasks]);
 
+  // Reset dialog state when opening
+  const handleOpenNewTask = () => {
+    setNewTaskProjectId(selectedProject ?? (projects[0]?.id ?? ""));
+    setNewTaskTitle("");
+    setNewTaskBody("");
+    setNewTaskLabels("");
+    setCreateError(null);
+    setNewTaskOpen(true);
+  };
+
+  // Handle create task
+  const handleCreateTask = async () => {
+    if (!newTaskTitle.trim()) {
+      setCreateError("Title is required");
+      return;
+    }
+    if (!newTaskProjectId) {
+      setCreateError("Please select a project");
+      return;
+    }
+
+    setCreating(true);
+    setCreateError(null);
+
+    try {
+      const labels = newTaskLabels
+        .split(",")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
+
+      await createIssue({
+        project_id: newTaskProjectId,
+        title: newTaskTitle.trim(),
+        body: newTaskBody.trim() || undefined,
+        labels: labels.length > 0 ? labels : undefined,
+      });
+
+      setNewTaskOpen(false);
+      await refreshSnapshot();
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : "Failed to create task");
+    } finally {
+      setCreating(false);
+    }
+  };
+
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
@@ -283,14 +357,25 @@ export function TasksPage() {
           </Tabs>
         </div>
 
-        <div className="relative w-48">
-          <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            placeholder="Filter..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="h-7 pl-7 text-xs"
-          />
+        <div className="flex items-center gap-2">
+          <div className="relative w-48">
+            <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder="Filter..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="h-7 pl-7 text-xs"
+            />
+          </div>
+          <Button
+            size="sm"
+            className="h-7 text-xs gap-1"
+            onClick={handleOpenNewTask}
+            disabled={projects.length === 0}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New Task
+          </Button>
         </div>
       </div>
 
@@ -315,6 +400,107 @@ export function TasksPage() {
           </div>
         )}
       </ScrollArea>
+
+      {/* New Task Dialog */}
+      <Dialog open={newTaskOpen} onOpenChange={setNewTaskOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Create new task</DialogTitle>
+            <DialogDescription>
+              Create a GitHub issue that will become a task. The poller will pick it up on the next cycle.
+            </DialogDescription>
+          </DialogHeader>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleCreateTask();
+            }}
+          >
+            <div className="space-y-4 py-3">
+              {/* Project selector */}
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium">Project</label>
+                <Select
+                  value={newTaskProjectId}
+                  onValueChange={setNewTaskProjectId}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select a project" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {projects.map((p) => (
+                      <SelectItem key={p.id} value={p.id}>
+                        {p.repo}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Title */}
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium">Title</label>
+                <Input
+                  placeholder="Issue title..."
+                  value={newTaskTitle}
+                  onChange={(e) => {
+                    setNewTaskTitle(e.target.value);
+                    setCreateError(null);
+                  }}
+                  disabled={creating}
+                  autoFocus
+                />
+              </div>
+
+              {/* Body */}
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium">Description (optional)</label>
+                <Textarea
+                  placeholder="Issue description in markdown..."
+                  value={newTaskBody}
+                  onChange={(e) => setNewTaskBody(e.target.value)}
+                  disabled={creating}
+                  className="min-h-24"
+                />
+              </div>
+
+              {/* Labels */}
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium">Labels (optional)</label>
+                <Input
+                  placeholder="bug, enhancement, help wanted"
+                  value={newTaskLabels}
+                  onChange={(e) => setNewTaskLabels(e.target.value)}
+                  disabled={creating}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Comma-separated list of labels
+                </p>
+              </div>
+
+              {createError && (
+                <p className="text-sm text-red-400">{createError}</p>
+              )}
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setNewTaskOpen(false)}
+                disabled={creating}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={creating || !newTaskTitle.trim() || !newTaskProjectId}
+              >
+                {creating ? "Creating..." : "Create Task"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `POST /api/issues` endpoint that creates GitHub issues via REST API
- Adds "New Task" button to the tasks page header with a dialog for composing issues
- Issues are created in GitHub and picked up by the poller on the next cycle

## Changes
- **crates/github/src/client.rs**: Add `create_issue` method using GitHub REST API
- **crates/github/src/error.rs**: Add `Validation` error variant for 422 responses
- **crates/app/src/web.rs**: Add `/api/issues` POST endpoint with project lookup
- **web/src/lib/api.ts**: Add `createIssue` function
- **web/src/pages/tasks/page.tsx**: Add New Task button and dialog with:
  - Project selector dropdown
  - Title input
  - Description textarea (markdown)
  - Labels input (comma-separated)

## Test plan
- [ ] Add a project to the platform
- [ ] Click "New Task" button in tasks page header
- [ ] Fill out form with title, description, and labels
- [ ] Submit and verify issue appears on GitHub
- [ ] Wait for poller cycle and verify task appears in the UI

Closes #28

---
Generated with [Claude Code](https://claude.com/claude-code)