### PR TITLE
Self-update Phase 2: API endpoints and events

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -834,24 +834,11 @@ async fn get_self_update_status(
 ///
 /// Note: Full functionality requires Phase 1 infrastructure (#319).
 async fn apply_self_update(
-    State(state): State<ApiState>,
+    State(_state): State<ApiState>,
     Json(req): Json<ApplySelfUpdateRequest>,
 ) -> Result<Json<ApplySelfUpdateResponse>, ApiError> {
     // TODO(#319): Integrate with SelfUpdateManager from Phase 1
-    // For now, return an error indicating the feature is not yet available
-
-    // Emit an event indicating update was requested (for debugging/logging)
-    let event = events::Event::new(
-        events::EventType::SystemUpdateApplying,
-        "",
-        Actor::System,
-        serde_json::json!({
-            "force": req.force,
-            "status": "not_available",
-            "reason": "Self-update infrastructure not yet configured (see #319)",
-        }),
-    );
-    let _ = state.server.event_bus.publish(event).await;
+    tracing::debug!(force = req.force, "self-update apply called (stub, #319 not yet integrated)");
 
     Ok(Json(ApplySelfUpdateResponse {
         status: "no_update".to_string(),

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -68,6 +68,9 @@ pub fn router(state: ApiState) -> Router {
         .route("/accounting/tasks", get(list_task_accounting))
         .route("/accounting/tasks/{id}", get(get_task_accounting))
         .route("/events/query", get(query_events))
+        // Self-update endpoints (issue #305, #320)
+        .route("/self-update", get(get_self_update_status))
+        .route("/self-update/apply", post(apply_self_update))
         .route("/events", get(event_stream))
         // Completions endpoints (fast mode with Haiku)
         .route("/completions", post(completions))
@@ -181,6 +184,42 @@ struct QueryEventsParams {
     type_prefix: Option<String>,
     /// Maximum number of events to return (default: 200).
     limit: Option<usize>,
+}
+
+// --- Self-update types (issue #305, #320) ---
+
+/// GET /api/self-update response.
+#[derive(Serialize)]
+struct SelfUpdateStatusResponse {
+    /// Whether an update is available.
+    available: bool,
+    /// Current commit hash (short form).
+    current_commit: Option<String>,
+    /// Target commit hash to update to (short form).
+    target_commit: Option<String>,
+    /// What needs to be rebuilt: "server", "container", or "frontend".
+    rebuild_scope: Option<String>,
+    /// First line of the commit message for the target commit.
+    commit_summary: Option<String>,
+    /// When the update was last checked.
+    last_checked: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// POST /api/self-update/apply request.
+#[derive(Deserialize)]
+struct ApplySelfUpdateRequest {
+    /// If true, skip waiting for active sessions to complete.
+    #[serde(default)]
+    force: bool,
+}
+
+/// POST /api/self-update/apply response.
+#[derive(Serialize)]
+struct ApplySelfUpdateResponse {
+    /// Status of the apply request: "applying", "no_update", "already_applying".
+    status: String,
+    /// Human-readable message about the update status.
+    message: String,
 }
 
 // --- Completions request/response types ---
@@ -763,6 +802,61 @@ async fn get_task_accounting(
         .map_err(ApiError::Server)?
         .ok_or_else(|| ApiError::NotFound(format!("accounting not found for task: {id}")))?;
     Ok(Json(accounting))
+}
+
+// --- Self-update endpoints (issue #305, #320) ---
+
+/// GET /api/self-update — Get current update status.
+///
+/// Returns information about whether an update is available from upstream.
+/// Note: Full functionality requires Phase 1 infrastructure (#319).
+async fn get_self_update_status(
+    State(_state): State<ApiState>,
+) -> Json<SelfUpdateStatusResponse> {
+    // TODO(#319): Integrate with SelfUpdateManager from Phase 1
+    // For now, return a stub response indicating no update mechanism is configured
+    Json(SelfUpdateStatusResponse {
+        available: false,
+        current_commit: None,
+        target_commit: None,
+        rebuild_scope: None,
+        commit_summary: None,
+        last_checked: None,
+    })
+}
+
+/// POST /api/self-update/apply — Trigger a self-update.
+///
+/// Initiates the update process:
+/// 1. Sets mode to Stop to prevent new session launches
+/// 2. Waits for active sessions to complete (unless force=true)
+/// 3. Exits with code 100 for the wrapper script to restart
+///
+/// Note: Full functionality requires Phase 1 infrastructure (#319).
+async fn apply_self_update(
+    State(state): State<ApiState>,
+    Json(req): Json<ApplySelfUpdateRequest>,
+) -> Result<Json<ApplySelfUpdateResponse>, ApiError> {
+    // TODO(#319): Integrate with SelfUpdateManager from Phase 1
+    // For now, return an error indicating the feature is not yet available
+
+    // Emit an event indicating update was requested (for debugging/logging)
+    let event = events::Event::new(
+        events::EventType::SystemUpdateApplying,
+        "",
+        Actor::System,
+        serde_json::json!({
+            "force": req.force,
+            "status": "not_available",
+            "reason": "Self-update infrastructure not yet configured (see #319)",
+        }),
+    );
+    let _ = state.server.event_bus.publish(event).await;
+
+    Ok(Json(ApplySelfUpdateResponse {
+        status: "no_update".to_string(),
+        message: "Self-update infrastructure not yet configured. See issue #319.".to_string(),
+    }))
 }
 
 /// A stream wrapper that holds a presence guard until the stream ends.

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -90,6 +90,12 @@ pub enum EventType {
     SystemAccountingApiCall,
     /// Session duration and total token accounting.
     SystemAccountingSession,
+
+    // Self-update events (issue #305)
+    /// New update is available from upstream.
+    SystemUpdateAvailable,
+    /// Update is being applied (graceful shutdown in progress).
+    SystemUpdateApplying,
 }
 
 impl EventType {
@@ -141,6 +147,8 @@ impl EventType {
             Self::SystemAccountingTokens => "system:accounting:tokens",
             Self::SystemAccountingApiCall => "system:accounting:api_call",
             Self::SystemAccountingSession => "system:accounting:session",
+            Self::SystemUpdateAvailable => "system:update_available",
+            Self::SystemUpdateApplying => "system:update_applying",
         }
     }
 
@@ -221,6 +229,8 @@ impl TryFrom<String> for EventType {
             "system:accounting:tokens" => Ok(Self::SystemAccountingTokens),
             "system:accounting:api_call" => Ok(Self::SystemAccountingApiCall),
             "system:accounting:session" => Ok(Self::SystemAccountingSession),
+            "system:update_available" => Ok(Self::SystemUpdateAvailable),
+            "system:update_applying" => Ok(Self::SystemUpdateApplying),
             _ => Err(format!("unknown event type: {}", s)),
         }
     }
@@ -419,5 +429,56 @@ mod tests {
         assert!(tokens.matches("system:accounting:*"));
         assert!(api_call.matches("system:accounting:*"));
         assert!(session.matches("system:accounting:*"));
+    }
+
+    #[test]
+    fn update_available_event_serializes() {
+        let e = Event::new(
+            EventType::SystemUpdateAvailable,
+            "",
+            Actor::System,
+            serde_json::json!({
+                "target_commit": "def5678",
+                "rebuild_scope": "server",
+                "commit_summary": "Fix SSE presence guard (#279)",
+            }),
+        );
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"type\":\"system:update_available\""));
+        assert!(json.contains("\"target_commit\":\"def5678\""));
+    }
+
+    #[test]
+    fn update_applying_event_serializes() {
+        let e = Event::new(
+            EventType::SystemUpdateApplying,
+            "",
+            Actor::System,
+            serde_json::json!({
+                "target_commit": "def5678",
+                "sessions_remaining": 2,
+            }),
+        );
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"type\":\"system:update_applying\""));
+        assert!(json.contains("\"sessions_remaining\":2"));
+    }
+
+    #[test]
+    fn update_events_deserialize() {
+        let available = EventType::try_from("system:update_available".to_string()).unwrap();
+        assert_eq!(available, EventType::SystemUpdateAvailable);
+
+        let applying = EventType::try_from("system:update_applying".to_string()).unwrap();
+        assert_eq!(applying, EventType::SystemUpdateApplying);
+    }
+
+    #[test]
+    fn update_events_match_system_wildcard() {
+        let available = EventType::SystemUpdateAvailable;
+        let applying = EventType::SystemUpdateApplying;
+
+        assert!(available.matches("system:*"));
+        assert!(applying.matches("system:*"));
     }
 }

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -147,8 +147,8 @@ impl EventType {
             Self::SystemAccountingTokens => "system:accounting:tokens",
             Self::SystemAccountingApiCall => "system:accounting:api_call",
             Self::SystemAccountingSession => "system:accounting:session",
-            Self::SystemUpdateAvailable => "system:update_available",
-            Self::SystemUpdateApplying => "system:update_applying",
+            Self::SystemUpdateAvailable => "system:update:available",
+            Self::SystemUpdateApplying => "system:update:applying",
         }
     }
 
@@ -229,8 +229,8 @@ impl TryFrom<String> for EventType {
             "system:accounting:tokens" => Ok(Self::SystemAccountingTokens),
             "system:accounting:api_call" => Ok(Self::SystemAccountingApiCall),
             "system:accounting:session" => Ok(Self::SystemAccountingSession),
-            "system:update_available" => Ok(Self::SystemUpdateAvailable),
-            "system:update_applying" => Ok(Self::SystemUpdateApplying),
+            "system:update:available" => Ok(Self::SystemUpdateAvailable),
+            "system:update:applying" => Ok(Self::SystemUpdateApplying),
             _ => Err(format!("unknown event type: {}", s)),
         }
     }
@@ -444,7 +444,7 @@ mod tests {
             }),
         );
         let json = serde_json::to_string(&e).unwrap();
-        assert!(json.contains("\"type\":\"system:update_available\""));
+        assert!(json.contains("\"type\":\"system:update:available\""));
         assert!(json.contains("\"target_commit\":\"def5678\""));
     }
 
@@ -460,16 +460,16 @@ mod tests {
             }),
         );
         let json = serde_json::to_string(&e).unwrap();
-        assert!(json.contains("\"type\":\"system:update_applying\""));
+        assert!(json.contains("\"type\":\"system:update:applying\""));
         assert!(json.contains("\"sessions_remaining\":2"));
     }
 
     #[test]
     fn update_events_deserialize() {
-        let available = EventType::try_from("system:update_available".to_string()).unwrap();
+        let available = EventType::try_from("system:update:available".to_string()).unwrap();
         assert_eq!(available, EventType::SystemUpdateAvailable);
 
-        let applying = EventType::try_from("system:update_applying".to_string()).unwrap();
+        let applying = EventType::try_from("system:update:applying".to_string()).unwrap();
         assert_eq!(applying, EventType::SystemUpdateApplying);
     }
 
@@ -480,5 +480,15 @@ mod tests {
 
         assert!(available.matches("system:*"));
         assert!(applying.matches("system:*"));
+    }
+
+    #[test]
+    fn update_events_match_update_wildcard() {
+        let available = EventType::SystemUpdateAvailable;
+        let applying = EventType::SystemUpdateApplying;
+
+        assert!(available.matches("system:update:*"));
+        assert!(applying.matches("system:update:*"));
+        assert!(!EventType::SystemModePlay.matches("system:update:*"));
     }
 }


### PR DESCRIPTION
## Summary

- Adds event types `system:update_available` and `system:update_applying` for the self-update mechanism
- Adds `GET /api/self-update` endpoint to check for available updates
- Adds `POST /api/self-update/apply` endpoint to trigger updates (with force flag support)

## Implementation Notes

This is Phase 2 of the self-update mechanism (#305). The endpoints currently return stub responses indicating "no update available" until Phase 1 (#319) provides the core infrastructure:

- `SelfUpdateManager` for background update checking
- Rebuild scope detection from git diff
- Exit code 100 mechanism for the wrapper script

Once Phase 1 is complete, the stubs can be replaced with calls to `SelfUpdateManager` methods.

### Event Types Added

| Event | Description |
|-------|-------------|
| `system:update_available` | Emitted when a new update is detected from upstream |
| `system:update_applying` | Emitted when update is being applied (graceful shutdown) |

### API Endpoints Added

| Endpoint | Description |
|----------|-------------|
| `GET /api/self-update` | Returns current update status (available, commits, scope) |
| `POST /api/self-update/apply` | Triggers update with optional `force` flag |

## Test plan

- [x] Events crate compiles and all tests pass
- [x] App crate compiles
- [x] New event type tests verify serialization/deserialization
- [ ] Manual: Start server, verify GET /api/self-update returns `{"available": false, ...}`
- [ ] Manual: POST /api/self-update/apply returns appropriate stub message

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)