### PR TITLE
Add frontend UI for update notifications

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -15,7 +15,9 @@ import {
   Play,
 } from "lucide-react";
 import { useAppState } from "@/hooks/use-app-state";
+import { useUpdateStatus } from "@/hooks/use-update-status";
 import { addProject, deleteProject, setMode } from "@/lib/api";
+import { UpdateBanner } from "@/components/update-banner";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -395,7 +397,10 @@ function ProjectList() {
 
 export function Layout() {
   const { connected, snapshot } = useAppState();
+  const { status: updateStatus, dismissed: updateDismissed, dismiss: dismissUpdate } = useUpdateStatus();
   const slotUtil = snapshot?.slot_utilization;
+
+  const showUpdateBanner = updateStatus?.available && !updateDismissed;
 
   return (
     <div className="flex h-screen bg-background text-foreground">
@@ -460,6 +465,11 @@ export function Layout() {
 
       {/* Main content */}
       <main className="flex-1 overflow-auto">
+        {showUpdateBanner && updateStatus && (
+          <div className="p-4 pb-0">
+            <UpdateBanner status={updateStatus} onDismiss={dismissUpdate} />
+          </div>
+        )}
         <Outlet />
       </main>
     </div>

--- a/web/src/components/update-banner.tsx
+++ b/web/src/components/update-banner.tsx
@@ -1,0 +1,167 @@
+import { useState } from "react";
+import { ArrowDownCircle, Loader2, X, CheckCircle2, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { applyUpdate } from "@/lib/api";
+import type { UpdateStatus, UpdateApplyState, RebuildScope } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+interface UpdateBannerProps {
+  status: UpdateStatus;
+  onDismiss: () => void;
+}
+
+function getScopeLabel(scope: RebuildScope): string {
+  switch (scope) {
+    case "frontend":
+      return "Frontend rebuild";
+    case "server":
+      return "Server restart";
+    case "container":
+      return "Full rebuild";
+    default:
+      return "Update";
+  }
+}
+
+function getScopeDescription(scope: RebuildScope): string {
+  switch (scope) {
+    case "frontend":
+      return "A quick frontend update is available.";
+    case "server":
+      return "Server restart required.";
+    case "container":
+      return "Full rebuild including container image required.";
+    default:
+      return "An update is available.";
+  }
+}
+
+export function UpdateBanner({ status, onDismiss }: UpdateBannerProps) {
+  const [applyState, setApplyState] = useState<UpdateApplyState>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  if (!status.available) {
+    return null;
+  }
+
+  const handleUpdate = async () => {
+    setApplyState("applying");
+    setError(null);
+    try {
+      await applyUpdate();
+      setApplyState("success");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Update failed");
+      setApplyState("error");
+    }
+  };
+
+  const isApplying = applyState === "applying";
+  const isSuccess = applyState === "success";
+  const isError = applyState === "error";
+
+  // Use different colors based on state
+  const bannerClasses = cn(
+    "flex items-start gap-3 rounded-md border p-3 text-sm",
+    isApplying && "border-yellow-500/30 bg-yellow-500/10",
+    isSuccess && "border-green-500/30 bg-green-500/10",
+    isError && "border-red-500/30 bg-red-500/10",
+    !isApplying && !isSuccess && !isError && "border-blue-500/30 bg-blue-500/10"
+  );
+
+  const iconClasses = cn(
+    "h-5 w-5 shrink-0 mt-0.5",
+    isApplying && "text-yellow-400",
+    isSuccess && "text-green-400",
+    isError && "text-red-400",
+    !isApplying && !isSuccess && !isError && "text-blue-400"
+  );
+
+  return (
+    <div className={bannerClasses}>
+      {isApplying ? (
+        <Loader2 className={cn(iconClasses, "animate-spin")} />
+      ) : isSuccess ? (
+        <CheckCircle2 className={iconClasses} />
+      ) : isError ? (
+        <AlertCircle className={iconClasses} />
+      ) : (
+        <ArrowDownCircle className={iconClasses} />
+      )}
+
+      <div className="flex-1 min-w-0">
+        <div className="font-medium">
+          {isApplying
+            ? "Applying update..."
+            : isSuccess
+              ? "Update complete"
+              : isError
+                ? "Update failed"
+                : "Update available"}
+        </div>
+
+        <div className="text-muted-foreground mt-0.5">
+          {isSuccess ? (
+            "Reload the page to see changes."
+          ) : isError ? (
+            error || "An error occurred while applying the update."
+          ) : (
+            <>
+              {status.rebuild_scope && getScopeDescription(status.rebuild_scope)}
+              {status.commit_summary && (
+                <span className="block mt-1 text-xs font-mono truncate">
+                  {status.commit_summary}
+                </span>
+              )}
+            </>
+          )}
+        </div>
+
+        {status.target_commit && !isApplying && !isSuccess && (
+          <div className="mt-1 text-xs text-muted-foreground/70 font-mono">
+            {status.current_commit.slice(0, 7)} → {status.target_commit.slice(0, 7)}
+            {status.rebuild_scope && (
+              <span className="ml-2 px-1.5 py-0.5 rounded bg-accent text-accent-foreground">
+                {getScopeLabel(status.rebuild_scope)}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 shrink-0">
+        {!isApplying && !isSuccess && (
+          <>
+            <Button
+              size="sm"
+              variant={isError ? "outline" : "default"}
+              onClick={handleUpdate}
+              className="h-7 text-xs"
+            >
+              {isError ? "Retry" : "Update Now"}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onDismiss}
+              className="h-7 w-7 p-0"
+              aria-label="Dismiss"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </>
+        )}
+        {isSuccess && (
+          <Button
+            size="sm"
+            variant="default"
+            onClick={() => window.location.reload()}
+            className="h-7 text-xs"
+          >
+            Reload
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/use-update-status.ts
+++ b/web/src/hooks/use-update-status.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchUpdateStatus, subscribeEvents } from "@/lib/api";
+import type { UpdateStatus } from "@/lib/types";
+
+const UPDATE_CHECK_INTERVAL_MS = 60_000; // Check every minute
+
+export interface UseUpdateStatusResult {
+  status: UpdateStatus | null;
+  dismissed: boolean;
+  dismiss: () => void;
+  refresh: () => Promise<void>;
+}
+
+export function useUpdateStatus(): UseUpdateStatusResult {
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const lastTargetCommit = useRef<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const newStatus = await fetchUpdateStatus();
+    if (newStatus) {
+      // If there's a new target commit, reset dismissed state
+      if (
+        newStatus.target_commit &&
+        newStatus.target_commit !== lastTargetCommit.current
+      ) {
+        setDismissed(false);
+        lastTargetCommit.current = newStatus.target_commit;
+      }
+      setStatus(newStatus);
+    }
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+  }, []);
+
+  // Initial fetch and polling
+  useEffect(() => {
+    refresh();
+
+    const interval = setInterval(() => {
+      refresh();
+    }, UPDATE_CHECK_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [refresh]);
+
+  // SSE subscription for real-time updates
+  useEffect(() => {
+    const source = subscribeEvents({ pattern: "system:update*" });
+
+    source.onmessage = (msg) => {
+      try {
+        const event = JSON.parse(msg.data);
+
+        if (event.type === "system:update_available") {
+          // Update available event - refresh status
+          const data = event.data as { target_commit?: string; commit_summary?: string; rebuild_scope?: string };
+          if (data.target_commit && data.target_commit !== lastTargetCommit.current) {
+            setDismissed(false);
+            lastTargetCommit.current = data.target_commit;
+          }
+          refresh();
+        } else if (event.type === "system:update_applying") {
+          // Update is being applied - could trigger UI refresh
+          refresh();
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    };
+
+    return () => {
+      source.close();
+    };
+  }, [refresh]);
+
+  return {
+    status,
+    dismissed,
+    dismiss,
+    refresh,
+  };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   Project,
   Snapshot,
   Task,
+  UpdateStatus,
 } from "./types";
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -174,5 +175,24 @@ export function summarize(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ text, max_words: maxWords }),
+  });
+}
+
+// --- Update endpoints ---
+
+export async function fetchUpdateStatus(): Promise<UpdateStatus | null> {
+  try {
+    return await request<UpdateStatus>("/api/update/status");
+  } catch {
+    // API not implemented yet or server doesn't support updates
+    return null;
+  }
+}
+
+export async function applyUpdate(force?: boolean): Promise<void> {
+  await requestVoid("/api/update/apply", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ force: force ?? false }),
   });
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -100,3 +100,19 @@ export interface Snapshot {
   slot_utilization: SlotUtilization;
   human_present: boolean;
 }
+
+/** Rebuild scope for self-update mechanism */
+export type RebuildScope = "frontend" | "server" | "container";
+
+/** Update status response from /api/update/status */
+export interface UpdateStatus {
+  available: boolean;
+  current_commit: string;
+  target_commit?: string;
+  rebuild_scope?: RebuildScope;
+  commit_summary?: string;
+  last_checked?: string;
+}
+
+/** State of an in-progress update */
+export type UpdateApplyState = "idle" | "applying" | "success" | "error";


### PR DESCRIPTION
## Summary
- Add `UpdateStatus` and `RebuildScope` types to `web/src/lib/types.ts`
- Add API client functions for `/api/update/status` and `/api/update/apply` endpoints
- Create `UpdateBanner` component showing update availability with dismiss/retry functionality
- Create `useUpdateStatus` hook with polling (60s) and SSE integration for real-time updates
- Integrate `UpdateBanner` into `Layout` component (appears at top of main content area)

## Implementation Details

### UpdateBanner Component
- Shows blue info banner when update is available
- Shows yellow banner when applying
- Shows green success banner with "Reload" button after successful update
- Shows red error banner with "Retry" option on failure
- Displays commit summary, commit hashes, and rebuild scope (frontend/server/container)
- Dismissible with X button (reappears when new update detected)

### SSE Integration
Listens for:
- `system:update_available` - triggers status refresh and resets dismissed state for new commits
- `system:update_applying` - triggers status refresh

### API Handling
Gracefully handles 404/errors when backend endpoints are not yet implemented (returns `null`).

## Test plan
- [ ] Verify TypeScript compiles without errors
- [ ] Verify banner displays when mock `UpdateStatus` has `available: true`
- [ ] Verify dismiss button hides banner
- [ ] Verify "Update Now" button calls `/api/update/apply`
- [ ] Verify error state shows retry option
- [ ] Verify success state shows reload button
- [ ] Test SSE event handling (when backend is ready)

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)