### PR TITLE
Add self-update Phase 4: robustness and deployment

### DIFF
--- a/docs/app/deployment.md
+++ b/docs/app/deployment.md
@@ -1,0 +1,273 @@
+# Deployment
+
+This guide covers deploying Tasks as a persistent service with self-update support.
+
+## Overview
+
+For production use, Tasks runs under a wrapper script (`tasks-runner.sh`) that:
+- Handles automatic updates when the server requests them
+- Manages process lifecycle and signals
+- Provides build failure recovery
+- Logs to persistent files
+
+## Quick Start
+
+### Development (Manual)
+
+```bash
+# Build and run directly
+cargo build --release
+./target/release/tasks run --web
+```
+
+### Production (Wrapper Script)
+
+```bash
+# Run with self-update support
+./scripts/tasks-runner.sh --web
+```
+
+## Service Installation
+
+### Linux (systemd)
+
+1. **Create a tasks user** (optional but recommended):
+
+   ```bash
+   sudo useradd -r -s /bin/false -d /opt/tasks tasks
+   ```
+
+2. **Install the application**:
+
+   ```bash
+   sudo git clone https://github.com/iamnbutler/tasks.git /opt/tasks
+   sudo chown -R tasks:tasks /opt/tasks
+   ```
+
+3. **Create environment file**:
+
+   ```bash
+   sudo mkdir -p /etc/tasks
+   sudo tee /etc/tasks/environment << 'EOF'
+   GITHUB_TOKEN=ghp_your_token_here
+   ANTHROPIC_API_KEY=sk-ant-your_key_here
+   TASKS_DATA_DIR=/var/lib/tasks
+   TASKS_UPDATE_CHECK_ENABLED=true
+   EOF
+   sudo chmod 600 /etc/tasks/environment
+   ```
+
+4. **Create data directory**:
+
+   ```bash
+   sudo mkdir -p /var/lib/tasks
+   sudo chown tasks:tasks /var/lib/tasks
+   ```
+
+5. **Build the server**:
+
+   ```bash
+   cd /opt/tasks
+   sudo -u tasks cargo build --release
+   sudo -u tasks bun install && sudo -u tasks bun web build
+   ```
+
+6. **Install and start the service**:
+
+   ```bash
+   sudo cp /opt/tasks/scripts/tasks.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable tasks
+   sudo systemctl start tasks
+   ```
+
+7. **View logs**:
+
+   ```bash
+   journalctl -u tasks -f
+   ```
+
+### macOS (launchd)
+
+1. **Clone the repository**:
+
+   ```bash
+   git clone https://github.com/iamnbutler/tasks.git ~/tasks
+   cd ~/tasks
+   ```
+
+2. **Build the server**:
+
+   ```bash
+   cargo build --release
+   bun install && bun web build
+   ```
+
+3. **Create logs directory**:
+
+   ```bash
+   mkdir -p ~/Library/Logs/tasks
+   ```
+
+4. **Edit the plist**:
+
+   ```bash
+   cp scripts/com.tasks.plist ~/Library/LaunchAgents/
+   # Edit ~/Library/LaunchAgents/com.tasks.plist
+   # Replace YOUR_USERNAME with your actual username
+   # Set GITHUB_TOKEN and ANTHROPIC_API_KEY
+   ```
+
+5. **Load the service**:
+
+   ```bash
+   launchctl load ~/Library/LaunchAgents/com.tasks.plist
+   ```
+
+6. **View logs**:
+
+   ```bash
+   tail -f ~/Library/Logs/tasks/stdout.log
+   ```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TASKS_DATA_DIR` | `~/.local/state/tasks` | Data directory for SQLite and logs |
+| `TASKS_WEB_PORT` | `4800` | HTTP server port |
+| `TASKS_UPDATE_CHECK_ENABLED` | `true` | Enable update checking |
+| `TASKS_UPDATE_CHECK_INTERVAL` | `300` | Update check interval (seconds) |
+| `TASKS_UPDATE_AUTO_APPLY` | `false` | Auto-apply updates when idle |
+
+### Wrapper Script Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TASKS_RUNNER_LOG` | `$DATA_DIR/runner.log` | Wrapper script log file |
+| `TASKS_PID_FILE` | `$DATA_DIR/tasks.pid` | PID file location |
+| `TASKS_HEALTH_TIMEOUT` | `30` | Health check timeout (seconds) |
+| `TASKS_HEALTH_ENDPOINT` | `http://localhost:4800/api/mode` | Health check URL |
+| `TASKS_MAX_RETRIES` | `5` | Max git fetch retry attempts |
+| `TASKS_RETRY_DELAY` | `5` | Initial retry delay (seconds) |
+
+## Self-Update System
+
+The self-update system allows Tasks to update itself from the main branch:
+
+1. **Detection**: Server polls `origin/main` for new commits
+2. **Notification**: Emits `system:update_available` event
+3. **Apply**: User triggers update via API or auto-apply kicks in
+4. **Execution**: Server exits with code 100
+5. **Rebuild**: Wrapper script pulls, rebuilds, and restarts
+
+### Manual Update Trigger
+
+```bash
+curl -X POST http://localhost:4800/api/self-update/apply
+```
+
+### Rebuild Scopes
+
+Updates rebuild only what changed:
+
+| Scope | Trigger | Actions |
+|-------|---------|---------|
+| `container` | `crates/supervisor/**`, `Dockerfile`, `Makefile` | Full rebuild |
+| `server` | `crates/**` | Server + frontend |
+| `frontend` | `web/**` | Frontend only |
+
+## Robustness Features
+
+### Build Failure Recovery
+
+If a build fails during update:
+1. The wrapper logs the error
+2. Restores the backup binary (if available)
+3. Restarts with the previous version
+
+### Network Failure Handling
+
+Git operations use exponential backoff:
+- Initial delay: 5 seconds
+- Max delay: 5 minutes
+- Max retries: 5 (configurable)
+
+### Partial Update Recovery
+
+If an update is interrupted:
+1. State is saved to `.update-state`
+2. On restart, the wrapper resumes from the last successful step
+3. Clean completion removes state files
+
+### Signal Handling
+
+The wrapper properly handles:
+- `SIGTERM`: Graceful shutdown (forwarded to server)
+- `SIGINT`: Graceful shutdown (forwarded to server)
+- Server gets 30 seconds to shut down gracefully
+
+## Troubleshooting
+
+### Service won't start
+
+Check logs:
+```bash
+# Linux
+journalctl -u tasks -n 50
+
+# macOS
+tail -50 ~/Library/Logs/tasks/stderr.log
+```
+
+Common issues:
+- Missing environment variables (GITHUB_TOKEN, ANTHROPIC_API_KEY)
+- Incorrect paths in service files
+- Permission issues on data directory
+
+### Update stuck
+
+Check state file:
+```bash
+cat ~/.local/state/tasks/.update-state
+```
+
+Clear stuck state:
+```bash
+rm ~/.local/state/tasks/.update-state ~/.local/state/tasks/.update-scope
+```
+
+### Build failures
+
+Check runner log:
+```bash
+tail -100 ~/.local/state/tasks/runner.log
+```
+
+Common causes:
+- Rust toolchain issues
+- Missing cross-compilation toolchain
+- Network issues during cargo fetch
+
+## Security
+
+### Recommended Practices
+
+1. **Run as dedicated user**: Don't run as root
+2. **Secure environment file**: `chmod 600` on files with tokens
+3. **Firewall**: Only expose port 4800 if needed externally
+4. **Updates**: Keep self-update enabled for security patches
+
+### Service File Security
+
+The systemd service includes hardening options:
+- `NoNewPrivileges=true`
+- `ProtectSystem=strict`
+- `ProtectHome=true`
+- `PrivateTmp=true`
+
+---
+
+*This documentation is automatically maintained. Last updated: <!-- LAST_UPDATED -->*

--- a/docs/app/getting-started.md
+++ b/docs/app/getting-started.md
@@ -94,6 +94,7 @@ This adds a GitHub repository for Tasks to monitor.
 ## Next Steps
 
 - [Architecture Overview](architecture.md) - Understand the system design
+- [Deployment Guide](deployment.md) - Run as a persistent service with self-update
 - [CLI Reference](cli-reference.md) - All available commands
 - [API Reference](api-reference.md) - REST API documentation
 - [Web UI Guide](web-ui.md) - Using the web interface

--- a/docs/app/index.md
+++ b/docs/app/index.md
@@ -5,6 +5,7 @@ Tasks is a human-in-the-loop platform that orchestrates AI coding agents to get 
 ## Quick Links
 
 - [Getting Started](getting-started.md) - Installation and first run
+- [Deployment](deployment.md) - Production deployment and service setup
 - [Architecture](architecture.md) - System design and components
 - [CLI Reference](cli-reference.md) - Command-line interface
 - [API Reference](api-reference.md) - REST API endpoints

--- a/docs/design/self-update.md
+++ b/docs/design/self-update.md
@@ -1,0 +1,295 @@
+# Self-Update Mechanism Design
+
+This document describes the self-update mechanism for the Tasks server, enabling it to detect, download, and apply updates automatically while maintaining high availability.
+
+## Overview
+
+The self-update system allows the Tasks server to update itself from the `main` branch without manual intervention. It consists of four components:
+
+1. **Update Checker** - Background task that polls `origin/main` for new commits
+2. **Rebuild Scope Detection** - Analyzes changed files to determine minimal rebuild scope
+3. **Update Executor** - Graceful shutdown with session wait, exits with code 100
+4. **Wrapper Script** - Catches exit 100, pulls changes, rebuilds, restarts
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    tasks-runner.sh                          │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │                   while true; do                      │  │
+│  │  ┌─────────────────────────────────────────────────┐  │  │
+│  │  │              Tasks Server Binary                 │  │  │
+│  │  │  ┌──────────────────────────────────────────┐   │  │  │
+│  │  │  │          Update Checker Task              │   │  │  │
+│  │  │  │  - git fetch origin main (every 5 min)   │   │  │  │
+│  │  │  │  - Compare HEAD vs origin/main           │   │  │  │
+│  │  │  │  - Analyze changed files → rebuild scope │   │  │  │
+│  │  │  │  - Emit UpdateAvailable event            │   │  │  │
+│  │  │  └──────────────────────────────────────────┘   │  │  │
+│  │  │                                                  │  │  │
+│  │  │  On /api/self-update/apply:                     │  │  │
+│  │  │    1. Lower mode to Stop                        │  │  │
+│  │  │    2. Wait for sessions (with timeout)          │  │  │
+│  │  │    3. Write .update-scope file                  │  │  │
+│  │  │    4. Exit with code 100                        │  │  │
+│  │  └─────────────────────────────────────────────────┘  │  │
+│  │                        │                              │  │
+│  │                   exit code 100                       │  │
+│  │                        ▼                              │  │
+│  │  ┌─────────────────────────────────────────────────┐  │  │
+│  │  │           Update Sequence                       │  │  │
+│  │  │  1. git pull origin main                       │  │  │
+│  │  │  2. Read .update-scope                         │  │  │
+│  │  │  3. Rebuild (container/server/frontend)        │  │  │
+│  │  │  4. Restart server                             │  │  │
+│  │  └─────────────────────────────────────────────────┘  │  │
+│  └───────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Rebuild Scope Detection
+
+Changed files are mapped to rebuild requirements using a hierarchy. Higher scopes include all lower scopes:
+
+| Scope | Trigger Patterns | Rebuild Actions |
+|-------|------------------|-----------------|
+| `container` | `crates/supervisor/**`, `src/runtime/Dockerfile`, `Makefile` | `make container-image` + server + frontend |
+| `server` | `crates/**` (except supervisor), `Cargo.*` | `cargo build --release` + frontend |
+| `frontend` | `web/**` | `bun install && bun run build` |
+
+Detection algorithm:
+```
+git diff --name-only HEAD..origin/main
+```
+
+Files are matched against patterns in priority order. The highest matching scope determines the rebuild.
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TASKS_UPDATE_CHECK_ENABLED` | `true` | Enable update checking |
+| `TASKS_UPDATE_CHECK_INTERVAL` | `300` | Check interval in seconds |
+| `TASKS_UPDATE_AUTO_APPLY` | `false` | Auto-apply when no sessions active |
+| `TASKS_UPDATE_SESSION_TIMEOUT` | `300` | Max wait for sessions to drain |
+
+## API Endpoints
+
+### GET /api/self-update
+
+Returns current update status:
+
+```json
+{
+  "available": true,
+  "current_commit": "abc1234",
+  "target_commit": "def5678",
+  "rebuild_scope": "server",
+  "commit_summary": "Fix SSE presence guard (#279)",
+  "last_checked": "2026-03-23T15:00:00Z"
+}
+```
+
+### POST /api/self-update/apply
+
+Triggers update with optional force flag:
+
+```json
+{
+  "force": false
+}
+```
+
+Response:
+```json
+{
+  "status": "applying",
+  "message": "Waiting for 2 active sessions to complete"
+}
+```
+
+## Event Types
+
+### system:update_available
+
+Emitted when a new update is detected:
+
+```json
+{
+  "target_commit": "def5678",
+  "rebuild_scope": "server",
+  "commit_summary": "Fix SSE presence guard (#279)"
+}
+```
+
+### system:update_applying
+
+Emitted when update is in progress:
+
+```json
+{
+  "target_commit": "def5678",
+  "sessions_remaining": 2
+}
+```
+
+## Wrapper Script
+
+The `scripts/tasks-runner.sh` wrapper script handles the outer loop:
+
+```bash
+#!/usr/bin/env bash
+# See scripts/tasks-runner.sh for full implementation
+
+while true; do
+    ./target/release/tasks run --web
+    exit_code=$?
+
+    case $exit_code in
+        100)
+            # Update requested
+            perform_update
+            ;;
+        0)
+            # Clean shutdown
+            break
+            ;;
+        *)
+            # Unexpected exit
+            log "Server exited with code $exit_code"
+            break
+            ;;
+    esac
+done
+```
+
+### Robustness Features (Phase 4)
+
+The wrapper script includes these robustness features:
+
+1. **Build Failure Handling**
+   - Detects build failures
+   - Falls back to running previous binary
+   - Logs error and emits event to log file
+
+2. **Network Failure Handling**
+   - Exponential backoff on git fetch failures
+   - Doesn't spam events on repeated failures
+   - Recovery when network returns
+
+3. **Partial Update Recovery**
+   - Tracks update state in `.update-state` file
+   - Can resume from last successful step
+   - Cleans up partial state on success
+
+4. **Signal Handling**
+   - SIGTERM/SIGINT forwarded to server
+   - Graceful shutdown on signals
+   - PID file management
+
+5. **Logging**
+   - Logs to `$DATA_DIR/runner.log`
+   - Log rotation support
+   - Structured log format
+
+6. **Health Check Integration**
+   - Waits for health endpoint after restart
+   - Configurable timeout
+
+## Service Files
+
+### systemd (Linux)
+
+`scripts/tasks.service`:
+
+```ini
+[Unit]
+Description=Tasks Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/path/to/scripts/tasks-runner.sh
+Restart=on-failure
+RestartSec=5
+User=tasks
+WorkingDirectory=/path/to/tasks
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### launchd (macOS)
+
+`scripts/com.tasks.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "...">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.tasks</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/path/to/scripts/tasks-runner.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>/path/to/tasks</string>
+</dict>
+</plist>
+```
+
+## Implementation Phases
+
+| Phase | Issue | Scope |
+|-------|-------|-------|
+| 1 | #319 | Core infrastructure: update checker, scope detection, exit mechanism, wrapper script |
+| 2 | #320 | API endpoints and events |
+| 3 | #321 | Frontend UI: update banner component |
+| 4 | #322 | Robustness: build failure handling, service files, signal handling |
+
+## Design Decisions
+
+### Why a wrapper script?
+
+The wrapper script approach was chosen over in-process `exec()` for several reasons:
+
+1. **Clean process replacement** - No orphaned state or file handles
+2. **Build failure handling** - Can fall back to previous binary if build fails
+3. **Service manager integration** - Works naturally with systemd/launchd
+4. **Debugging** - Easier to inspect and debug the update process
+
+### Why exit code 100?
+
+Exit code 100 was chosen because:
+- It's above the standard Unix error codes (1-127)
+- It's distinct from common shell errors (126, 127, 128+)
+- It's easy to remember and unlikely to conflict
+
+### Why default to manual updates?
+
+Auto-apply is opt-in (`TASKS_UPDATE_AUTO_APPLY=false` by default) because:
+- Updates may interrupt active work
+- Users may want to review changes before applying
+- Predictable behavior is preferred for production systems
+
+## Security Considerations
+
+1. **Trust model** - Updates come from `origin/main`, which requires push access
+2. **Build verification** - Consider adding commit signature verification
+3. **Rollback** - Keep previous binary for rollback capability
+4. **Audit trail** - Log all update operations with timestamps
+
+## Future Considerations
+
+1. **Partial frontend updates** - Hot-reload frontend without server restart
+2. **Orchestrator integration** - Factor pending updates into dispatch decisions
+3. **Notification channels** - Slack/email notifications for available updates
+4. **Update scheduling** - Schedule updates during low-activity periods

--- a/scripts/com.tasks.plist
+++ b/scripts/com.tasks.plist
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.tasks.plist - launchd plist for Tasks server (macOS)
+
+  Installation (user agent - runs when logged in):
+    1. Copy to ~/Library/LaunchAgents/com.tasks.plist
+    2. Edit paths to match your installation
+    3. Run: launchctl load ~/Library/LaunchAgents/com.tasks.plist
+
+  Installation (system daemon - runs at boot):
+    1. Copy to /Library/LaunchDaemons/com.tasks.plist
+    2. Edit paths and set UserName
+    3. Run: sudo launchctl load /Library/LaunchDaemons/com.tasks.plist
+
+  View logs:
+    tail -f ~/Library/Logs/tasks/runner.log
+    # or check Console.app
+
+  Commands:
+    launchctl start com.tasks     # Start
+    launchctl stop com.tasks      # Stop
+    launchctl unload <path>       # Disable
+    launchctl load <path>         # Enable
+-->
+<plist version="1.0">
+<dict>
+    <!-- Service identifier (must match filename without .plist) -->
+    <key>Label</key>
+    <string>com.tasks</string>
+
+    <!-- Command to run -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOUR_USERNAME/tasks/scripts/tasks-runner.sh</string>
+        <string>--web</string>
+    </array>
+
+    <!-- Working directory (must be the tasks repository root) -->
+    <key>WorkingDirectory</key>
+    <string>/Users/YOUR_USERNAME/tasks</string>
+
+    <!-- Environment variables -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <!-- Required: Set these to your actual tokens -->
+        <key>GITHUB_TOKEN</key>
+        <string>ghp_YOUR_TOKEN_HERE</string>
+        <key>ANTHROPIC_API_KEY</key>
+        <string>sk-ant-YOUR_KEY_HERE</string>
+
+        <!-- Optional: Override data directory -->
+        <key>TASKS_DATA_DIR</key>
+        <string>/Users/YOUR_USERNAME/.local/state/tasks</string>
+
+        <!-- Optional: Enable auto-updates -->
+        <key>TASKS_UPDATE_CHECK_ENABLED</key>
+        <string>true</string>
+
+        <!-- PATH for cargo, git, bun, etc. -->
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/Users/YOUR_USERNAME/.cargo/bin</string>
+    </dict>
+
+    <!-- Start at login/boot -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Keep running (restart if it exits) -->
+    <key>KeepAlive</key>
+    <dict>
+        <!-- Only restart on crash, not on clean exit -->
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <!-- Throttle restarts (wait at least 10 seconds between restarts) -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- Logging -->
+    <key>StandardOutPath</key>
+    <string>/Users/YOUR_USERNAME/Library/Logs/tasks/stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOUR_USERNAME/Library/Logs/tasks/stderr.log</string>
+
+    <!-- Nice level (lower priority to not compete with interactive apps) -->
+    <key>Nice</key>
+    <integer>5</integer>
+
+    <!-- Soft resource limits -->
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>8192</integer>
+    </dict>
+
+    <!-- Hard resource limits -->
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>16384</integer>
+    </dict>
+
+    <!-- Process type (Background = lower priority) -->
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/scripts/tasks-runner.sh
+++ b/scripts/tasks-runner.sh
@@ -1,0 +1,551 @@
+#!/usr/bin/env bash
+# tasks-runner.sh - Wrapper script for Tasks server with self-update support
+#
+# This script manages the Tasks server lifecycle and handles self-updates.
+# When the server exits with code 100, it triggers an update sequence.
+#
+# Features:
+# - Build failure handling with fallback to previous binary
+# - Network failure handling with exponential backoff
+# - Partial update recovery
+# - Signal handling (SIGTERM, SIGINT)
+# - PID file management
+# - Logging to file
+# - Health check integration
+#
+# Usage:
+#   ./scripts/tasks-runner.sh [--web]
+#
+# Environment:
+#   TASKS_DATA_DIR          Data directory (default: ~/.local/state/tasks)
+#   TASKS_RUNNER_LOG        Log file path (default: $DATA_DIR/runner.log)
+#   TASKS_HEALTH_TIMEOUT    Health check timeout in seconds (default: 30)
+#   TASKS_HEALTH_ENDPOINT   Health check URL (default: http://localhost:4800/api/mode)
+#   TASKS_MAX_RETRIES       Max git fetch retries (default: 5)
+#   TASKS_RETRY_DELAY       Initial retry delay in seconds (default: 5)
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+
+DATA_DIR="${TASKS_DATA_DIR:-$HOME/.local/state/tasks}"
+LOG_FILE="${TASKS_RUNNER_LOG:-$DATA_DIR/runner.log}"
+PID_FILE="${TASKS_PID_FILE:-$DATA_DIR/tasks.pid}"
+STATE_FILE="${DATA_DIR}/.update-state"
+SCOPE_FILE="${DATA_DIR}/.update-scope"
+HEALTH_TIMEOUT="${TASKS_HEALTH_TIMEOUT:-30}"
+HEALTH_ENDPOINT="${TASKS_HEALTH_ENDPOINT:-http://localhost:4800/api/mode}"
+MAX_RETRIES="${TASKS_MAX_RETRIES:-5}"
+INITIAL_RETRY_DELAY="${TASKS_RETRY_DELAY:-5}"
+
+# Resolve paths relative to script location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BINARY_PATH="${PROJECT_ROOT}/target/release/tasks"
+BACKUP_BINARY_PATH="${PROJECT_ROOT}/target/release/tasks.backup"
+
+# Track child process
+SERVER_PID=""
+SHUTDOWN_REQUESTED=false
+
+# Network failure tracking (for backoff)
+CONSECUTIVE_FAILURES=0
+LAST_FAILURE_TIME=0
+
+# -----------------------------------------------------------------------------
+# Logging
+# -----------------------------------------------------------------------------
+
+log() {
+    local level="$1"
+    shift
+    local timestamp
+    timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "${timestamp} [${level}] $*" | tee -a "$LOG_FILE"
+}
+
+log_info() { log "INFO" "$@"; }
+log_warn() { log "WARN" "$@"; }
+log_error() { log "ERROR" "$@"; }
+
+rotate_log() {
+    local max_size=$((10 * 1024 * 1024))  # 10MB
+    if [[ -f "$LOG_FILE" ]] && [[ $(stat -f%z "$LOG_FILE" 2>/dev/null || stat -c%s "$LOG_FILE" 2>/dev/null) -gt $max_size ]]; then
+        mv "$LOG_FILE" "${LOG_FILE}.1"
+        log_info "Log rotated"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# PID File Management
+# -----------------------------------------------------------------------------
+
+write_pid() {
+    echo $$ > "$PID_FILE"
+    log_info "PID file written: $PID_FILE ($$)"
+}
+
+cleanup_pid() {
+    if [[ -f "$PID_FILE" ]]; then
+        rm -f "$PID_FILE"
+        log_info "PID file removed"
+    fi
+}
+
+check_already_running() {
+    if [[ -f "$PID_FILE" ]]; then
+        local old_pid
+        old_pid=$(cat "$PID_FILE")
+        if kill -0 "$old_pid" 2>/dev/null; then
+            log_error "Another instance is already running (PID: $old_pid)"
+            exit 1
+        else
+            log_warn "Stale PID file found, removing"
+            rm -f "$PID_FILE"
+        fi
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Signal Handling
+# -----------------------------------------------------------------------------
+
+shutdown_server() {
+    if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        log_info "Forwarding signal to server (PID: $SERVER_PID)"
+        kill -TERM "$SERVER_PID" 2>/dev/null || true
+
+        # Wait for graceful shutdown with timeout
+        local timeout=30
+        local waited=0
+        while kill -0 "$SERVER_PID" 2>/dev/null && [[ $waited -lt $timeout ]]; do
+            sleep 1
+            ((waited++))
+        done
+
+        if kill -0 "$SERVER_PID" 2>/dev/null; then
+            log_warn "Server didn't stop gracefully, sending SIGKILL"
+            kill -KILL "$SERVER_PID" 2>/dev/null || true
+        fi
+    fi
+}
+
+handle_signal() {
+    local signal="$1"
+    log_info "Received $signal"
+    SHUTDOWN_REQUESTED=true
+    shutdown_server
+    cleanup_pid
+    cleanup_state
+    exit 0
+}
+
+trap 'handle_signal SIGTERM' SIGTERM
+trap 'handle_signal SIGINT' SIGINT
+
+# -----------------------------------------------------------------------------
+# State Management (for partial update recovery)
+# -----------------------------------------------------------------------------
+
+# Update states:
+# - FETCHING: Started git fetch
+# - PULLING: Started git pull
+# - BUILDING_CONTAINER: Building container image
+# - BUILDING_SERVER: Building server binary
+# - BUILDING_FRONTEND: Building frontend
+# - RESTARTING: About to restart server
+# - COMPLETE: Update finished successfully
+
+write_state() {
+    local state="$1"
+    local extra="${2:-}"
+    echo "${state}:${extra}" > "$STATE_FILE"
+    log_info "Update state: $state ${extra:+($extra)}"
+}
+
+read_state() {
+    if [[ -f "$STATE_FILE" ]]; then
+        cat "$STATE_FILE"
+    else
+        echo ""
+    fi
+}
+
+cleanup_state() {
+    rm -f "$STATE_FILE" "$SCOPE_FILE"
+}
+
+get_state_name() {
+    local state
+    state=$(read_state)
+    echo "${state%%:*}"
+}
+
+# -----------------------------------------------------------------------------
+# Network Operations with Retry
+# -----------------------------------------------------------------------------
+
+calculate_backoff() {
+    local attempt=$1
+    local delay=$INITIAL_RETRY_DELAY
+    for ((i = 1; i < attempt; i++)); do
+        delay=$((delay * 2))
+        if [[ $delay -gt 300 ]]; then
+            delay=300  # Cap at 5 minutes
+        fi
+    done
+    echo $delay
+}
+
+git_fetch_with_retry() {
+    local attempt=1
+    local now
+    now=$(date +%s)
+
+    # If we had a recent failure, wait before retrying
+    if [[ $CONSECUTIVE_FAILURES -gt 0 ]]; then
+        local time_since_failure=$((now - LAST_FAILURE_TIME))
+        local required_delay
+        required_delay=$(calculate_backoff $CONSECUTIVE_FAILURES)
+
+        if [[ $time_since_failure -lt $required_delay ]]; then
+            local remaining=$((required_delay - time_since_failure))
+            log_info "Backing off for ${remaining}s due to previous failures"
+            sleep $remaining
+        fi
+    fi
+
+    while [[ $attempt -le $MAX_RETRIES ]]; do
+        log_info "Fetching from origin (attempt $attempt/$MAX_RETRIES)"
+
+        if git -C "$PROJECT_ROOT" fetch origin main 2>&1 | tee -a "$LOG_FILE"; then
+            CONSECUTIVE_FAILURES=0
+            return 0
+        fi
+
+        LAST_FAILURE_TIME=$(date +%s)
+        CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+
+        if [[ $attempt -lt $MAX_RETRIES ]]; then
+            local delay
+            delay=$(calculate_backoff $attempt)
+            log_warn "Git fetch failed, retrying in ${delay}s"
+            sleep $delay
+        fi
+
+        ((attempt++))
+    done
+
+    log_error "Git fetch failed after $MAX_RETRIES attempts"
+    return 1
+}
+
+git_pull_with_retry() {
+    local attempt=1
+
+    while [[ $attempt -le $MAX_RETRIES ]]; do
+        log_info "Pulling from origin/main (attempt $attempt/$MAX_RETRIES)"
+
+        if git -C "$PROJECT_ROOT" pull origin main 2>&1 | tee -a "$LOG_FILE"; then
+            return 0
+        fi
+
+        if [[ $attempt -lt $MAX_RETRIES ]]; then
+            local delay
+            delay=$(calculate_backoff $attempt)
+            log_warn "Git pull failed, retrying in ${delay}s"
+            sleep $delay
+        fi
+
+        ((attempt++))
+    done
+
+    log_error "Git pull failed after $MAX_RETRIES attempts"
+    return 1
+}
+
+# -----------------------------------------------------------------------------
+# Build Operations
+# -----------------------------------------------------------------------------
+
+backup_binary() {
+    if [[ -f "$BINARY_PATH" ]]; then
+        log_info "Backing up current binary"
+        cp "$BINARY_PATH" "$BACKUP_BINARY_PATH"
+    fi
+}
+
+restore_binary() {
+    if [[ -f "$BACKUP_BINARY_PATH" ]]; then
+        log_warn "Restoring previous binary"
+        cp "$BACKUP_BINARY_PATH" "$BINARY_PATH"
+        return 0
+    else
+        log_error "No backup binary available"
+        return 1
+    fi
+}
+
+build_container() {
+    log_info "Building container image..."
+    write_state "BUILDING_CONTAINER"
+
+    if make -C "$PROJECT_ROOT" container-image 2>&1 | tee -a "$LOG_FILE"; then
+        log_info "Container image built successfully"
+        return 0
+    else
+        log_error "Container image build failed"
+        return 1
+    fi
+}
+
+build_server() {
+    log_info "Building server binary..."
+    write_state "BUILDING_SERVER"
+
+    backup_binary
+
+    if cargo build --release --manifest-path "$PROJECT_ROOT/Cargo.toml" 2>&1 | tee -a "$LOG_FILE"; then
+        log_info "Server binary built successfully"
+        return 0
+    else
+        log_error "Server binary build failed"
+        restore_binary
+        return 1
+    fi
+}
+
+build_frontend() {
+    log_info "Building frontend..."
+    write_state "BUILDING_FRONTEND"
+
+    local web_dir="$PROJECT_ROOT/web"
+    if [[ -d "$web_dir" ]]; then
+        if (cd "$web_dir" && bun install && bun run build) 2>&1 | tee -a "$LOG_FILE"; then
+            log_info "Frontend built successfully"
+            return 0
+        else
+            log_error "Frontend build failed"
+            return 1
+        fi
+    else
+        log_warn "Web directory not found, skipping frontend build"
+        return 0
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Update Sequence
+# -----------------------------------------------------------------------------
+
+read_scope() {
+    if [[ -f "$SCOPE_FILE" ]]; then
+        cat "$SCOPE_FILE"
+    else
+        echo "server"  # Default to server rebuild
+    fi
+}
+
+perform_update() {
+    local state
+    state=$(get_state_name)
+    local scope
+    scope=$(read_scope)
+
+    log_info "=== Starting update sequence ==="
+    log_info "Scope: $scope, Resuming from: ${state:-START}"
+
+    # Resume from last successful state if recovering
+    case "$state" in
+        ""|"FETCHING")
+            write_state "PULLING"
+            if ! git_pull_with_retry; then
+                log_error "Update failed at PULLING stage"
+                cleanup_state
+                return 1
+            fi
+            ;&  # Fall through
+
+        "PULLING")
+            if [[ "$scope" == "container" ]]; then
+                if ! build_container; then
+                    log_error "Update failed at BUILDING_CONTAINER stage"
+                    cleanup_state
+                    return 1
+                fi
+            fi
+            ;&  # Fall through
+
+        "BUILDING_CONTAINER")
+            if [[ "$scope" == "container" || "$scope" == "server" ]]; then
+                if ! build_server; then
+                    log_error "Update failed at BUILDING_SERVER stage"
+                    cleanup_state
+                    return 1
+                fi
+            fi
+            ;&  # Fall through
+
+        "BUILDING_SERVER")
+            if ! build_frontend; then
+                log_error "Update failed at BUILDING_FRONTEND stage"
+                # Frontend failures are non-fatal for server operation
+                log_warn "Continuing despite frontend build failure"
+            fi
+            ;;
+
+        "BUILDING_FRONTEND"|"RESTARTING")
+            # Already past build stages, just restart
+            log_info "Resuming from near completion"
+            ;;
+
+        *)
+            log_warn "Unknown state: $state, starting fresh"
+            ;;
+    esac
+
+    write_state "COMPLETE"
+    cleanup_state
+    log_info "=== Update sequence complete ==="
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# Health Check
+# -----------------------------------------------------------------------------
+
+wait_for_health() {
+    log_info "Waiting for server health check..."
+    local timeout=$HEALTH_TIMEOUT
+    local waited=0
+
+    while [[ $waited -lt $timeout ]]; do
+        if curl -sf "$HEALTH_ENDPOINT" > /dev/null 2>&1; then
+            log_info "Server is healthy"
+            return 0
+        fi
+        sleep 1
+        ((waited++))
+    done
+
+    log_warn "Health check timed out after ${timeout}s"
+    return 1
+}
+
+# -----------------------------------------------------------------------------
+# Main Loop
+# -----------------------------------------------------------------------------
+
+ensure_data_dir() {
+    mkdir -p "$DATA_DIR"
+}
+
+run_server() {
+    local args=("$@")
+
+    if [[ ! -x "$BINARY_PATH" ]]; then
+        log_error "Server binary not found: $BINARY_PATH"
+        log_info "Building server..."
+        if ! build_server; then
+            log_error "Failed to build server"
+            return 1
+        fi
+    fi
+
+    log_info "Starting server: $BINARY_PATH run ${args[*]:-}"
+    write_state "RESTARTING"
+
+    # Start server in background
+    "$BINARY_PATH" run "${args[@]}" &
+    SERVER_PID=$!
+
+    log_info "Server started (PID: $SERVER_PID)"
+
+    # Wait for health if --web flag is present
+    if [[ " ${args[*]} " =~ " --web " ]]; then
+        sleep 2  # Give server time to bind
+        wait_for_health || log_warn "Server may not be fully ready"
+    fi
+
+    cleanup_state
+
+    # Wait for server to exit
+    wait $SERVER_PID
+    return $?
+}
+
+main() {
+    rotate_log
+    ensure_data_dir
+    check_already_running
+    write_pid
+
+    log_info "=== Tasks Runner starting ==="
+    log_info "Project root: $PROJECT_ROOT"
+    log_info "Data directory: $DATA_DIR"
+    log_info "Log file: $LOG_FILE"
+
+    # Check for interrupted update
+    local state
+    state=$(get_state_name)
+    if [[ -n "$state" && "$state" != "COMPLETE" ]]; then
+        log_warn "Found interrupted update in state: $state"
+        log_info "Attempting to resume update..."
+        if ! perform_update; then
+            log_error "Failed to complete interrupted update"
+            log_info "Attempting to start with existing binary"
+        fi
+    fi
+
+    # Pass through command line arguments
+    local server_args=("$@")
+
+    while true; do
+        if [[ "$SHUTDOWN_REQUESTED" == "true" ]]; then
+            log_info "Shutdown requested, exiting"
+            break
+        fi
+
+        run_server "${server_args[@]}" || true
+        exit_code=$?
+        SERVER_PID=""
+
+        log_info "Server exited with code: $exit_code"
+
+        case $exit_code in
+            100)
+                # Update requested
+                log_info "Update requested (exit code 100)"
+                if perform_update; then
+                    log_info "Update successful, restarting server"
+                else
+                    log_error "Update failed"
+                    if [[ -f "$BACKUP_BINARY_PATH" ]]; then
+                        log_warn "Falling back to previous binary"
+                        restore_binary
+                    else
+                        log_error "No fallback available, waiting before retry"
+                        sleep 30
+                    fi
+                fi
+                ;;
+            0)
+                # Clean shutdown
+                log_info "Clean shutdown"
+                break
+                ;;
+            *)
+                # Unexpected exit
+                log_error "Unexpected exit, not restarting"
+                break
+                ;;
+        esac
+    done
+
+    cleanup_pid
+    log_info "=== Tasks Runner stopped ==="
+}
+
+main "$@"

--- a/scripts/tasks.service
+++ b/scripts/tasks.service
@@ -1,0 +1,73 @@
+# tasks.service - systemd unit file for Tasks server
+#
+# Installation:
+#   1. Copy this file to /etc/systemd/system/tasks.service (or ~/.config/systemd/user/)
+#   2. Edit the file to set correct paths and user
+#   3. Run: systemctl daemon-reload
+#   4. Run: systemctl enable tasks
+#   5. Run: systemctl start tasks
+#
+# View logs:
+#   journalctl -u tasks -f
+#
+# Environment:
+#   Create /etc/tasks/environment with your environment variables:
+#     GITHUB_TOKEN=ghp_...
+#     ANTHROPIC_API_KEY=sk-ant-...
+#     TASKS_DATA_DIR=/var/lib/tasks
+#     TASKS_UPDATE_CHECK_ENABLED=true
+
+[Unit]
+Description=Tasks - Human-in-the-loop coding agent orchestrator
+Documentation=https://github.com/iamnbutler/tasks
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+# Run as a dedicated user (recommended)
+# Create the user with: useradd -r -s /bin/false tasks
+User=tasks
+Group=tasks
+
+# Working directory must be the tasks repository root
+# This is where the server binary and scripts are located
+WorkingDirectory=/opt/tasks
+
+# Use the wrapper script for self-update support
+ExecStart=/opt/tasks/scripts/tasks-runner.sh --web
+
+# Environment file for secrets and configuration
+# Create this file with your GITHUB_TOKEN and ANTHROPIC_API_KEY
+EnvironmentFile=-/etc/tasks/environment
+
+# Restart policy
+# on-failure: Restart if the service exits with non-zero exit code
+# Note: The wrapper script handles most restarts internally (exit 100)
+#       This catches unexpected crashes of the wrapper script itself
+Restart=on-failure
+RestartSec=10
+
+# Give the service time to shut down gracefully
+# The wrapper script forwards SIGTERM to the server
+TimeoutStopSec=90
+
+# Security hardening (optional, adjust as needed)
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/tasks /opt/tasks/target
+
+# Resource limits (optional)
+# MemoryMax=4G
+# CPUQuota=200%
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=tasks
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds wrapper script (`scripts/tasks-runner.sh`) with all Phase 4 robustness features
- Adds systemd and launchd service files for production deployment
- Adds design document and deployment documentation

## Deliverables

### Build Failure Handling
- Wrapper script detects build failures during update
- Falls back to running previous binary (backed up before build)
- Logs errors to `$DATA_DIR/runner.log`

### Network Failure Handling
- Exponential backoff on git fetch/pull failures (5s initial, 5m max)
- Tracks consecutive failures to avoid spamming
- Configurable via `TASKS_MAX_RETRIES` and `TASKS_RETRY_DELAY`

### Partial Update Recovery
- Tracks update state in `.update-state` file
- Can resume from last successful step if interrupted
- Cleans up state files on successful completion

### Service Files
- `scripts/tasks.service` - systemd unit for Linux with security hardening
- `scripts/com.tasks.plist` - launchd plist for macOS

### Wrapper Script Features
- Logging to file with rotation (10MB max)
- Signal handling (SIGTERM, SIGINT forwarded to server)
- PID file management with stale PID detection
- Health check integration after restart

### Documentation
- `docs/design/self-update.md` - Full design document referenced by all phase issues
- `docs/app/deployment.md` - Production deployment guide

## Notes

This phase provides the robustness layer for the self-update mechanism. The core update detection logic, API endpoints, and UI will be implemented in Phases 1-3 (#319, #320, #321). The wrapper script is ready to be extended when those phases are complete.

## Test plan

- [ ] Verify wrapper script starts server correctly: `./scripts/tasks-runner.sh --web`
- [ ] Verify PID file is created and cleaned up
- [ ] Verify logs are written to `$DATA_DIR/runner.log`
- [ ] Test signal handling: `kill -TERM $(cat ~/.local/state/tasks/tasks.pid)`
- [ ] Review systemd service file structure
- [ ] Review launchd plist structure

Closes #322

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)