### PR TITLE
Fix task queue ordering to process older issues first

### DIFF
--- a/crates/models/src/task.rs
+++ b/crates/models/src/task.rs
@@ -129,6 +129,9 @@ pub struct Task {
     pub last_failure: Option<FailureInfo>,
     /// When the source (GitHub issue/PR) was created. Used for dispatch ordering.
     pub source_created_at: Option<DateTime<Utc>>,
+    /// GitHub issue/PR number. Used for deterministic dispatch ordering within a project.
+    /// Lower numbers are older and should be processed first among otherwise equal tasks.
+    pub source_number: Option<u64>,
     /// Last activity timestamp for stale workspace detection (spec §10.3).
     /// Updated when the task transitions to/from active states.
     pub last_activity_at: Option<DateTime<Utc>>,
@@ -162,6 +165,7 @@ impl Task {
             last_failure_at: None,
             last_failure: None,
             source_created_at: None,
+            source_number: None,
             last_activity_at: None,
             created_at: now,
             updated_at: now,

--- a/crates/server/src/dispatcher.rs
+++ b/crates/server/src/dispatcher.rs
@@ -158,12 +158,24 @@ pub fn evaluate(
             return unblock_cmp;
         }
 
-        // Recency: newer source creation date first (descending).
-        // Use source_created_at (GitHub issue/PR date) when available,
-        // fall back to internal created_at for non-GitHub tasks.
+        // Source number: lower issue/PR numbers first (ascending).
+        // GitHub issues are numbered sequentially, so lower numbers are older.
+        // This ensures related tasks (e.g., "Phase 1", "Phase 2", "Phase 3")
+        // are processed in logical order. Tasks without a source number
+        // (internal tasks) sort after those with numbers.
+        let num_a = a.source_number.unwrap_or(u64::MAX);
+        let num_b = b.source_number.unwrap_or(u64::MAX);
+        let num_cmp = num_a.cmp(&num_b);
+        if num_cmp != std::cmp::Ordering::Equal {
+            return num_cmp;
+        }
+
+        // Fallback: older creation date first (ascending).
+        // For tasks with the same source number (shouldn't happen) or
+        // both without source numbers, prefer older tasks.
         let time_a = a.source_created_at.unwrap_or(a.created_at);
         let time_b = b.source_created_at.unwrap_or(b.created_at);
-        time_b.cmp(&time_a)
+        time_a.cmp(&time_b)
     });
 
     // 6. Apply concurrency limits.
@@ -319,11 +331,33 @@ mod tests {
     }
 
     #[test]
-    fn priority_sorting_recency() {
+    fn priority_sorting_by_source_number() {
+        let mut tasks = HashMap::new();
+
+        // t1 has lower issue number (older), should sort first
+        let mut t1 = make_task("t1", "proj");
+        t1.priority = Some(1);
+        t1.source_number = Some(10);
+        insert(&mut tasks, t1);
+
+        // t2 has higher issue number (newer), should sort second
+        let mut t2 = make_task("t2", "proj");
+        t2.priority = Some(1);
+        t2.source_number = Some(15);
+        insert(&mut tasks, t2);
+
+        let plan = evaluate(&tasks, &[], &no_active_prs(), &HashMap::new(), 10);
+        // Lower source_number (older issue) sorts first.
+        assert_eq!(plan.new_work, vec!["t1", "t2"]);
+    }
+
+    #[test]
+    fn priority_sorting_fallback_to_created_at() {
         let mut tasks = HashMap::new();
 
         let now = Utc::now();
 
+        // Both tasks have no source_number (internal tasks), so fall back to created_at.
         let mut t1 = make_task("t1", "proj");
         t1.priority = Some(1);
         t1.created_at = now - Duration::seconds(100);
@@ -335,8 +369,8 @@ mod tests {
         insert(&mut tasks, t2);
 
         let plan = evaluate(&tasks, &[], &no_active_prs(), &HashMap::new(), 10);
-        // t2 is newer, so it sorts first at same priority.
-        assert_eq!(plan.new_work, vec!["t2", "t1"]);
+        // Without source_number, older created_at sorts first.
+        assert_eq!(plan.new_work, vec!["t1", "t2"]);
     }
 
     #[test]

--- a/crates/server/src/scheduler.rs
+++ b/crates/server/src/scheduler.rs
@@ -58,6 +58,7 @@ pub fn issue_to_task(
     task.description = issue.body.clone();
     task.labels = issue.labels.iter().map(|l| l.name.clone()).collect();
     task.source_created_at = Some(issue.created_at);
+    task.source_number = Some(issue.number);
 
     // If any label matches a blocked label, set state to Blocked.
     let is_blocked = label_config.blocked.iter().any(|b| issue_label_names.contains(&b.as_str()));
@@ -105,6 +106,7 @@ pub fn pr_to_task(
     task.description = pr.body.clone();
     task.labels = pr.labels.iter().map(|l| l.name.clone()).collect();
     task.source_created_at = Some(pr.created_at);
+    task.source_number = Some(pr.number);
 
     // If any label matches a blocked label, set state to Blocked.
     let is_blocked = label_config.blocked.iter().any(|b| pr_label_names.contains(&b.as_str()));

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -284,12 +284,12 @@ impl Store {
                 id, source_json, title, description, state,
                 parent_id, blocked_by_json, project, labels_json, priority,
                 session_id, workspace_id, retry_count, last_failure_at,
-                last_failure_json, source_created_at, last_activity_at, created_at, updated_at
+                last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5,
                 ?6, ?7, ?8, ?9, ?10,
                 ?11, ?12, ?13, ?14,
-                ?15, ?16, ?17, ?18, ?19
+                ?15, ?16, ?17, ?18, ?19, ?20
             )",
             params![
                 task.id,
@@ -308,6 +308,7 @@ impl Store {
                 last_failure_at,
                 last_failure_json,
                 source_created_at,
+                task.source_number,
                 last_activity_at,
                 created_at,
                 updated_at,
@@ -322,7 +323,7 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    last_failure_json, source_created_at, last_activity_at, created_at, updated_at
+                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at
              FROM tasks WHERE id = ?1",
         )?;
         let mut rows = stmt.query_map(params![id], row_to_task)?;
@@ -341,7 +342,7 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    last_failure_json, source_created_at, last_activity_at, created_at, updated_at
+                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at
              FROM tasks",
         )?;
         let rows = stmt.query_map([], row_to_task)?;
@@ -358,7 +359,7 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    last_failure_json, source_created_at, last_activity_at, created_at, updated_at
+                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at
              FROM tasks WHERE project = ?1",
         )?;
         let rows = stmt.query_map(params![project], row_to_task)?;
@@ -376,7 +377,7 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    last_failure_json, source_created_at, last_activity_at, created_at, updated_at
+                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at
              FROM tasks WHERE state = ?1",
         )?;
         let rows = stmt.query_map(params![state_json], row_to_task)?;
@@ -559,9 +560,10 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
     let last_failure_at_str: Option<String> = row.get(13)?;
     let last_failure_json: Option<String> = row.get(14)?;
     let source_created_at_str: Option<String> = row.get(15)?;
-    let last_activity_at_str: Option<String> = row.get(16)?;
-    let created_at_str: String = row.get(17)?;
-    let updated_at_str: String = row.get(18)?;
+    let source_number: Option<u64> = row.get(16)?;
+    let last_activity_at_str: Option<String> = row.get(17)?;
+    let created_at_str: String = row.get(18)?;
+    let updated_at_str: String = row.get(19)?;
 
     let source: TaskSource = serde_json::from_str(&source_json).map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Text, Box::new(e))
@@ -619,7 +621,7 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
                 .map(|dt| dt.with_timezone(&Utc))
                 .map_err(|e| {
                     rusqlite::Error::FromSqlConversionFailure(
-                        16,
+                        17,
                         rusqlite::types::Type::Text,
                         Box::new(e),
                     )
@@ -630,7 +632,7 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
         .map(|dt| dt.with_timezone(&Utc))
         .map_err(|e| {
             rusqlite::Error::FromSqlConversionFailure(
-                17,
+                18,
                 rusqlite::types::Type::Text,
                 Box::new(e),
             )
@@ -639,7 +641,7 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
         .map(|dt| dt.with_timezone(&Utc))
         .map_err(|e| {
             rusqlite::Error::FromSqlConversionFailure(
-                18,
+                19,
                 rusqlite::types::Type::Text,
                 Box::new(e),
             )
@@ -662,6 +664,7 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
         last_failure_at,
         last_failure,
         source_created_at,
+        source_number,
         last_activity_at,
         created_at,
         updated_at,

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -30,6 +30,7 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
             last_failure_at TEXT,
             last_failure_json TEXT,
             source_created_at TEXT,
+            source_number INTEGER,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
@@ -116,6 +117,28 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
         }
         Err(e) => {
             tracing::error!(error = %e, "failed to add last_polled_at column");
+            return Err(e);
+        }
+    }
+
+    // Migration: add source_number column if it doesn't exist (issue #327)
+    // This stores the GitHub issue/PR number for deterministic dispatch ordering.
+    match conn.execute(
+        "ALTER TABLE tasks ADD COLUMN source_number INTEGER",
+        [],
+    ) {
+        Ok(_) => {
+            tracing::info!("added source_number column to tasks table");
+        }
+        Err(rusqlite::Error::SqliteFailure(e, Some(ref msg)))
+            if e.extended_code == rusqlite::ffi::SQLITE_ERROR
+                && msg.contains("duplicate column name") =>
+        {
+            // Column already exists — this is expected for existing databases
+            tracing::debug!("source_number column already exists");
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "failed to add source_number column");
             return Err(e);
         }
     }

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -929,9 +929,10 @@ Within each pool, candidates are sorted by:
    explicitly prioritized tasks.
 2. **Unblocking value.** Tasks that appear in other tasks' `blocked_by` lists sort before tasks
    that don't. This favors completing work that unblocks downstream tasks.
-3. **Recency.** Among otherwise equal tasks, newer tasks (`created_at` descending) go first.
-   In practice, older tasks in a backlog tend to be lower-priority or complex items; active work
-   is recent.
+3. **Source order.** For GitHub tasks, lower issue/PR numbers sort first (older issues before
+   newer ones). This ensures related tasks (e.g., "Phase 1", "Phase 2", "Phase 3") are processed
+   in logical creation order. For internal tasks without source numbers, older creation dates
+   sort first.
 
 The orchestrator influences dispatch indirectly by setting task priorities and creating or
 cancelling tasks, not by participating in the dispatch loop itself. This keeps dispatch fast and


### PR DESCRIPTION
## Summary
- Fix task queue ordering that was causing newer tasks to be processed before older ones
- Add `source_number` field to track GitHub issue/PR numbers for deterministic ordering
- Update dispatcher to sort by issue number ascending (lower = older = first)
- Tasks without source numbers fall back to created_at ascending (older first)

Closes #327

## Test plan
- [x] All existing tests pass (174 tests)
- [x] New tests added:
  - `priority_sorting_by_source_number` - verifies lower issue numbers sort first
  - `priority_sorting_fallback_to_created_at` - verifies older tasks sort first when no source number
- [ ] Manual testing: Create multiple related issues (e.g., Phase 1, 2, 3) and verify they are processed in creation order

🤖 Generated with [Claude Code](https://claude.com/claude-code)