### PR TITLE
Add self-update API endpoints and event types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,8 @@ bun web dev                    # dev mode (proxies /api to localhost:4800)
 - `POST /api/merge-queue/flush` — Flush approved entries (Pause mode only)
 - `POST /api/tasks/:id/chat` — Send chat message to agent session `{ message: string }`
 - `GET /api/events` — SSE live event stream (optional `?pattern=&task_id=` filters)
+- `GET /api/self-update` — Current update status (available, commit info, rebuild scope)
+- `POST /api/self-update/apply` — Trigger update `{ force: boolean }`
 
 ## Desktop app (GPUI)
 

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -65,6 +65,9 @@ pub fn router(state: ApiState) -> Router {
         .route("/accounting/tasks", get(list_task_accounting))
         .route("/accounting/tasks/{id}", get(get_task_accounting))
         .route("/events", get(event_stream))
+        // Self-update endpoints
+        .route("/self-update", get(get_self_update_status))
+        .route("/self-update/apply", post(apply_self_update))
         // Completions endpoints (fast mode with Haiku)
         .route("/completions", post(completions))
         .route("/completions/name", post(completions_name))
@@ -156,6 +159,42 @@ struct EventStreamQuery {
     pattern: Option<String>,
     /// Optional task ID filter.
     task_id: Option<String>,
+}
+
+// --- Self-update request/response types ---
+
+/// Response for GET /api/self-update.
+#[derive(Serialize)]
+struct SelfUpdateStatusResponse {
+    /// Whether an update is available.
+    available: bool,
+    /// Current commit hash.
+    current_commit: String,
+    /// Target commit hash (if update available).
+    target_commit: Option<String>,
+    /// Rebuild scope: "frontend", "server", or "container".
+    rebuild_scope: Option<String>,
+    /// Summary of the commit(s) to be applied.
+    commit_summary: Option<String>,
+    /// When the update check was last performed.
+    last_checked: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Request for POST /api/self-update/apply.
+#[derive(Deserialize)]
+struct ApplySelfUpdateRequest {
+    /// Force update even if sessions are active.
+    #[serde(default)]
+    force: bool,
+}
+
+/// Response for POST /api/self-update/apply.
+#[derive(Serialize)]
+struct ApplySelfUpdateResponse {
+    /// Status of the apply operation: "applying", "waiting", or "error".
+    status: String,
+    /// Human-readable message describing the current state.
+    message: String,
 }
 
 // --- Completions request/response types ---
@@ -875,6 +914,72 @@ async fn completions_summarize(
     Ok(Json(SummarizeResponse { summary }))
 }
 
+// --- Self-update handlers ---
+
+/// Get the current git commit hash.
+fn get_current_commit() -> String {
+    // Try to get the commit from git
+    std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout).ok().map(|s| s.trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// GET /api/self-update — Get current update status.
+///
+/// Returns the current update availability status. When Phase 1 infrastructure
+/// is connected, this will return actual update state from the update checker.
+async fn get_self_update_status(State(_state): State<ApiState>) -> Json<SelfUpdateStatusResponse> {
+    // TODO: Connect to Phase 1 update checker infrastructure when available.
+    // For now, return a placeholder indicating no update is available.
+    Json(SelfUpdateStatusResponse {
+        available: false,
+        current_commit: get_current_commit(),
+        target_commit: None,
+        rebuild_scope: None,
+        commit_summary: None,
+        last_checked: Some(chrono::Utc::now()),
+    })
+}
+
+/// POST /api/self-update/apply — Trigger update application.
+///
+/// When Phase 1 infrastructure is connected, this will:
+/// 1. Lower mode to Stop
+/// 2. Wait for active sessions to complete (or force if requested)
+/// 3. Exit with code 100 to signal the wrapper script to update
+async fn apply_self_update(
+    State(state): State<ApiState>,
+    Json(req): Json<ApplySelfUpdateRequest>,
+) -> Result<Json<ApplySelfUpdateResponse>, ApiError> {
+    // TODO: Connect to Phase 1 update executor when available.
+    // For now, return an error indicating the feature is not yet implemented.
+
+    // Even though we can't apply updates yet, we can emit an event for observability
+    let event = events::Event::new(
+        events::EventType::SystemUpdateApplying,
+        "",
+        events::Actor::Human,
+        serde_json::json!({
+            "force": req.force,
+            "status": "not_implemented",
+        }),
+    );
+    let _ = state.server.event_bus.publish(event).await;
+
+    Err(ApiError::UpdateUnavailable(
+        "Self-update infrastructure not yet configured. See issue #319.".to_string(),
+    ))
+}
+
 // --- Error handling ---
 
 enum ApiError {
@@ -886,6 +991,7 @@ enum ApiError {
     CompletionsUnavailable(String),
     CompletionsError(String),
     GitHub(String),
+    UpdateUnavailable(String),
 }
 
 impl IntoResponse for ApiError {
@@ -899,6 +1005,7 @@ impl IntoResponse for ApiError {
             ApiError::CompletionsUnavailable(e) => (StatusCode::SERVICE_UNAVAILABLE, e),
             ApiError::CompletionsError(e) => (StatusCode::INTERNAL_SERVER_ERROR, e),
             ApiError::GitHub(e) => (StatusCode::BAD_GATEWAY, e),
+            ApiError::UpdateUnavailable(e) => (StatusCode::SERVICE_UNAVAILABLE, e),
         };
         (status, Json(serde_json::json!({ "error": message }))).into_response()
     }

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -86,6 +86,12 @@ pub enum EventType {
     SystemAccountingApiCall,
     /// Session duration and total token accounting.
     SystemAccountingSession,
+
+    // Self-update events (spec §18)
+    /// Update available from upstream.
+    SystemUpdateAvailable,
+    /// Update is being applied (graceful shutdown in progress).
+    SystemUpdateApplying,
 }
 
 impl EventType {
@@ -134,6 +140,8 @@ impl EventType {
             Self::SystemAccountingTokens => "system:accounting:tokens",
             Self::SystemAccountingApiCall => "system:accounting:api_call",
             Self::SystemAccountingSession => "system:accounting:session",
+            Self::SystemUpdateAvailable => "system:update_available",
+            Self::SystemUpdateApplying => "system:update_applying",
         }
     }
 
@@ -211,6 +219,8 @@ impl TryFrom<String> for EventType {
             "system:accounting:tokens" => Ok(Self::SystemAccountingTokens),
             "system:accounting:api_call" => Ok(Self::SystemAccountingApiCall),
             "system:accounting:session" => Ok(Self::SystemAccountingSession),
+            "system:update_available" => Ok(Self::SystemUpdateAvailable),
+            "system:update_applying" => Ok(Self::SystemUpdateApplying),
             _ => Err(format!("unknown event type: {}", s)),
         }
     }
@@ -409,5 +419,56 @@ mod tests {
         assert!(tokens.matches("system:accounting:*"));
         assert!(api_call.matches("system:accounting:*"));
         assert!(session.matches("system:accounting:*"));
+    }
+
+    #[test]
+    fn update_available_event_serializes() {
+        let e = Event::new(
+            EventType::SystemUpdateAvailable,
+            "",
+            Actor::System,
+            serde_json::json!({
+                "target_commit": "def5678",
+                "rebuild_scope": "server",
+                "commit_summary": "Fix SSE presence guard (#279)",
+            }),
+        );
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"type\":\"system:update_available\""));
+        assert!(json.contains("\"target_commit\":\"def5678\""));
+    }
+
+    #[test]
+    fn update_applying_event_serializes() {
+        let e = Event::new(
+            EventType::SystemUpdateApplying,
+            "",
+            Actor::System,
+            serde_json::json!({
+                "target_commit": "def5678",
+                "sessions_remaining": 2,
+            }),
+        );
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"type\":\"system:update_applying\""));
+        assert!(json.contains("\"sessions_remaining\":2"));
+    }
+
+    #[test]
+    fn update_events_deserialize() {
+        let available = EventType::try_from("system:update_available".to_string()).unwrap();
+        assert_eq!(available, EventType::SystemUpdateAvailable);
+
+        let applying = EventType::try_from("system:update_applying".to_string()).unwrap();
+        assert_eq!(applying, EventType::SystemUpdateApplying);
+    }
+
+    #[test]
+    fn update_events_match_system_wildcard() {
+        let available = EventType::SystemUpdateAvailable;
+        let applying = EventType::SystemUpdateApplying;
+
+        assert!(available.matches("system:*"));
+        assert!(applying.matches("system:*"));
     }
 }


### PR DESCRIPTION
## Summary
- Adds `SystemUpdateAvailable` and `SystemUpdateApplying` event types to the events crate
- Adds `GET /api/self-update` endpoint to check update status
- Adds `POST /api/self-update/apply` endpoint to trigger updates
- Updates CLAUDE.md with new API documentation

## Implementation Notes

This is Phase 2 of the self-update mechanism (#305). The API endpoints include stub implementations that return:
- GET: `available: false` with current commit hash
- POST: 503 Service Unavailable (infrastructure not configured)

These stubs will be connected to the Phase 1 update checker infrastructure when #319 is completed.

### Event Types
| Event | Description |
|-------|-------------|
| `system:update_available` | Emitted when upstream has new commits |
| `system:update_applying` | Emitted when update process starts |

### API Responses
```json
// GET /api/self-update
{
  "available": false,
  "current_commit": "abc1234",
  "target_commit": null,
  "rebuild_scope": null,
  "commit_summary": null,
  "last_checked": "2026-03-23T15:00:00Z"
}
```

## Test plan
- [x] `cargo check` passes
- [x] `cargo test --package events` passes (33 tests including 4 new update event tests)
- [ ] Manual verification of API endpoints

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)