### PR TITLE
Load historical orchestrator events on page mount

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -64,6 +64,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/accounting", get(get_accounting_summary))
         .route("/accounting/tasks", get(list_task_accounting))
         .route("/accounting/tasks/{id}", get(get_task_accounting))
+        .route("/events/query", get(query_events))
         .route("/events", get(event_stream))
         // Completions endpoints (fast mode with Haiku)
         .route("/completions", post(completions))
@@ -156,6 +157,14 @@ struct EventStreamQuery {
     pattern: Option<String>,
     /// Optional task ID filter.
     task_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct QueryEventsParams {
+    /// Event type prefix to filter by (e.g. "orchestrator:").
+    type_prefix: Option<String>,
+    /// Maximum number of events to return (default: 200).
+    limit: Option<usize>,
 }
 
 // --- Completions request/response types ---
@@ -697,6 +706,32 @@ impl<S: Stream> Stream for PresenceStream<S> {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.project().inner.poll_next(cx)
     }
+}
+
+/// GET /api/events/query — Query historical events by type prefix.
+///
+/// Returns events matching the given `type_prefix` across all task logs,
+/// sorted by timestamp ascending and capped at `limit` (default 200).
+async fn query_events(
+    State(state): State<ApiState>,
+    Query(params): Query<QueryEventsParams>,
+) -> Result<Json<Vec<events::Event>>, ApiError> {
+    let type_prefix = params.type_prefix.unwrap_or_default();
+    let limit = params.limit.unwrap_or(200);
+
+    if type_prefix.is_empty() {
+        return Err(ApiError::BadRequest(
+            "type_prefix query parameter is required".to_string(),
+        ));
+    }
+
+    state
+        .server
+        .event_bus
+        .query_by_type_prefix(&type_prefix, limit)
+        .await
+        .map(Json)
+        .map_err(|e| ApiError::Server(server::ServerError::EventStore(e)))
 }
 
 /// GET /api/events — SSE stream of live events.

--- a/crates/events/src/bus.rs
+++ b/crates/events/src/bus.rs
@@ -62,6 +62,17 @@ impl EventBus {
         self.store.read_task(task_id).await
     }
 
+    /// Query events across all tasks by event-type prefix.
+    ///
+    /// See [`EventStore::query_by_type_prefix`] for details.
+    pub async fn query_by_type_prefix(
+        &self,
+        type_prefix: &str,
+        limit: usize,
+    ) -> Result<Vec<Event>, StoreError> {
+        self.store.query_by_type_prefix(type_prefix, limit).await
+    }
+
     /// List all task IDs with event logs.
     pub async fn list_tasks(&self) -> Result<Vec<String>, StoreError> {
         self.store.list_tasks().await

--- a/crates/events/src/store.rs
+++ b/crates/events/src/store.rs
@@ -99,6 +99,47 @@ impl EventStore {
         Ok(events.into_iter().skip(offset).collect())
     }
 
+    /// Query events across all tasks, filtered by an event-type prefix.
+    ///
+    /// Scans every task's event log and returns events whose type starts with
+    /// `type_prefix` (e.g. `"orchestrator:"`).  Results are sorted by timestamp
+    /// ascending and truncated to `limit`.
+    pub async fn query_by_type_prefix(
+        &self,
+        type_prefix: &str,
+        limit: usize,
+    ) -> Result<Vec<Event>, StoreError> {
+        let task_ids = self.list_tasks().await?;
+        let mut matching = Vec::new();
+
+        for task_id in &task_ids {
+            let events = self.read_task(task_id).await?;
+            for event in events {
+                if event.event_type.as_str().starts_with(type_prefix) {
+                    matching.push(event);
+                }
+            }
+        }
+
+        // Also scan the empty-string task dir (system-wide events like orchestrator messages)
+        let empty_events = self.read_task("").await?;
+        for event in empty_events {
+            if event.event_type.as_str().starts_with(type_prefix) {
+                matching.push(event);
+            }
+        }
+
+        // Sort by timestamp ascending
+        matching.sort_by(|a, b| a.ts.cmp(&b.ts));
+
+        // Apply limit (take from the end to get the most recent)
+        if matching.len() > limit {
+            matching = matching.split_off(matching.len() - limit);
+        }
+
+        Ok(matching)
+    }
+
     /// List all task IDs that have event logs.
     pub async fn list_tasks(&self) -> Result<Vec<String>, StoreError> {
         let mut tasks = Vec::new();
@@ -188,5 +229,88 @@ mod tests {
         let mut tasks = store.list_tasks().await.unwrap();
         tasks.sort();
         assert_eq!(tasks, vec!["task-a", "task-b"]);
+    }
+
+    #[tokio::test]
+    async fn query_by_type_prefix() {
+        let dir = tempdir().unwrap();
+        let store = EventStore::new(dir.path());
+
+        // Events across different task dirs
+        store
+            .append(&Event::new(
+                EventType::OrchestratorDecision,
+                "task-1",
+                Actor::Orchestrator,
+                serde_json::json!({"approved": true}),
+            ))
+            .await
+            .unwrap();
+
+        store
+            .append(&Event::new(
+                EventType::TaskCreated,
+                "task-1",
+                Actor::System,
+                serde_json::json!({}),
+            ))
+            .await
+            .unwrap();
+
+        store
+            .append(&Event::new(
+                EventType::OrchestratorMessage,
+                "", // system-wide
+                Actor::Human,
+                serde_json::json!({"message": "hello"}),
+            ))
+            .await
+            .unwrap();
+
+        store
+            .append(&Event::new(
+                EventType::OrchestratorFeedback,
+                "task-2",
+                Actor::Orchestrator,
+                serde_json::json!({"feedback": "add tests"}),
+            ))
+            .await
+            .unwrap();
+
+        let results = store
+            .query_by_type_prefix("orchestrator:", 100)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
+        // All should be orchestrator events
+        for event in &results {
+            assert!(event.event_type.as_str().starts_with("orchestrator:"));
+        }
+    }
+
+    #[tokio::test]
+    async fn query_by_type_prefix_respects_limit() {
+        let dir = tempdir().unwrap();
+        let store = EventStore::new(dir.path());
+
+        for i in 0..5 {
+            store
+                .append(&Event::new(
+                    EventType::OrchestratorDecision,
+                    &format!("task-{}", i),
+                    Actor::Orchestrator,
+                    serde_json::json!({"approved": true}),
+                ))
+                .await
+                .unwrap();
+        }
+
+        let results = store
+            .query_by_type_prefix("orchestrator:", 3)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
     }
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -134,6 +134,16 @@ export function createIssue(req: CreateIssueRequest): Promise<CreateIssueRespons
   });
 }
 
+export function fetchEvents(params: {
+  type_prefix: string;
+  limit?: number;
+}): Promise<Event[]> {
+  const qs = new URLSearchParams();
+  qs.set("type_prefix", params.type_prefix);
+  if (params.limit != null) qs.set("limit", String(params.limit));
+  return request<Event[]>(`/api/events/query?${qs.toString()}`);
+}
+
 export function subscribeEvents(opts?: {
   pattern?: string;
   task_id?: string;

--- a/web/src/pages/orchestrator/page.tsx
+++ b/web/src/pages/orchestrator/page.tsx
@@ -9,7 +9,7 @@ import {
   Brain,
 } from "lucide-react";
 import { useAppState } from "@/hooks/use-app-state";
-import { sendOrchestratorChat, subscribeEvents } from "@/lib/api";
+import { fetchEvents, sendOrchestratorChat, subscribeEvents } from "@/lib/api";
 import { cn, formatRelativeTime, projectLabel } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -382,6 +382,7 @@ function BlockView({ block }: { block: OrchestratorBlock }) {
 export function OrchestratorPage() {
   const { snapshot, events: allEvents } = useAppState();
   const [localEvents, setLocalEvents] = useState<Event[]>([]);
+  const [historicalEvents, setHistoricalEvents] = useState<Event[]>([]);
   const [chatInput, setChatInput] = useState("");
   const [sending, setSending] = useState(false);
   const [isAtBottom, setIsAtBottom] = useState(true);
@@ -391,12 +392,27 @@ export function OrchestratorPage() {
 
   const orchestratorEvents = useMemo(() => {
     const globalOrchEvents = allEvents.filter((e) => e.type.startsWith("orchestrator:"));
-    const merged = [...globalOrchEvents, ...localEvents];
+    const merged = [...historicalEvents, ...globalOrchEvents, ...localEvents];
     const seen = new Set<string>();
     return merged
       .filter((e) => { if (seen.has(e.id)) return false; seen.add(e.id); return true; })
       .sort((a, b) => a.ts.localeCompare(b.ts));
-  }, [allEvents, localEvents]);
+  }, [allEvents, localEvents, historicalEvents]);
+
+  // Fetch historical orchestrator events on mount
+  useEffect(() => {
+    let cancelled = false;
+    fetchEvents({ type_prefix: "orchestrator:", limit: 200 })
+      .then((events) => {
+        if (!cancelled) {
+          setHistoricalEvents(events);
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to fetch historical orchestrator events:", err);
+      });
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => {
     const source = subscribeEvents({ pattern: "orchestrator:*" });


### PR DESCRIPTION
## Summary

Fixes #335.

The orchestrator page only showed events received via live SSE while the page was open. If evaluations happened before the page was loaded, it showed "No orchestrator activity yet" — even if the orchestrator had evaluated dozens of entries.

**Backend:** Added `GET /api/events/query?type_prefix=orchestrator:&limit=200` endpoint that queries historical events from the event store by type prefix.

- `EventStore::query_by_type_prefix()` scans all task event logs plus system-wide logs, filters by prefix, sorts by timestamp, and applies a limit
- Exposed through `EventBus` facade
- 2 new tests for the query logic

**Frontend:** On mount, the orchestrator page now fetches historical events and merges them with live SSE events (deduped by ID, sorted by timestamp).

## Test plan

- [ ] `cargo check` passes
- [ ] `cargo test -p events` — 31 tests pass (2 new)
- [ ] `bun run build` succeeds
- [ ] Open orchestrator page after evaluations have run — should show historical decisions
- [ ] New live events still appear via SSE
- [ ] No duplicate events when historical and live overlap