### PR TITLE
Fix review issues from bulk-merged PRs

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -156,9 +156,19 @@ async fn cmd_rebuild() -> Result<(), String> {
                         );
                         let entry_id = format!("mq-{}-{}-pr-{}", pr.owner, pr.repo, pr.number);
 
-                        // Try to find linked task by branch name
-                        let task_id = find_task_by_branch_in_store(&store, &pr.head_ref)
-                            .unwrap_or_default();
+                        // Try to find linked task by branch name.
+                        // Skip PRs with no linked task — a merge queue entry with
+                        // an empty task_id is unusable.
+                        let task_id = match find_task_by_branch_in_store(&store, &pr.head_ref) {
+                            Some(id) => id,
+                            None => {
+                                eprintln!(
+                                    "  Skipping PR #{}: no linked task found for branch {}",
+                                    pr.number, pr.head_ref
+                                );
+                                continue;
+                            }
+                        };
 
                         let entry = server::model::merge_queue::MergeQueueEntry::new(
                             entry_id,

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -577,6 +577,10 @@ async fn set_mode(
 /// Clears tasks and merge queue from both memory and database,
 /// then signals the poll loop to re-fetch all data from GitHub.
 /// Preserves: accounting data, event logs, projects table, operating mode.
+///
+/// Note: The response contains counts of items *cleared*. The actual re-fetch
+/// happens asynchronously in the poll loop — new data will appear as the
+/// pollers discover items from GitHub.
 async fn rebuild_from_github(
     State(state): State<ApiState>,
 ) -> Result<Json<server::RebuildStats>, ApiError> {

--- a/crates/github/src/poller.rs
+++ b/crates/github/src/poller.rs
@@ -61,12 +61,6 @@ impl RepoPoller {
         self.since
     }
 
-    /// Reset the high-water mark to None (for rebuild command, issue #256).
-    /// Next poll will fetch all open items from scratch.
-    pub fn reset(&mut self) {
-        self.since = None;
-    }
-
     /// Poll for both issues and PRs updated since the last poll.
     ///
     /// On first call, fetches all open items. On subsequent calls, only items

--- a/crates/server/src/dispatcher.rs
+++ b/crates/server/src/dispatcher.rs
@@ -158,16 +158,16 @@ pub fn evaluate(
             return unblock_cmp;
         }
 
-        // Source number: lower issue/PR numbers first (ascending).
-        // GitHub issues are numbered sequentially, so lower numbers are older.
-        // This ensures related tasks (e.g., "Phase 1", "Phase 2", "Phase 3")
-        // are processed in logical order. Tasks without a source number
-        // (internal tasks) sort after those with numbers.
-        let num_a = a.source_number.unwrap_or(u64::MAX);
-        let num_b = b.source_number.unwrap_or(u64::MAX);
-        let num_cmp = num_a.cmp(&num_b);
-        if num_cmp != std::cmp::Ordering::Equal {
-            return num_cmp;
+        // Source number: lower issue/PR numbers first (ascending), but only
+        // compared within the same project. Issue numbers are per-repo, so
+        // comparing across projects has no semantic meaning.
+        if a.project == b.project {
+            let num_a = a.source_number.unwrap_or(u64::MAX);
+            let num_b = b.source_number.unwrap_or(u64::MAX);
+            let num_cmp = num_a.cmp(&num_b);
+            if num_cmp != std::cmp::Ordering::Equal {
+                return num_cmp;
+            }
         }
 
         // Fallback: older creation date first (ascending).

--- a/web/src/hooks/use-app-state.ts
+++ b/web/src/hooks/use-app-state.ts
@@ -18,10 +18,6 @@ const POLL_INTERVAL_MS = 5_000;
 /** Regex matching event types that should trigger a snapshot refresh. */
 const STATE_CHANGING_EVENT = /^(task:|merge:|system:mode)/;
 
-/** High-frequency event types excluded from the global events buffer.
- * These events are still available via task-specific event fetches. */
-const EXCLUDED_FROM_BUFFER = ["agent:message", "human:message"];
-
 export interface AppState {
   snapshot: Snapshot | null;
   events: Event[];
@@ -137,15 +133,10 @@ function useAppStateCore(): AppState {
         try {
           const event: Event = JSON.parse(msg.data);
 
-          // Only add non-excluded events to the buffer to prevent
-          // high-frequency events like agent:message from drowning out
-          // important state changes (see issue #318).
-          if (!EXCLUDED_FROM_BUFFER.includes(event.type)) {
-            setEvents((prev) => {
-              const next = [event, ...prev];
-              return next.length > MAX_EVENTS ? next.slice(0, MAX_EVENTS) : next;
-            });
-          }
+          setEvents((prev) => {
+            const next = [event, ...prev];
+            return next.length > MAX_EVENTS ? next.slice(0, MAX_EVENTS) : next;
+          });
 
           if (STATE_CHANGING_EVENT.test(event.type)) {
             refreshSnapshot();

--- a/web/src/pages/tasks/page.tsx
+++ b/web/src/pages/tasks/page.tsx
@@ -181,18 +181,26 @@ function TaskRow({
         </Badge>
       ))}
 
-      {/* PR link */}
-      {prUrl && (
-        <a
-          href={prUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={(e) => e.stopPropagation()}
-          className="inline-flex items-center gap-1 text-blue-400 hover:underline text-xs font-mono shrink-0"
+      {/* PR link — use span + onPointerUp to avoid invalid nested <a> inside <button> */}
+      {prUrl && prNumber(prUrl) && (
+        <span
+          role="link"
+          tabIndex={0}
+          onPointerUp={(e) => {
+            e.stopPropagation();
+            window.open(prUrl, "_blank", "noopener,noreferrer");
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.stopPropagation();
+              window.open(prUrl, "_blank", "noopener,noreferrer");
+            }
+          }}
+          className="inline-flex items-center gap-1 text-blue-400 hover:underline text-xs font-mono shrink-0 cursor-pointer"
         >
           #{prNumber(prUrl)}
           <ExternalLink className="h-3 w-3" />
-        </a>
+        </span>
       )}
 
       {/* Project */}


### PR DESCRIPTION
## Summary

Addresses review comments that were missed when PRs #313, #334, #274, and #331 were merged without checking their reviews first.

### Fixes

**#313 (PR link in task list):**
- Replaced nested `<a>` inside `<button>` (invalid HTML5) with `<span role="link">` + `onPointerUp`
- Added `prNumber(prUrl)` null guard so `#null` is never rendered

**#334 (Filter agent:message events):**
- Removed buffer-level filtering from `use-app-state.ts` — was dropping events for ALL consumers (orchestrator page, task detail) not just the events page
- The events page already has display-level "Important" filter via `VERBOSE_EVENT_TYPES` which is the right approach

**#274 (Rebuild from GitHub):**
- Removed dead `RepoPoller::reset()` method (rebuild uses `pollers.clear()`)
- Skip PRs with no linked task instead of creating merge entries with empty `task_id`
- Documented that rebuild response returns before re-fetch completes

**#331 (Task ordering):**
- `source_number` comparison now only applies within the same project — issue numbers are per-repo, cross-project comparison is meaningless

## Test plan

- [x] `cargo build` — compiles clean
- [x] `cargo test` — 9 app tests pass
- [x] `cargo test -p server` — 136 tests pass (includes dispatcher sort tests)
- [x] `bun run build` — frontend builds clean