### PR TITLE
Add self-update mechanism core infrastructure

### DIFF
--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -49,6 +49,15 @@ pub struct AppConfig {
     pub web: bool,
     /// Web server port (default: 4800).
     pub web_port: u16,
+    /// Whether to run the update checker background task (default: true).
+    pub update_check_enabled: bool,
+    /// Update check interval (default: 300s / 5 minutes).
+    pub update_check_interval: Duration,
+    /// Whether to automatically apply updates when detected (default: false).
+    /// When false, updates are detected but not applied until manually triggered.
+    pub update_auto_apply: bool,
+    /// Timeout for waiting on sessions to stop during update (default: 300s / 5 minutes).
+    pub update_session_timeout: Duration,
 }
 
 impl AppConfig {
@@ -166,6 +175,24 @@ impl AppConfig {
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(4800),
+            update_check_enabled: std::env::var("TASKS_UPDATE_CHECK_ENABLED")
+                .map(|s| s != "false" && s != "0")
+                .unwrap_or(true),
+            update_check_interval: Duration::from_secs(
+                std::env::var("TASKS_UPDATE_CHECK_INTERVAL")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(300),
+            ),
+            update_auto_apply: std::env::var("TASKS_UPDATE_AUTO_APPLY")
+                .map(|s| s == "true" || s == "1")
+                .unwrap_or(false),
+            update_session_timeout: Duration::from_secs(
+                std::env::var("TASKS_UPDATE_SESSION_TIMEOUT")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(300),
+            ),
         })
     }
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -7,6 +7,7 @@ mod config;
 mod memory;
 mod problem_tracker;
 mod run_loop;
+mod update;
 mod web;
 
 use models::project::Project;
@@ -157,7 +158,14 @@ async fn main() {
             if args.iter().any(|a| a == "--web") {
                 config.web = true;
             }
-            run_loop::run(config).await.map_err(|e| e.to_string())
+            match run_loop::run(config).await {
+                Ok(run_loop::RunResult::UpdateReady) => {
+                    // Exit with code 100 to signal wrapper script
+                    std::process::exit(update::EXIT_CODE_UPDATE);
+                }
+                Ok(run_loop::RunResult::Shutdown) => Ok(()),
+                Err(e) => Err(e.to_string()),
+            }
         }
         "--help" | "-h" | "help" => {
             print_usage();

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -28,6 +28,7 @@ use tasks_orchestrator::{
 use crate::config::AppConfig;
 use crate::memory::{MemoryGate, MemoryThresholds};
 use crate::problem_tracker::ProblemTracker;
+use crate::update::UpdateChecker;
 
 /// Enum wrapper for orchestrator implementations.
 ///
@@ -131,11 +132,23 @@ fn classify_conflict(status: &tasks_github::model::PrMergeStatus) -> ConflictTyp
     }
 }
 
+/// Result of running the platform.
+#[derive(Debug)]
+pub enum RunResult {
+    /// Normal shutdown (ctrl-c or signal).
+    Shutdown,
+    /// Update ready — exit with code 100 for wrapper script.
+    UpdateReady,
+}
+
 /// Run the Tasks platform.
 ///
 /// Constructs all components and starts the GitHub poll loop,
 /// dispatch tick loop, and session management.
-pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
+///
+/// Returns `RunResult::UpdateReady` when an update is ready and the
+/// platform should restart after pulling/rebuilding.
+pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Error>> {
     info!(
         data_dir = %config.data_dir,
         max_sessions = config.max_sessions,
@@ -291,6 +304,34 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         )
         .await;
     });
+
+    // --- 5d. Create update checker (self-update mechanism) ---
+
+    let (update_shutdown_tx, update_shutdown_rx) = tokio::sync::watch::channel(false);
+    let update_checker = if config.update_check_enabled {
+        let checker = UpdateChecker::new(config.update_check_interval);
+        let state = checker.state();
+
+        // Clone values needed for the spawned task
+        let shutdown_rx = update_shutdown_rx.clone();
+        let check_interval = config.update_check_interval;
+
+        let handle = tokio::spawn(async move {
+            let checker = UpdateChecker::new(check_interval);
+            checker.run_loop(shutdown_rx).await;
+        });
+
+        info!(
+            interval = ?config.update_check_interval,
+            auto_apply = config.update_auto_apply,
+            "update checker enabled"
+        );
+
+        Some((state, handle))
+    } else {
+        info!("update checker disabled");
+        None
+    };
 
     // --- 6. Emit system:started ---
 
@@ -1794,13 +1835,92 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
         None
     };
 
-    // --- 10. Wait for shutdown ---
+    // --- 10. Wait for shutdown or update trigger ---
 
-    tokio::signal::ctrl_c().await?;
+    let update_triggered = if let Some((ref update_state, _)) = update_checker {
+        // Check if auto-apply is enabled and wait for either shutdown or update
+        if config.update_auto_apply {
+            let state = update_state.clone();
+            let session_timeout = config.update_session_timeout;
+
+            loop {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {
+                        break false;
+                    }
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                        let update = state.read().await;
+                        if update.update_available && update.scope.needs_rebuild() {
+                            info!(
+                                current = ?update.current_commit,
+                                target = ?update.target_commit,
+                                scope = ?update.scope,
+                                "update available, initiating graceful shutdown for update"
+                            );
+                            drop(update);
+
+                            // Lower mode to Stop
+                            if let Err(e) = server
+                                .set_mode(server::Mode::Stop, &events::Actor::System)
+                                .await
+                            {
+                                error!(error = %e, "failed to lower mode to Stop for update");
+                            }
+
+                            // Wait for all sessions to finish (with timeout)
+                            let start = std::time::Instant::now();
+                            loop {
+                                let active = session_manager.active_count().await;
+                                if active == 0 {
+                                    info!("all sessions stopped, proceeding with update");
+                                    break;
+                                }
+                                if start.elapsed() > session_timeout {
+                                    warn!(
+                                        active_sessions = active,
+                                        "session timeout exceeded, forcing update"
+                                    );
+                                    session_manager.destroy_all().await;
+                                    break;
+                                }
+                                debug!(
+                                    active_sessions = active,
+                                    elapsed = ?start.elapsed(),
+                                    "waiting for sessions to stop"
+                                );
+                                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                            }
+
+                            // Write scope file for wrapper script
+                            let scope = state.read().await.scope.clone();
+                            if let Err(e) = crate::update::write_scope_file(&scope, &config.data_dir) {
+                                error!(error = %e, "failed to write update scope file");
+                            }
+
+                            break true;
+                        }
+                    }
+                }
+            }
+        } else {
+            // Auto-apply disabled, just wait for ctrl-c
+            tokio::signal::ctrl_c().await?;
+            false
+        }
+    } else {
+        tokio::signal::ctrl_c().await?;
+        false
+    };
+
     info!("shutting down");
 
+    // Signal update checker to stop
+    let _ = update_shutdown_tx.send(true);
+
     // Stop all sessions and destroy their containers
-    session_manager.destroy_all().await;
+    if !update_triggered {
+        session_manager.destroy_all().await;
+    }
 
     // Cancel the loops
     poll_handle.abort();
@@ -1810,12 +1930,20 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     watchdog_handle.abort();
     cleanup_handle.abort();
     stop_mode_handle.abort();
+    if let Some((_, handle)) = update_checker {
+        handle.abort();
+    }
     if let Some(h) = web_handle {
         h.abort();
     }
 
-    info!("shutdown complete");
-    Ok(())
+    if update_triggered {
+        info!("shutdown complete, exiting for update (code 100)");
+        Ok(RunResult::UpdateReady)
+    } else {
+        info!("shutdown complete");
+        Ok(RunResult::Shutdown)
+    }
 }
 
 /// Per-project workflow settings loaded from `workflow.toml` (spec §14).

--- a/crates/app/src/update.rs
+++ b/crates/app/src/update.rs
@@ -1,0 +1,486 @@
+//! Self-update mechanism for the Tasks platform.
+//!
+//! This module implements a background update checker that:
+//! 1. Periodically fetches from origin/main to detect new commits
+//! 2. Analyzes changed files to determine rebuild scope
+//! 3. Coordinates graceful shutdown when updates are ready
+//!
+//! The server exits with code 100 when an update is ready, signaling
+//! the wrapper script to pull, rebuild, and restart.
+
+use std::collections::HashSet;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::sync::{watch, RwLock};
+use tracing::{debug, info, warn};
+
+/// Rebuild scope indicating which components need rebuilding.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RebuildScope {
+    /// Server binary needs rebuilding (any crates/** changes except supervisor).
+    pub server: bool,
+    /// Container image needs rebuilding (supervisor, Dockerfile, Makefile).
+    pub container: bool,
+    /// Frontend needs rebuilding (web/** changes).
+    pub frontend: bool,
+}
+
+impl RebuildScope {
+    /// Returns true if any component needs rebuilding.
+    pub fn needs_rebuild(&self) -> bool {
+        self.server || self.container || self.frontend
+    }
+
+    /// Serialize to a string for writing to .update-scope file.
+    pub fn to_scope_string(&self) -> String {
+        let mut parts = Vec::new();
+        if self.server {
+            parts.push("server");
+        }
+        if self.container {
+            parts.push("container");
+        }
+        if self.frontend {
+            parts.push("frontend");
+        }
+        parts.join(",")
+    }
+
+    /// Parse from a scope string (comma-separated).
+    /// Used by wrapper script to read `.update-scope` file.
+    #[allow(dead_code)]
+    pub fn from_scope_string(s: &str) -> Self {
+        let parts: HashSet<&str> = s.split(',').map(|p| p.trim()).collect();
+        Self {
+            server: parts.contains("server"),
+            container: parts.contains("container"),
+            frontend: parts.contains("frontend"),
+        }
+    }
+}
+
+/// State of the update checker.
+#[derive(Debug, Clone, Default)]
+pub struct UpdateState {
+    /// Whether an update is available.
+    pub update_available: bool,
+    /// The current HEAD commit (short hash).
+    pub current_commit: Option<String>,
+    /// The target commit on origin/main (short hash).
+    pub target_commit: Option<String>,
+    /// Number of commits behind origin/main.
+    pub commits_behind: u32,
+    /// Rebuild scope if update is available.
+    pub scope: RebuildScope,
+    /// Last error message if any.
+    pub last_error: Option<String>,
+    /// Whether an update is currently being applied.
+    pub applying: bool,
+}
+
+/// The update checker background task.
+pub struct UpdateChecker {
+    /// Check interval.
+    interval: Duration,
+    /// Current state (shared with external readers).
+    state: Arc<RwLock<UpdateState>>,
+    /// Channel to trigger an update application (for future web API use).
+    #[allow(dead_code)]
+    apply_tx: watch::Sender<bool>,
+    /// Channel to receive apply trigger.
+    apply_rx: watch::Receiver<bool>,
+    /// Path to the repository root.
+    repo_root: String,
+}
+
+impl UpdateChecker {
+    /// Create a new update checker.
+    pub fn new(interval: Duration) -> Self {
+        let (apply_tx, apply_rx) = watch::channel(false);
+        Self {
+            interval,
+            state: Arc::new(RwLock::new(UpdateState::default())),
+            apply_tx,
+            apply_rx,
+            repo_root: std::env::current_dir()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| ".".to_string()),
+        }
+    }
+
+    /// Get a clone of the shared state handle.
+    pub fn state(&self) -> Arc<RwLock<UpdateState>> {
+        Arc::clone(&self.state)
+    }
+
+    /// Trigger update application (called externally via web API).
+    #[allow(dead_code)]
+    pub fn trigger_apply(&self) {
+        let _ = self.apply_tx.send(true);
+    }
+
+    /// Check for updates by fetching from origin/main.
+    pub async fn check(&self) -> Result<UpdateState, String> {
+        // Get current HEAD
+        let current = self.get_current_commit().await?;
+
+        // Fetch origin/main
+        self.fetch_origin().await?;
+
+        // Get origin/main HEAD
+        let target = self.get_origin_main_commit().await?;
+
+        // Check if we're behind
+        if current == target {
+            return Ok(UpdateState {
+                update_available: false,
+                current_commit: Some(current),
+                target_commit: Some(target),
+                commits_behind: 0,
+                scope: RebuildScope::default(),
+                last_error: None,
+                applying: false,
+            });
+        }
+
+        // Count commits behind
+        let commits_behind = self.count_commits_behind().await?;
+
+        // Analyze changed files to determine scope
+        let scope = self.analyze_scope().await?;
+
+        Ok(UpdateState {
+            update_available: true,
+            current_commit: Some(current),
+            target_commit: Some(target),
+            commits_behind,
+            scope,
+            last_error: None,
+            applying: false,
+        })
+    }
+
+    /// Run the background check loop.
+    pub async fn run_loop(&self, mut shutdown_rx: watch::Receiver<bool>) {
+        let mut interval = tokio::time::interval(self.interval);
+        let mut apply_rx = self.apply_rx.clone();
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    match self.check().await {
+                        Ok(state) => {
+                            let mut current = self.state.write().await;
+                            // Preserve applying flag if set
+                            let applying = current.applying;
+                            *current = state;
+                            current.applying = applying;
+
+                            if current.update_available {
+                                info!(
+                                    current = ?current.current_commit,
+                                    target = ?current.target_commit,
+                                    commits_behind = current.commits_behind,
+                                    scope = ?current.scope,
+                                    "update available"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "update check failed");
+                            let mut current = self.state.write().await;
+                            current.last_error = Some(e);
+                        }
+                    }
+                }
+                _ = apply_rx.changed() => {
+                    if *apply_rx.borrow() {
+                        let mut state = self.state.write().await;
+                        state.applying = true;
+                        info!("update apply triggered");
+                        // The actual application is handled by the run_loop in main
+                    }
+                }
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        info!("update checker shutting down");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get the current HEAD commit (short hash).
+    async fn get_current_commit(&self) -> Result<String, String> {
+        let output = Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .current_dir(&self.repo_root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| format!("failed to run git rev-parse: {e}"))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "git rev-parse failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    /// Fetch from origin.
+    async fn fetch_origin(&self) -> Result<(), String> {
+        let output = Command::new("git")
+            .args(["fetch", "origin", "main"])
+            .current_dir(&self.repo_root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| format!("failed to run git fetch: {e}"))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "git fetch failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Get the origin/main commit (short hash).
+    async fn get_origin_main_commit(&self) -> Result<String, String> {
+        let output = Command::new("git")
+            .args(["rev-parse", "--short", "origin/main"])
+            .current_dir(&self.repo_root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| format!("failed to run git rev-parse origin/main: {e}"))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "git rev-parse origin/main failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    /// Count commits behind origin/main.
+    async fn count_commits_behind(&self) -> Result<u32, String> {
+        let output = Command::new("git")
+            .args(["rev-list", "--count", "HEAD..origin/main"])
+            .current_dir(&self.repo_root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| format!("failed to count commits: {e}"))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "git rev-list failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse()
+            .map_err(|e| format!("failed to parse commit count: {e}"))
+    }
+
+    /// Analyze changed files to determine rebuild scope.
+    async fn analyze_scope(&self) -> Result<RebuildScope, String> {
+        let output = Command::new("git")
+            .args(["diff", "--name-only", "HEAD..origin/main"])
+            .current_dir(&self.repo_root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| format!("failed to get diff: {e}"))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "git diff failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let files: Vec<&str> = stdout
+            .lines()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        Ok(determine_rebuild_scope(&files))
+    }
+}
+
+/// Determine rebuild scope from a list of changed files.
+///
+/// Rules:
+/// - `crates/supervisor/**`, `src/runtime/Dockerfile`, `Makefile` → Container scope
+/// - `crates/**` (except supervisor) → Server scope
+/// - `web/**` → Frontend scope
+pub fn determine_rebuild_scope(files: &[&str]) -> RebuildScope {
+    let mut scope = RebuildScope::default();
+
+    for &file in files {
+        // Container scope: supervisor, runtime Dockerfile, Makefile
+        if file.starts_with("crates/supervisor/")
+            || file == "src/runtime/Dockerfile"
+            || file == "Makefile"
+        {
+            scope.container = true;
+            // Supervisor is part of the workspace, so server also needs rebuild
+            if file.starts_with("crates/supervisor/") {
+                scope.server = true;
+            }
+        }
+        // Server scope: any other crates/** changes
+        else if file.starts_with("crates/") {
+            scope.server = true;
+        }
+        // Frontend scope: web/** changes
+        else if file.starts_with("web/") {
+            scope.frontend = true;
+        }
+        // Cargo workspace files affect server build
+        else if file == "Cargo.toml" || file == "Cargo.lock" {
+            scope.server = true;
+        }
+    }
+
+    scope
+}
+
+/// Write the update scope file used by the wrapper script.
+pub fn write_scope_file(scope: &RebuildScope, data_dir: &str) -> std::io::Result<()> {
+    let scope_path = format!("{}/.update-scope", data_dir);
+    std::fs::write(&scope_path, scope.to_scope_string())?;
+    debug!(path = %scope_path, scope = %scope.to_scope_string(), "wrote update scope file");
+    Ok(())
+}
+
+/// Exit code indicating that an update is ready.
+pub const EXIT_CODE_UPDATE: i32 = 100;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scope_server_changes() {
+        let files = vec!["crates/app/src/main.rs", "crates/server/src/lib.rs"];
+        let scope = determine_rebuild_scope(&files);
+        assert!(scope.server);
+        assert!(!scope.container);
+        assert!(!scope.frontend);
+    }
+
+    #[test]
+    fn test_scope_supervisor_changes() {
+        let files = vec!["crates/supervisor/src/main.rs"];
+        let scope = determine_rebuild_scope(&files);
+        assert!(scope.server); // supervisor is part of workspace
+        assert!(scope.container);
+        assert!(!scope.frontend);
+    }
+
+    #[test]
+    fn test_scope_dockerfile_changes() {
+        let files = vec!["src/runtime/Dockerfile"];
+        let scope = determine_rebuild_scope(&files);
+        assert!(!scope.server);
+        assert!(scope.container);
+        assert!(!scope.frontend);
+    }
+
+    #[test]
+    fn test_scope_makefile_changes() {
+        let files = vec!["Makefile"];
+        let scope = determine_rebuild_scope(&files);
+        assert!(!scope.server);
+        assert!(scope.container);
+        assert!(!scope.frontend);
+    }
+
+    #[test]
+    fn test_scope_frontend_changes() {
+        let files = vec!["web/src/App.tsx", "web/package.json"];
+        let scope = determine_rebuild_scope(&files);
+        assert!(!scope.server);
+        assert!(!scope.container);
+        assert!(scope.frontend);
+    }
+
+    #[test]
+    fn test_scope_mixed_changes() {
+        let files = vec![
+            "crates/app/src/main.rs",
+            "crates/supervisor/src/main.rs",
+            "web/src/App.tsx",
+        ];
+        let scope = determine_rebuild_scope(&files);
+        assert!(scope.server);
+        assert!(scope.container);
+        assert!(scope.frontend);
+    }
+
+    #[test]
+    fn test_scope_cargo_files() {
+        let files = vec!["Cargo.toml", "Cargo.lock"];
+        let scope = determine_rebuild_scope(&files);
+        assert!(scope.server);
+        assert!(!scope.container);
+        assert!(!scope.frontend);
+    }
+
+    #[test]
+    fn test_scope_no_rebuild_needed() {
+        let files = vec!["README.md", "docs/design.md", ".gitignore"];
+        let scope = determine_rebuild_scope(&files);
+        assert!(!scope.server);
+        assert!(!scope.container);
+        assert!(!scope.frontend);
+        assert!(!scope.needs_rebuild());
+    }
+
+    #[test]
+    fn test_scope_string_roundtrip() {
+        let scope = RebuildScope {
+            server: true,
+            container: true,
+            frontend: false,
+        };
+        let s = scope.to_scope_string();
+        assert_eq!(s, "server,container");
+
+        let parsed = RebuildScope::from_scope_string(&s);
+        assert_eq!(parsed, scope);
+    }
+
+    #[test]
+    fn test_scope_string_empty() {
+        let scope = RebuildScope::default();
+        let s = scope.to_scope_string();
+        assert_eq!(s, "");
+
+        let parsed = RebuildScope::from_scope_string(&s);
+        assert_eq!(parsed, scope);
+    }
+}

--- a/scripts/tasks-runner.sh
+++ b/scripts/tasks-runner.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# tasks-runner.sh — Wrapper script for self-updating Tasks platform
+#
+# This script runs the Tasks server in a loop, handling automatic updates.
+# When the server exits with code 100, it pulls changes, rebuilds based on
+# the scope file, and restarts.
+#
+# Usage:
+#   ./scripts/tasks-runner.sh [--web] [--auto-update]
+#
+# Options:
+#   --web          Enable the web UI
+#   --auto-update  Enable automatic update application (TASKS_UPDATE_AUTO_APPLY=true)
+#
+# Environment variables:
+#   TASKS_DATA_DIR              Data directory (default: ~/.local/state/tasks)
+#   TASKS_UPDATE_CHECK_ENABLED  Enable update checking (default: true)
+#   TASKS_UPDATE_CHECK_INTERVAL Update check interval in seconds (default: 300)
+#   TASKS_UPDATE_AUTO_APPLY     Auto-apply updates (default: false)
+#   TASKS_UPDATE_SESSION_TIMEOUT Session stop timeout in seconds (default: 300)
+
+set -euo pipefail
+
+# Exit code indicating update ready
+EXIT_CODE_UPDATE=100
+
+# Parse arguments
+ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        --auto-update)
+            export TASKS_UPDATE_AUTO_APPLY=true
+            ;;
+        *)
+            ARGS+=("$arg")
+            ;;
+    esac
+done
+
+# Data directory for scope file
+DATA_DIR="${TASKS_DATA_DIR:-$HOME/.local/state/tasks}"
+SCOPE_FILE="$DATA_DIR/.update-scope"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${BLUE}[tasks-runner]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[tasks-runner]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[tasks-runner]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[tasks-runner]${NC} $1"
+}
+
+# Build based on scope
+build_scope() {
+    local scope="$1"
+    local build_failed=false
+
+    log_info "Building components: $scope"
+
+    # Server rebuild (cargo build)
+    if [[ "$scope" == *"server"* ]]; then
+        log_info "Building server..."
+        if ! cargo build --release --package tasks-app; then
+            log_error "Server build failed"
+            build_failed=true
+        else
+            log_success "Server built successfully"
+        fi
+    fi
+
+    # Container rebuild (make container-image)
+    if [[ "$scope" == *"container"* ]]; then
+        log_info "Building container image..."
+        if ! make container-image; then
+            log_error "Container build failed"
+            build_failed=true
+        else
+            log_success "Container image built successfully"
+        fi
+    fi
+
+    # Frontend rebuild (bun web build)
+    if [[ "$scope" == *"frontend"* ]]; then
+        log_info "Building frontend..."
+        if command -v bun &> /dev/null; then
+            if ! (cd web && bun install && bun run build); then
+                log_error "Frontend build failed"
+                build_failed=true
+            else
+                log_success "Frontend built successfully"
+            fi
+        else
+            log_warn "bun not found, skipping frontend build"
+        fi
+    fi
+
+    if $build_failed; then
+        return 1
+    fi
+    return 0
+}
+
+# Main loop
+main() {
+    log_info "Starting Tasks runner (auto-update wrapper)"
+    log_info "Data directory: $DATA_DIR"
+    log_info "Update auto-apply: ${TASKS_UPDATE_AUTO_APPLY:-false}"
+
+    while true; do
+        log_info "Starting Tasks server..."
+
+        # Run the server
+        set +e
+        cargo run --release --package tasks-app -- run "${ARGS[@]}"
+        exit_code=$?
+        set -e
+
+        log_info "Server exited with code: $exit_code"
+
+        # Check for update exit code
+        if [[ $exit_code -eq $EXIT_CODE_UPDATE ]]; then
+            log_info "Update requested, pulling changes..."
+
+            # Pull latest changes
+            if ! git pull origin main; then
+                log_error "Failed to pull changes, retrying in 60 seconds..."
+                sleep 60
+                continue
+            fi
+
+            # Read scope file
+            if [[ -f "$SCOPE_FILE" ]]; then
+                scope=$(cat "$SCOPE_FILE")
+                log_info "Update scope: $scope"
+                rm -f "$SCOPE_FILE"
+            else
+                # Default to full rebuild if no scope file
+                scope="server,container,frontend"
+                log_warn "No scope file found, defaulting to full rebuild"
+            fi
+
+            # Build based on scope
+            if ! build_scope "$scope"; then
+                log_error "Build failed, retrying in 60 seconds..."
+                sleep 60
+                continue
+            fi
+
+            log_success "Update complete, restarting server..."
+            continue
+        fi
+
+        # Any other exit code — break the loop
+        if [[ $exit_code -ne 0 ]]; then
+            log_error "Server exited with error code $exit_code"
+            exit $exit_code
+        fi
+
+        log_info "Server exited normally"
+        break
+    done
+}
+
+# Handle signals
+trap 'log_info "Received signal, shutting down..."; exit 0' SIGINT SIGTERM
+
+main


### PR DESCRIPTION
## Summary

Implements the core infrastructure for the self-update mechanism (Phase 1 of #305):

- **Update configuration**: New `AppConfig` fields for controlling update behavior
  - `TASKS_UPDATE_CHECK_ENABLED` - Enable/disable update checking (default: true)
  - `TASKS_UPDATE_CHECK_INTERVAL` - Check interval in seconds (default: 300)
  - `TASKS_UPDATE_AUTO_APPLY` - Auto-apply updates when detected (default: false)
  - `TASKS_UPDATE_SESSION_TIMEOUT` - Timeout for session stop during update (default: 300s)

- **Update checker background task** (`update.rs`):
  - Periodically runs `git fetch origin main` to detect new commits
  - Compares HEAD with origin/main to detect available updates
  - Analyzes changed files to determine rebuild scope (server/container/frontend)

- **Graceful update application**:
  - Lowers mode to Stop when update triggered
  - Waits for active sessions to complete (with timeout)
  - Writes `.update-scope` file for wrapper script
  - Exits with code 100 to signal wrapper

- **Wrapper script** (`scripts/tasks-runner.sh`):
  - Runs server in a loop, handling restarts
  - On exit code 100: pulls changes, reads scope, rebuilds only needed components
  - Handles build failures with retry logic

## Test plan

- [x] Unit tests for scope detection logic pass (`cargo test --package tasks-app update::`)
- [x] All existing tests pass
- [ ] Manual testing: Start server with `--auto-update`, verify it detects and applies updates

## Files changed

- `crates/app/src/config.rs` - Add update configuration fields
- `crates/app/src/main.rs` - Handle exit code 100 for updates
- `crates/app/src/run_loop.rs` - Spawn update checker, handle graceful shutdown
- `crates/app/src/update.rs` - New file: UpdateChecker, scope detection, tests
- `scripts/tasks-runner.sh` - New file: Wrapper script for self-updating

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)