### PR TITLE
Implement GitHub merge for approved entries via API

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -312,55 +312,120 @@ async fn list_merge_queue(
 
 /// POST /api/merge-queue/flush — Flush approved entries (Pause mode only).
 ///
-/// Flushes approved entries and executes the actual GitHub merges.
+/// Collects approved entries and executes the actual GitHub merges.
+/// Each entry's status is updated based on the merge result:
+/// - Success: marked as Merged, task transitions to Completed
+/// - Failure: marked as Conflict
 async fn flush_merge_queue(State(state): State<ApiState>) -> Result<Json<Vec<String>>, ApiError> {
-    let flushed_entries = state
+    // Collect approved entries (mode check happens here - Pause mode only)
+    let entries_to_merge = state
         .server
-        .flush_merge_queue()
+        .collect_entries_for_flush()
         .await
         .map_err(ApiError::Server)?;
 
-    // Execute GitHub merges for each flushed entry
+    if entries_to_merge.is_empty() {
+        return Ok(Json(Vec::new()));
+    }
+
+    let mut merged_ids: Vec<String> = Vec::new();
+
+    // Execute GitHub merges for each entry
     let github_token = std::env::var("GITHUB_TOKEN").unwrap_or_default();
-    if !github_token.is_empty() {
-        let client = tasks_github::client::GitHubClient::new(&github_token);
-        for (entry_id, pr_url) in &flushed_entries {
-            if let Some((owner, repo, number)) = tasks_orchestrator::parse_pr_url(pr_url) {
-                match client.merge_pull_request(&owner, &repo, number).await {
-                    Ok(true) => {
-                        tracing::info!(entry_id = %entry_id, pr_url = %pr_url, "PR merged via flush");
-                        if let Err(e) = state.server.mark_entry_merged(entry_id, pr_url).await {
-                            tracing::error!(entry_id = %entry_id, error = %e, "failed to mark entry merged after flush");
-                        }
+    if github_token.is_empty() {
+        tracing::warn!("GITHUB_TOKEN not set, cannot perform merges");
+        return Ok(Json(Vec::new()));
+    }
+
+    let client = tasks_github::client::GitHubClient::new(&github_token);
+    for (entry_id, pr_url) in &entries_to_merge {
+        if let Some((owner, repo, number)) = tasks_orchestrator::parse_pr_url(pr_url) {
+            match client.merge_pull_request(&owner, &repo, number).await {
+                Ok(true) => {
+                    tracing::info!(entry_id = %entry_id, pr_url = %pr_url, "PR merged via flush");
+                    if let Err(e) = state.server.mark_entry_merged(entry_id, pr_url).await {
+                        tracing::error!(entry_id = %entry_id, error = %e, "failed to mark entry merged after flush");
+                    } else {
+                        merged_ids.push(entry_id.clone());
                     }
-                    Ok(false) => {
-                        tracing::warn!(entry_id = %entry_id, pr_url = %pr_url, "PR not mergeable during flush");
-                        if let Err(e) = state.server.mark_entry_conflict(entry_id, pr_url, None).await {
-                            tracing::error!(entry_id = %entry_id, error = %e, "failed to mark entry conflict after flush");
-                        }
+                }
+                Ok(false) => {
+                    tracing::warn!(entry_id = %entry_id, pr_url = %pr_url, "PR not mergeable during flush");
+                    if let Err(e) = state.server.mark_entry_conflict(entry_id, pr_url, None).await {
+                        tracing::error!(entry_id = %entry_id, error = %e, "failed to mark entry conflict after flush");
                     }
-                    Err(e) => {
-                        tracing::error!(entry_id = %entry_id, pr_url = %pr_url, error = %e, "failed to merge PR during flush");
-                    }
+                }
+                Err(e) => {
+                    tracing::error!(entry_id = %entry_id, pr_url = %pr_url, error = %e, "failed to merge PR during flush");
                 }
             }
         }
     }
 
-    let ids: Vec<String> = flushed_entries.into_iter().map(|(id, _)| id).collect();
-    Ok(Json(ids))
+    // Emit flush event with the IDs that were successfully merged
+    if !merged_ids.is_empty() {
+        if let Err(e) = state.server.emit_flush_event(&merged_ids).await {
+            tracing::error!(error = %e, "failed to emit flush event");
+        }
+    }
+
+    Ok(Json(merged_ids))
 }
 
 /// POST /api/merge-queue/:id/approve — Approve a merge queue entry.
+///
+/// In Play mode, this also triggers an immediate merge via the GitHub API.
+/// In Pause mode, the entry is approved but merge happens on flush.
 async fn approve_merge(
     State(state): State<ApiState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    let mut server_state = state.server.state.write().await;
-    server_state
-        .merge_queue
-        .approve(&id)
-        .map_err(|e| ApiError::MergeQueue(e.to_string()))?;
+    // Get entry details and current mode before modifying state
+    let (pr_url, mode) = {
+        let server_state = state.server.state.read().await;
+        let entry = server_state
+            .merge_queue
+            .get(&id)
+            .ok_or_else(|| ApiError::MergeQueue(format!("entry not found: {}", id)))?;
+        (entry.pr_url.clone(), server_state.mode)
+    };
+
+    // Approve the entry using the server method (emits merge:approved event)
+    state
+        .server
+        .approve_merge_entry(&id, "Manual approval via API")
+        .await
+        .map_err(ApiError::Server)?;
+
+    // In Play mode, trigger immediate merge (Play mode = continuous merge authority)
+    if mode == Mode::Play {
+        let github_token = std::env::var("GITHUB_TOKEN").unwrap_or_default();
+        if !github_token.is_empty() {
+            if let Some((owner, repo, number)) = tasks_orchestrator::parse_pr_url(&pr_url) {
+                let client = tasks_github::client::GitHubClient::new(&github_token);
+                match client.merge_pull_request(&owner, &repo, number).await {
+                    Ok(true) => {
+                        tracing::info!(entry_id = %id, pr_url = %pr_url, "PR merged after manual approval (Play mode)");
+                        if let Err(e) = state.server.mark_entry_merged(&id, &pr_url).await {
+                            tracing::error!(entry_id = %id, error = %e, "failed to mark entry merged");
+                        }
+                    }
+                    Ok(false) => {
+                        tracing::warn!(entry_id = %id, pr_url = %pr_url, "PR not mergeable after approval");
+                        if let Err(e) = state.server.mark_entry_conflict(&id, &pr_url, None).await {
+                            tracing::error!(entry_id = %id, error = %e, "failed to mark entry conflict");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(entry_id = %id, pr_url = %pr_url, error = %e, "failed to merge PR after approval");
+                    }
+                }
+            }
+        } else {
+            tracing::warn!("GITHUB_TOKEN not set, cannot perform merge in Play mode");
+        }
+    }
+
     Ok(StatusCode::OK)
 }
 

--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -139,28 +139,27 @@ impl MergeQueue {
             .collect()
     }
 
-    /// Flush: push through all approved entries (spec Section 6.2).
+    /// Collect approved entries for flush (spec Section 6.2).
     ///
-    /// Returns the IDs of entries that were flushed. Only valid in Pause mode.
-    pub fn flush(&mut self, mode: Mode) -> Result<Vec<String>, MergeQueueError> {
+    /// Returns (entry_id, pr_url) pairs of approved entries. Only valid in Pause mode.
+    /// The caller is responsible for performing the actual merge and updating status
+    /// via mark_merged() or mark_conflict().
+    pub fn collect_approved_for_flush(
+        &self,
+        mode: Mode,
+    ) -> Result<Vec<(String, String)>, MergeQueueError> {
         if !mode.flush_available() {
             return Err(MergeQueueError::Held(mode));
         }
 
-        let ids: Vec<String> = self
+        let entries: Vec<(String, String)> = self
             .entries
             .iter()
             .filter(|e| e.status == MergeStatus::Approved)
-            .map(|e| e.id.clone())
+            .map(|e| (e.id.clone(), e.pr_url.clone()))
             .collect();
 
-        for entry in &mut self.entries {
-            if entry.status == MergeStatus::Approved {
-                entry.status = MergeStatus::Merged;
-            }
-        }
-
-        Ok(ids)
+        Ok(entries)
     }
 
     /// Remove a specific entry by PR URL. Returns the removed entry if found.
@@ -204,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    fn approve_and_flush() {
+    fn approve_and_collect_for_flush() {
         let mut q = MergeQueue::new();
         q.enqueue(entry("m1", "t1"));
         q.enqueue(entry("m2", "t2"));
@@ -212,22 +211,27 @@ mod tests {
         q.approve("m1").unwrap();
         assert_eq!(q.approved().len(), 1);
 
-        let flushed = q.flush(Mode::Pause).unwrap();
-        assert_eq!(flushed, vec!["m1"]);
-        assert_eq!(q.get("m1").unwrap().status, MergeStatus::Merged);
+        // collect_approved_for_flush returns entries but doesn't mark them as Merged
+        let collected = q.collect_approved_for_flush(Mode::Pause).unwrap();
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0].0, "m1");
+        // Entry should still be Approved (not Merged) - caller is responsible for marking
+        assert_eq!(q.get("m1").unwrap().status, MergeStatus::Approved);
         // m2 stays pending
         assert_eq!(q.get("m2").unwrap().status, MergeStatus::Pending);
+
+        // Caller marks as merged after successful GitHub merge
+        q.mark_merged("m1").unwrap();
+        assert_eq!(q.get("m1").unwrap().status, MergeStatus::Merged);
     }
 
     #[test]
-    fn flush_only_in_pause() {
-        let mut q = MergeQueue::new();
-        q.enqueue(entry("m1", "t1"));
-        q.approve("m1").unwrap();
+    fn collect_for_flush_only_in_pause() {
+        let q = MergeQueue::new();
 
-        assert!(q.flush(Mode::Stop).is_err());
-        assert!(q.flush(Mode::Play).is_err());
-        assert!(q.flush(Mode::Pause).is_ok());
+        assert!(q.collect_approved_for_flush(Mode::Stop).is_err());
+        assert!(q.collect_approved_for_flush(Mode::Play).is_err());
+        assert!(q.collect_approved_for_flush(Mode::Pause).is_ok());
     }
 
     #[test]

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -730,42 +730,35 @@ impl Server {
 
     // --- Merge queue (spec Section 7) ---
 
-    /// Flush the merge queue (spec Section 6.2).
+    /// Collect approved entries for flush (spec Section 6.2).
     ///
     /// Only valid in Pause mode. Returns (entry_id, pr_url) pairs for
-    /// the caller to execute the actual GitHub merges.
-    pub async fn flush_merge_queue(&self) -> Result<Vec<(String, String)>, ServerError> {
-        let flushed_entries = {
-            let mut state = self.state.write().await;
-            let mode = state.mode;
-            // Collect entry details before flushing
-            let entries: Vec<(String, String)> = state
-                .merge_queue
-                .approved()
-                .iter()
-                .map(|e| (e.id.clone(), e.pr_url.clone()))
-                .collect();
-            state
-                .merge_queue
-                .flush(mode)
-                .map_err(|e| ServerError::EventStore(events::StoreError::Io(
-                    std::io::Error::other(e.to_string()),
-                )))?;
-            entries
-        };
+    /// the caller to execute the actual GitHub merges. Does NOT mark entries
+    /// as merged - the caller must call mark_entry_merged() or mark_entry_conflict()
+    /// based on the result of the GitHub API call.
+    pub async fn collect_entries_for_flush(&self) -> Result<Vec<(String, String)>, ServerError> {
+        let state = self.state.read().await;
+        let mode = state.mode;
+        state
+            .merge_queue
+            .collect_approved_for_flush(mode)
+            .map_err(|e| ServerError::EventStore(events::StoreError::Io(
+                std::io::Error::other(e.to_string()),
+            )))
+    }
 
-        let ids: Vec<String> = flushed_entries.iter().map(|(id, _)| id.clone()).collect();
-
-        // Emit flush event
+    /// Emit the system:flush event after merges have been processed.
+    ///
+    /// This should be called after all merge operations are complete.
+    pub async fn emit_flush_event(&self, merged_ids: &[String]) -> Result<(), ServerError> {
         let event = Event::new(
             EventType::SystemFlush,
             "system",
             Actor::Human,
-            serde_json::json!({ "flushed": ids }),
+            serde_json::json!({ "flushed": merged_ids }),
         );
         self.event_bus.publish(event).await?;
-
-        Ok(flushed_entries)
+        Ok(())
     }
 
     /// Approve a merge queue entry and emit a `merge:approved` event.


### PR DESCRIPTION
## Summary

- Fix flush endpoint to call GitHub API before marking entries as Merged
- Add immediate merge trigger when approving entries in Play mode
- Refactor server methods for cleaner separation of concerns

## Changes

### Flush endpoint (Pause mode)
- Changed `flush()` to `collect_approved_for_flush()` - returns entries without prematurely marking them as Merged
- The endpoint now calls GitHub API for each entry, then updates status based on the result (Merged on success, Conflict on failure)
- Emits `system:flush` event only after successful merges complete

### Approve endpoint (Play mode)
- Now triggers immediate merge when approving in Play mode (continuous merge authority)
- Uses `approve_merge_entry()` server method to emit proper events
- Calls GitHub API and updates entry status based on result

### Server refactoring
- Added `collect_entries_for_flush()` - returns approved entries for merge without changing status
- Added `emit_flush_event()` - emits system:flush event after merges complete
- Kept existing `mark_entry_merged()` and `mark_entry_conflict()` methods for status updates

## Test plan

- [ ] Verify flush endpoint only merges in Pause mode (returns error otherwise)
- [ ] Test flush with approved entries - should call GitHub API and mark as Merged on success
- [ ] Test flush with conflicting PR - should mark as Conflict (not incorrectly Merged)
- [ ] Test manual approval in Play mode - should trigger immediate GitHub merge
- [ ] Test manual approval in Pause mode - should only approve (no merge until flush)
- [ ] Verify system:flush event only emitted after successful merges

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)