### PR TITLE
Unify event data for issue vs PR closure paths

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -638,7 +638,12 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                         "detected external PR merge, transitioning task to Completed"
                                     );
                                     if let Err(e) = poll_server
-                                        .set_task_state(&task_id, TaskState::Completed, Actor::Scheduler)
+                                        .set_task_state_with_data(
+                                            &task_id,
+                                            TaskState::Completed,
+                                            Actor::Scheduler,
+                                            serde_json::json!({ "source": "reconciliation" }),
+                                        )
                                         .await
                                     {
                                         warn!(task_id = %task_id, error = %e, "failed to transition task for merged PR");
@@ -653,7 +658,12 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                                             "detected external PR closure, transitioning task to Cancelled"
                                         );
                                         if let Err(e) = poll_server
-                                            .set_task_state(&task_id, TaskState::Cancelled, Actor::Scheduler)
+                                            .set_task_state_with_data(
+                                                &task_id,
+                                                TaskState::Cancelled,
+                                                Actor::Scheduler,
+                                                serde_json::json!({ "source": "reconciliation" }),
+                                            )
                                             .await
                                         {
                                             warn!(task_id = %task_id, error = %e, "failed to transition task for closed PR");

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -323,6 +323,23 @@ impl Server {
         new_state: TaskState,
         actor: Actor,
     ) -> Result<(), ServerError> {
+        self.set_task_state_with_data(task_id, new_state, actor, serde_json::json!({}))
+            .await
+    }
+
+    /// Transition a task's state and emit the corresponding event with custom data.
+    ///
+    /// Like [`set_task_state`], but allows passing custom event data for
+    /// downstream consumers. Use this when the state change source needs to
+    /// be distinguished (e.g., `{ "source": "reconciliation" }` for external
+    /// closure detection during polling).
+    pub async fn set_task_state_with_data(
+        &self,
+        task_id: &str,
+        new_state: TaskState,
+        actor: Actor,
+        data: serde_json::Value,
+    ) -> Result<(), ServerError> {
         // Check if task is already terminal to prevent duplicate events
         let current_state = {
             let state = self.state.read().await;
@@ -365,7 +382,7 @@ impl Server {
             TaskState::Cancelled => EventType::TaskStateCancelled,
         };
 
-        let event = Event::new(event_type, task_id, actor, serde_json::json!({}));
+        let event = Event::new(event_type, task_id, actor, data);
         self.event_bus.publish(event).await?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Adds `set_task_state_with_data()` method to `Server` that accepts custom event data
- Updates PR closure detection in `run_loop.rs` to emit `{ "source": "reconciliation" }` data
- Issue closures via `reconcile_task()` and PR closures in the run_loop now emit consistent event data

Both paths now emit events with `Actor::Scheduler` and `{ "source": "reconciliation" }`, ensuring downstream consumers only need to handle one unified event format for external closures detected during polling.

Fixes #262

## Test plan

- [x] `cargo check --package server --package tasks-app` passes
- [x] `cargo test --package server --package tasks-app` passes (145 tests)
- [ ] Manual verification: trigger both issue closure and PR closure scenarios and verify event data matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)