### PR TITLE
Add frontend UI for update notifications

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { useAppState } from "@/hooks/use-app-state";
 import { addProject, deleteProject, setMode } from "@/lib/api";
+import { UpdateBanner } from "@/components/update-banner";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -394,8 +395,11 @@ function ProjectList() {
 // ---------------------------------------------------------------------------
 
 export function Layout() {
-  const { connected, snapshot } = useAppState();
+  const { connected, snapshot, updateStatus, updateDismissed, dismissUpdate, refreshUpdateStatus } = useAppState();
   const slotUtil = snapshot?.slot_utilization;
+
+  // Show update banner if update is available (or applying) and not dismissed
+  const showUpdateBanner = updateStatus && (updateStatus.available || updateStatus.applying) && !updateDismissed;
 
   return (
     <div className="flex h-screen bg-background text-foreground">
@@ -459,8 +463,17 @@ export function Layout() {
       </aside>
 
       {/* Main content */}
-      <main className="flex-1 overflow-auto">
-        <Outlet />
+      <main className="flex flex-1 flex-col overflow-hidden">
+        {showUpdateBanner && (
+          <UpdateBanner
+            status={updateStatus}
+            onDismiss={dismissUpdate}
+            onUpdateComplete={refreshUpdateStatus}
+          />
+        )}
+        <div className="flex-1 overflow-auto">
+          <Outlet />
+        </div>
       </main>
     </div>
   );

--- a/web/src/components/update-banner.tsx
+++ b/web/src/components/update-banner.tsx
@@ -3,7 +3,6 @@ import { Download, RefreshCw, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Spinner } from "@/components/ui/spinner";
 import type { UpdateStatus, RebuildScope } from "@/lib/types";
 import { applyUpdate } from "@/lib/api";
 
@@ -104,37 +103,30 @@ export function UpdateBanner({
       </div>
 
       {/* Actions */}
-      <div className="flex items-center gap-2 shrink-0">
-        {isApplying ? (
-          <div className="flex items-center gap-2 text-xs text-yellow-600">
-            <Spinner className="h-3 w-3" />
-            <span>Updating...</span>
-          </div>
-        ) : (
-          <>
+      {!isApplying && (
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            size="xs"
+            variant="outline"
+            onClick={handleApplyUpdate}
+            disabled={applying}
+            className="border-blue-500/50 text-blue-600 hover:bg-blue-500/20"
+          >
+            Update Now
+          </Button>
+          {onDismiss && (
             <Button
-              size="xs"
-              variant="outline"
-              onClick={handleApplyUpdate}
-              disabled={applying}
-              className="border-blue-500/50 text-blue-600 hover:bg-blue-500/20"
+              size="icon-xs"
+              variant="ghost"
+              onClick={onDismiss}
+              className="text-muted-foreground hover:text-foreground"
+              aria-label="Dismiss"
             >
-              Update Now
+              <X className="h-3 w-3" />
             </Button>
-            {onDismiss && (
-              <Button
-                size="icon-xs"
-                variant="ghost"
-                onClick={onDismiss}
-                className="text-muted-foreground hover:text-foreground"
-                aria-label="Dismiss"
-              >
-                <X className="h-3 w-3" />
-              </Button>
-            )}
-          </>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/update-banner.tsx
+++ b/web/src/components/update-banner.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import { Download, RefreshCw, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Spinner } from "@/components/ui/spinner";
+import type { UpdateStatus, RebuildScope } from "@/lib/types";
+import { applyUpdate } from "@/lib/api";
+
+const scopeLabels: Record<RebuildScope, string> = {
+  frontend: "Frontend",
+  server: "Server",
+  container: "Container",
+};
+
+const scopeDescriptions: Record<RebuildScope, string> = {
+  frontend: "Only frontend assets will be rebuilt",
+  server: "Server will restart after rebuild",
+  container: "Container image will be rebuilt (may take a few minutes)",
+};
+
+interface UpdateBannerProps {
+  status: UpdateStatus;
+  onDismiss?: () => void;
+  onUpdateComplete?: () => void;
+}
+
+export function UpdateBanner({
+  status,
+  onDismiss,
+  onUpdateComplete,
+}: UpdateBannerProps) {
+  const [applying, setApplying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Don't show if no update available and not applying
+  if (!status.available && !status.applying && !applying) {
+    return null;
+  }
+
+  const isApplying = applying || status.applying;
+
+  async function handleApplyUpdate() {
+    setApplying(true);
+    setError(null);
+    try {
+      await applyUpdate();
+      onUpdateComplete?.();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to apply update");
+      setApplying(false);
+    }
+  }
+
+  const shortCommit = status.target_commit?.slice(0, 7);
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 border-b px-4 py-2 text-sm",
+        isApplying
+          ? "border-yellow-500/30 bg-yellow-500/10"
+          : "border-blue-500/30 bg-blue-500/10"
+      )}
+    >
+      {/* Icon */}
+      <div className="shrink-0">
+        {isApplying ? (
+          <RefreshCw className="h-4 w-4 text-yellow-500 animate-spin" />
+        ) : (
+          <Download className="h-4 w-4 text-blue-500" />
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex flex-1 items-center gap-3 min-w-0">
+        <span className={cn(isApplying ? "text-yellow-600" : "text-blue-600")}>
+          {isApplying ? "Applying update..." : "Update available"}
+        </span>
+
+        {shortCommit && (
+          <code className="rounded bg-background/50 px-1.5 py-0.5 text-xs text-muted-foreground">
+            {shortCommit}
+          </code>
+        )}
+
+        {status.rebuild_scope && (
+          <Badge
+            variant="outline"
+            className="text-xs"
+            title={scopeDescriptions[status.rebuild_scope]}
+          >
+            {scopeLabels[status.rebuild_scope]}
+          </Badge>
+        )}
+
+        {status.commit_summary && (
+          <span className="truncate text-muted-foreground" title={status.commit_summary}>
+            {status.commit_summary}
+          </span>
+        )}
+
+        {error && <span className="text-xs text-red-400">{error}</span>}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 shrink-0">
+        {isApplying ? (
+          <div className="flex items-center gap-2 text-xs text-yellow-600">
+            <Spinner className="h-3 w-3" />
+            <span>Updating...</span>
+          </div>
+        ) : (
+          <>
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={handleApplyUpdate}
+              disabled={applying}
+              className="border-blue-500/50 text-blue-600 hover:bg-blue-500/20"
+            >
+              Update Now
+            </Button>
+            {onDismiss && (
+              <Button
+                size="icon-xs"
+                variant="ghost"
+                onClick={onDismiss}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Dismiss"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/use-app-state.ts
+++ b/web/src/hooks/use-app-state.ts
@@ -19,7 +19,7 @@ const POLL_INTERVAL_MS = 5_000;
 const STATE_CHANGING_EVENT = /^(task:|merge:|system:mode)/;
 
 /** Regex matching event types that should trigger an update status refresh. */
-const UPDATE_EVENT = /^system:update_/;
+const UPDATE_EVENT = /^system:update:/;
 
 export interface AppState {
   snapshot: Snapshot | null;
@@ -85,6 +85,7 @@ function useAppStateCore(): AppState {
   // Keep a ref to the latest snapshot-fetch promise so we can avoid races.
   const fetchInFlight = useRef(false);
   const updateFetchInFlight = useRef(false);
+  const prevTargetCommit = useRef<string | undefined>(undefined);
 
   const refreshSnapshot = useCallback(async () => {
     if (fetchInFlight.current) return;
@@ -107,15 +108,16 @@ function useAppStateCore(): AppState {
       const status = await fetchUpdateStatus();
       setUpdateStatus(status);
       // Reset dismissed state when a new update becomes available
-      if (status.available && status.target_commit !== updateStatus?.target_commit) {
+      if (status.available && status.target_commit !== prevTargetCommit.current) {
         setUpdateDismissed(false);
       }
+      prevTargetCommit.current = status.target_commit;
     } catch {
       // Update status endpoint may not exist yet; ignore errors silently
     } finally {
       updateFetchInFlight.current = false;
     }
-  }, [updateStatus?.target_commit]);
+  }, []);
 
   const dismissUpdate = useCallback(() => {
     setUpdateDismissed(true);

--- a/web/src/hooks/use-app-state.ts
+++ b/web/src/hooks/use-app-state.ts
@@ -9,14 +9,17 @@ import {
 } from "react";
 import type { ReactNode } from "react";
 import { createElement } from "react";
-import type { Event, Snapshot, Task, MergeQueueEntry } from "@/lib/types";
-import { fetchSnapshot, subscribeEvents } from "@/lib/api";
+import type { Event, Snapshot, Task, MergeQueueEntry, UpdateStatus } from "@/lib/types";
+import { fetchSnapshot, fetchUpdateStatus, subscribeEvents } from "@/lib/api";
 
 const MAX_EVENTS = 200;
 const POLL_INTERVAL_MS = 5_000;
 
 /** Regex matching event types that should trigger a snapshot refresh. */
 const STATE_CHANGING_EVENT = /^(task:|merge:|system:mode)/;
+
+/** Regex matching event types that should trigger an update status refresh. */
+const UPDATE_EVENT = /^system:update_/;
 
 export interface AppState {
   snapshot: Snapshot | null;
@@ -33,6 +36,14 @@ export interface AppState {
   filteredTasks: Task[];
   /** Merge queue entries filtered by selected project */
   filteredMergeQueue: MergeQueueEntry[];
+  /** Update status for self-update mechanism */
+  updateStatus: UpdateStatus | null;
+  /** Whether the update banner has been dismissed */
+  updateDismissed: boolean;
+  /** Dismiss the update banner (reappears on next check) */
+  dismissUpdate: () => void;
+  /** Refresh update status */
+  refreshUpdateStatus: () => Promise<void>;
 }
 
 const defaultState: AppState = {
@@ -46,6 +57,10 @@ const defaultState: AppState = {
   setSelectedProject: () => {},
   filteredTasks: [],
   filteredMergeQueue: [],
+  updateStatus: null,
+  updateDismissed: false,
+  dismissUpdate: () => {},
+  refreshUpdateStatus: async () => {},
 };
 
 export const AppStateContext = createContext<AppState | null>(null);
@@ -61,12 +76,15 @@ function useAppStateCore(): AppState {
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
+  const [updateDismissed, setUpdateDismissed] = useState(false);
 
   // Track seen orchestrator event IDs for deduplication
   const seenOrchestratorIds = useRef(new Set<string>());
 
   // Keep a ref to the latest snapshot-fetch promise so we can avoid races.
   const fetchInFlight = useRef(false);
+  const updateFetchInFlight = useRef(false);
 
   const refreshSnapshot = useCallback(async () => {
     if (fetchInFlight.current) return;
@@ -80,6 +98,27 @@ function useAppStateCore(): AppState {
     } finally {
       fetchInFlight.current = false;
     }
+  }, []);
+
+  const refreshUpdateStatus = useCallback(async () => {
+    if (updateFetchInFlight.current) return;
+    updateFetchInFlight.current = true;
+    try {
+      const status = await fetchUpdateStatus();
+      setUpdateStatus(status);
+      // Reset dismissed state when a new update becomes available
+      if (status.available && status.target_commit !== updateStatus?.target_commit) {
+        setUpdateDismissed(false);
+      }
+    } catch {
+      // Update status endpoint may not exist yet; ignore errors silently
+    } finally {
+      updateFetchInFlight.current = false;
+    }
+  }, [updateStatus?.target_commit]);
+
+  const dismissUpdate = useCallback(() => {
+    setUpdateDismissed(true);
   }, []);
 
   // Compute filtered tasks based on selected project
@@ -105,13 +144,22 @@ function useAppStateCore(): AppState {
   useEffect(() => {
     // Fetch immediately on mount.
     refreshSnapshot();
+    refreshUpdateStatus();
 
     const interval = setInterval(() => {
       refreshSnapshot();
     }, POLL_INTERVAL_MS);
 
-    return () => clearInterval(interval);
-  }, [refreshSnapshot]);
+    // Update status is checked less frequently (every 60 seconds)
+    const updateInterval = setInterval(() => {
+      refreshUpdateStatus();
+    }, 60_000);
+
+    return () => {
+      clearInterval(interval);
+      clearInterval(updateInterval);
+    };
+  }, [refreshSnapshot, refreshUpdateStatus]);
 
   // --- SSE subscription with reconnection --------------------------------
   useEffect(() => {
@@ -156,6 +204,11 @@ function useAppStateCore(): AppState {
           if (STATE_CHANGING_EVENT.test(event.type)) {
             refreshSnapshot();
           }
+
+          // Handle update events
+          if (UPDATE_EVENT.test(event.type)) {
+            refreshUpdateStatus();
+          }
         } catch {
           // Ignore unparseable messages.
         }
@@ -182,7 +235,7 @@ function useAppStateCore(): AppState {
       source?.close();
       setConnected(false);
     };
-  }, [refreshSnapshot]);
+  }, [refreshSnapshot, refreshUpdateStatus]);
 
   return {
     snapshot,
@@ -195,6 +248,10 @@ function useAppStateCore(): AppState {
     setSelectedProject,
     filteredTasks,
     filteredMergeQueue,
+    updateStatus,
+    updateDismissed,
+    dismissUpdate,
+    refreshUpdateStatus,
   };
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -207,11 +207,11 @@ export function summarize(
 // Update API (self-update mechanism)
 
 export function fetchUpdateStatus(): Promise<UpdateStatus> {
-  return request<UpdateStatus>("/api/update/status");
+  return request<UpdateStatus>("/api/self-update");
 }
 
 export function applyUpdate(force?: boolean): Promise<void> {
-  return requestVoid("/api/update/apply", {
+  return requestVoid("/api/self-update/apply", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ force: force ?? false }),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   Project,
   Snapshot,
   Task,
+  UpdateStatus,
 } from "./types";
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -200,5 +201,19 @@ export function summarize(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ text, max_words: maxWords }),
+  });
+}
+
+// Update API (self-update mechanism)
+
+export function fetchUpdateStatus(): Promise<UpdateStatus> {
+  return request<UpdateStatus>("/api/update/status");
+}
+
+export function applyUpdate(force?: boolean): Promise<void> {
+  return requestVoid("/api/update/apply", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ force: force ?? false }),
   });
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -100,3 +100,17 @@ export interface Snapshot {
   slot_utilization: SlotUtilization;
   human_present: boolean;
 }
+
+/** Rebuild scope for self-update mechanism */
+export type RebuildScope = "frontend" | "server" | "container";
+
+/** Update status for self-update mechanism */
+export interface UpdateStatus {
+  available: boolean;
+  current_commit: string;
+  target_commit?: string;
+  rebuild_scope?: RebuildScope;
+  commit_summary?: string;
+  last_checked?: string;
+  applying?: boolean;
+}


### PR DESCRIPTION
## Summary
- Adds UpdateBanner component for displaying update availability and progress
- Extends AppState hook with update status polling (60s interval) and SSE event handling
- Adds API client functions for fetching update status and applying updates
- Banner appears at top of main content area when an update is available

## Implementation Details

### New Types (`web/src/lib/types.ts`)
- `RebuildScope`: "frontend" | "server" | "container"
- `UpdateStatus`: Interface with available, current_commit, target_commit, rebuild_scope, commit_summary, last_checked, applying fields

### API Functions (`web/src/lib/api.ts`)
- `fetchUpdateStatus()`: GET /api/update/status
- `applyUpdate(force?)`: POST /api/update/apply

### UpdateBanner Component (`web/src/components/update-banner.tsx`)
- Dismissible banner with blue styling (available) or yellow (applying)
- Shows target commit (short hash), rebuild scope badge, and commit summary
- "Update Now" button triggers `applyUpdate()` API call
- "Dismiss" button hides banner temporarily (reappears on next check or new commit)

### State Management (`web/src/hooks/use-app-state.ts`)
- Added `updateStatus`, `updateDismissed`, `dismissUpdate()`, `refreshUpdateStatus()` to AppState
- Polls update status every 60 seconds (vs 5s for snapshot)
- Listens for `system:update_*` SSE events to trigger immediate refresh
- Resets dismissed state when a new target_commit is detected

## Dependencies
This is Phase 3 of the self-update mechanism. The backend (Phases 1 & 2) must implement:
- `GET /api/update/status` endpoint
- `POST /api/update/apply` endpoint
- `system:update_available` and `system:update_applying` SSE events

## Test plan
- [ ] Banner appears when API returns `available: true`
- [ ] Commit hash and scope badge display correctly
- [ ] "Update Now" triggers POST /api/update/apply
- [ ] "Dismiss" hides banner, reappears on new target_commit
- [ ] Banner shows yellow "Applying" state during update
- [ ] SSE events trigger real-time updates

Part of #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)