### PR TITLE
Add self-update Phase 4: robustness and deployment

### DIFF
--- a/docs/app/configuration.md
+++ b/docs/app/configuration.md
@@ -80,7 +80,7 @@ Tasks is configured through environment variables and a `.env` file.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `TASKS_MAX_RETRIES` | Max network retry attempts | `10` |
+| `TASKS_NET_MAX_RETRIES` | Max network retry attempts | `10` |
 | `TASKS_RETRY_DELAY` | Initial retry delay (seconds) | `5` |
 | `TASKS_MAX_RETRY_DELAY` | Maximum retry delay (seconds) | `300` |
 | `TASKS_HEALTH_TIMEOUT` | Health check timeout (seconds) | `30` |

--- a/docs/app/configuration.md
+++ b/docs/app/configuration.md
@@ -67,6 +67,25 @@ Tasks is configured through environment variables and a `.env` file.
 |----------|-------------|---------|
 | `RUST_LOG` | Log level filter | `info` |
 
+### Self-Update
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TASKS_UPDATE_CHECK_ENABLED` | Enable update checking | `true` |
+| `TASKS_UPDATE_CHECK_INTERVAL` | Check interval (seconds) | `300` |
+| `TASKS_UPDATE_AUTO_APPLY` | Auto-apply updates | `false` |
+| `TASKS_UPDATE_SESSION_TIMEOUT` | Session drain timeout (seconds) | `300` |
+
+### Wrapper Script
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TASKS_MAX_RETRIES` | Max network retry attempts | `10` |
+| `TASKS_RETRY_DELAY` | Initial retry delay (seconds) | `5` |
+| `TASKS_MAX_RETRY_DELAY` | Maximum retry delay (seconds) | `300` |
+| `TASKS_HEALTH_TIMEOUT` | Health check timeout (seconds) | `30` |
+| `TASKS_LOG_MAX_SIZE` | Log rotation size (bytes) | `10485760` |
+
 ## .env File
 
 Create a `.env` file at the project root:

--- a/docs/app/deployment.md
+++ b/docs/app/deployment.md
@@ -234,7 +234,7 @@ The `scripts/tasks-runner.sh` wrapper provides production-ready features:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `TASKS_DATA_DIR` | Data directory | `~/.local/state/tasks` |
-| `TASKS_MAX_RETRIES` | Network retry attempts | `10` |
+| `TASKS_NET_MAX_RETRIES` | Network retry attempts | `10` |
 | `TASKS_RETRY_DELAY` | Initial retry delay (seconds) | `5` |
 | `TASKS_MAX_RETRY_DELAY` | Maximum retry delay (seconds) | `300` |
 | `TASKS_HEALTH_TIMEOUT` | Health check timeout (seconds) | `30` |

--- a/docs/app/deployment.md
+++ b/docs/app/deployment.md
@@ -1,0 +1,351 @@
+# Deployment
+
+This guide covers deploying Tasks as a long-running service on Linux (systemd) and macOS (launchd).
+
+## Quick Start
+
+### Development
+
+For development, run the server directly:
+
+```bash
+cargo run -- run --web
+```
+
+### Production
+
+For production, use the wrapper script which handles self-updates:
+
+```bash
+./scripts/tasks-runner.sh --web
+```
+
+## Prerequisites
+
+### Required
+
+- Rust toolchain (1.75+)
+- bun (for frontend)
+- git
+- Cross-compilation toolchain for container builds
+
+### Environment
+
+Create an environment file with your credentials:
+
+```bash
+# ~/.config/tasks/env (macOS) or /etc/tasks/env (Linux)
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ANTHROPIC_API_KEY=sk-ant-api03-xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## Linux (systemd)
+
+### Installation
+
+1. **Clone the repository:**
+
+   ```bash
+   sudo mkdir -p /opt/tasks
+   sudo git clone https://github.com/iamnbutler/tasks.git /opt/tasks
+   cd /opt/tasks
+   ```
+
+2. **Build the application:**
+
+   ```bash
+   cargo build --release --package tasks-app
+   cd web && bun install && bun run build && cd ..
+   make container-image
+   ```
+
+3. **Create the tasks user:**
+
+   ```bash
+   sudo useradd -r -s /bin/false tasks
+   ```
+
+4. **Create data directory:**
+
+   ```bash
+   sudo mkdir -p /var/lib/tasks
+   sudo chown tasks:tasks /var/lib/tasks
+   ```
+
+5. **Create environment file:**
+
+   ```bash
+   sudo mkdir -p /etc/tasks
+   sudo cat > /etc/tasks/env << 'EOF'
+   GITHUB_TOKEN=ghp_xxxx
+   ANTHROPIC_API_KEY=sk-ant-xxxx
+   EOF
+   sudo chmod 600 /etc/tasks/env
+   sudo chown tasks:tasks /etc/tasks/env
+   ```
+
+6. **Install the service file:**
+
+   ```bash
+   sudo cp scripts/tasks.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   ```
+
+7. **Enable and start:**
+
+   ```bash
+   sudo systemctl enable tasks
+   sudo systemctl start tasks
+   ```
+
+### Management
+
+```bash
+# Check status
+sudo systemctl status tasks
+
+# View logs
+journalctl -u tasks -f
+
+# Restart
+sudo systemctl restart tasks
+
+# Stop
+sudo systemctl stop tasks
+
+# Disable
+sudo systemctl disable tasks
+```
+
+### Updating
+
+The self-update mechanism handles updates automatically. To manually update:
+
+```bash
+cd /opt/tasks
+sudo -u tasks git pull
+sudo -u tasks cargo build --release --package tasks-app
+sudo systemctl restart tasks
+```
+
+## macOS (launchd)
+
+### User Agent Installation (Recommended)
+
+Runs as your user, starts at login:
+
+1. **Clone the repository:**
+
+   ```bash
+   mkdir -p ~/Developer
+   git clone https://github.com/iamnbutler/tasks.git ~/Developer/tasks
+   cd ~/Developer/tasks
+   ```
+
+2. **Build the application:**
+
+   ```bash
+   cargo build --release --package tasks-app
+   cd web && bun install && bun run build && cd ..
+   make container-image
+   ```
+
+3. **Create environment file:**
+
+   ```bash
+   mkdir -p ~/.config/tasks
+   cat > ~/.config/tasks/env << 'EOF'
+   export GITHUB_TOKEN=ghp_xxxx
+   export ANTHROPIC_API_KEY=sk-ant-xxxx
+   EOF
+   chmod 600 ~/.config/tasks/env
+   ```
+
+4. **Create data directory:**
+
+   ```bash
+   mkdir -p ~/.local/state/tasks
+   ```
+
+5. **Install the plist:**
+
+   ```bash
+   # Edit the plist to match your paths if needed
+   cp scripts/com.tasks.plist ~/Library/LaunchAgents/
+   ```
+
+6. **Load and start:**
+
+   ```bash
+   launchctl load ~/Library/LaunchAgents/com.tasks.plist
+   launchctl start com.tasks
+   ```
+
+### Management
+
+```bash
+# Check status
+launchctl list | grep tasks
+
+# View logs
+tail -f ~/.local/state/tasks/runner.log
+
+# Stop
+launchctl stop com.tasks
+
+# Unload (disable)
+launchctl unload ~/Library/LaunchAgents/com.tasks.plist
+
+# Reload after plist changes
+launchctl unload ~/Library/LaunchAgents/com.tasks.plist
+launchctl load ~/Library/LaunchAgents/com.tasks.plist
+```
+
+### Updating
+
+Updates happen automatically via the self-update mechanism. To manually update:
+
+```bash
+cd ~/Developer/tasks
+git pull
+cargo build --release --package tasks-app
+launchctl stop com.tasks
+launchctl start com.tasks
+```
+
+## Wrapper Script
+
+The `scripts/tasks-runner.sh` wrapper provides production-ready features:
+
+### Features
+
+| Feature | Description |
+|---------|-------------|
+| Self-update | Automatically pulls and rebuilds on update signal |
+| Build fallback | Restores backup binary if build fails |
+| Network retry | Exponential backoff on network failures |
+| Signal handling | Graceful shutdown on SIGTERM/SIGINT |
+| PID management | Prevents duplicate instances |
+| Log rotation | Rotates logs at 10MB |
+| Health checks | Verifies server started successfully |
+
+### Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TASKS_DATA_DIR` | Data directory | `~/.local/state/tasks` |
+| `TASKS_MAX_RETRIES` | Network retry attempts | `10` |
+| `TASKS_RETRY_DELAY` | Initial retry delay (seconds) | `5` |
+| `TASKS_MAX_RETRY_DELAY` | Maximum retry delay (seconds) | `300` |
+| `TASKS_HEALTH_TIMEOUT` | Health check timeout (seconds) | `30` |
+| `TASKS_LOG_MAX_SIZE` | Log rotation size (bytes) | `10485760` |
+
+### Logs
+
+The wrapper logs to `$DATA_DIR/runner.log`:
+
+```bash
+tail -f ~/.local/state/tasks/runner.log
+```
+
+### Manual Usage
+
+```bash
+# Run with web UI
+./scripts/tasks-runner.sh --web
+
+# Run headless
+./scripts/tasks-runner.sh
+
+# Pass additional arguments
+./scripts/tasks-runner.sh --web --port 8080
+```
+
+## Self-Update
+
+Tasks includes a self-update mechanism that:
+
+1. Polls `origin/main` for new commits (every 5 minutes)
+2. Shows an update banner in the web UI
+3. On "Update Now", drains active sessions gracefully
+4. Exits with code 100 to signal the wrapper
+5. Wrapper pulls, rebuilds, and restarts
+
+### Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TASKS_UPDATE_CHECK_ENABLED` | Enable update checking | `true` |
+| `TASKS_UPDATE_CHECK_INTERVAL` | Poll interval (seconds) | `300` |
+| `TASKS_UPDATE_AUTO_APPLY` | Auto-apply updates | `false` |
+| `TASKS_UPDATE_SESSION_TIMEOUT` | Drain timeout (seconds) | `300` |
+
+### Rebuild Scopes
+
+The update system intelligently rebuilds only what changed:
+
+| Scope | Triggers | Rebuilds |
+|-------|----------|----------|
+| `frontend` | `web/**` changes | bun install + build |
+| `server` | `crates/**` changes | cargo build |
+| `container` | Supervisor/Containerfile | make container-image |
+
+## Troubleshooting
+
+### Server won't start
+
+1. Check logs: `journalctl -u tasks -f` or `tail -f ~/.local/state/tasks/runner.log`
+2. Verify environment file exists and is readable
+3. Check port 4800 is not in use: `lsof -i :4800`
+4. Verify data directory permissions
+
+### Build failures during update
+
+The wrapper automatically falls back to the previous binary. Check:
+
+1. Rust toolchain is installed and accessible
+2. bun is installed (for frontend)
+3. Cross-compilation toolchain (for container image)
+
+### Update stuck
+
+1. Check `.update-state` file: `cat ~/.local/state/tasks/.update-state`
+2. Remove state files to reset: `rm ~/.local/state/tasks/.update-*`
+3. Restart the service
+
+### High memory usage
+
+1. Check memory limits in service file
+2. Reduce `TASKS_MAX_SESSIONS`
+3. Check container memory with `container list`
+
+## Security Considerations
+
+### Token Security
+
+- Store tokens in environment files with restricted permissions (600)
+- Never commit tokens to git
+- Use separate tokens for dev/prod
+
+### Network Access
+
+Agent containers have network access for:
+- GitHub API
+- Package managers (npm, cargo, pip)
+- Anthropic API
+
+Consider network policies for sensitive environments.
+
+### Service Hardening
+
+The systemd service includes security options:
+- `NoNewPrivileges=true`
+- `ProtectSystem=strict`
+- `PrivateTmp=true`
+
+Review and adjust based on your security requirements.
+
+---
+
+*See [Configuration](configuration.md) for all environment variables.*
+*See [Self-Update Design](../design/self-update.md) for implementation details.*

--- a/docs/app/getting-started.md
+++ b/docs/app/getting-started.md
@@ -91,9 +91,25 @@ cargo run -- add-project owner/repo
 
 This adds a GitHub repository for Tasks to monitor.
 
+## Production Deployment
+
+For production use, run Tasks with the wrapper script which provides:
+
+- Automatic self-updates when new commits are pushed to `origin/main`
+- Build failure recovery with binary backup
+- Signal handling and graceful shutdown
+- Log rotation
+
+```bash
+./scripts/tasks-runner.sh --web
+```
+
+For systemd (Linux) or launchd (macOS) service setup, see the [Deployment Guide](deployment.md).
+
 ## Next Steps
 
 - [Architecture Overview](architecture.md) - Understand the system design
+- [Deployment](deployment.md) - Production setup with systemd/launchd
 - [CLI Reference](cli-reference.md) - All available commands
 - [API Reference](api-reference.md) - REST API documentation
 - [Web UI Guide](web-ui.md) - Using the web interface

--- a/docs/app/index.md
+++ b/docs/app/index.md
@@ -6,6 +6,7 @@ Tasks is a human-in-the-loop platform that orchestrates AI coding agents to get 
 
 - [Getting Started](getting-started.md) - Installation and first run
 - [Architecture](architecture.md) - System design and components
+- [Deployment](deployment.md) - Production setup with systemd/launchd
 - [CLI Reference](cli-reference.md) - Command-line interface
 - [API Reference](api-reference.md) - REST API endpoints
 - [Web UI Guide](web-ui.md) - Using the web interface

--- a/docs/design/self-update.md
+++ b/docs/design/self-update.md
@@ -1,0 +1,254 @@
+# Self-Update Mechanism
+
+Tasks includes a self-update mechanism that allows the server to detect new commits on `origin/main`, notify users, and seamlessly restart with the updated code.
+
+## Overview
+
+The self-update system consists of four components:
+
+1. **UpdateChecker** - Background task that polls for new commits
+2. **API Endpoints** - HTTP endpoints for checking/triggering updates
+3. **Frontend UI** - Update banner with one-click apply
+4. **Wrapper Script** - Shell script that handles rebuild and restart
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    tasks-runner.sh (wrapper)                      │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │                    Tasks Server                             │  │
+│  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────────┐  │  │
+│  │  │ UpdateChecker │  │ API Endpoints │  │ Event Bus        │  │  │
+│  │  │ (poll origin) │  │ /self-update  │  │ system:update_*  │  │  │
+│  │  └──────┬───────┘  └──────────────┘  └──────────────────┘  │  │
+│  │         │                                                    │  │
+│  │         ▼                                                    │  │
+│  │  Detect new commit → Emit event → Show banner → Apply       │  │
+│  │                                                              │  │
+│  │  Exit code 100 → wrapper pulls, rebuilds, restarts          │  │
+│  └────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Update Flow
+
+### Detection
+
+1. `UpdateChecker` runs in background (every 5 minutes by default)
+2. Executes `git fetch origin main`
+3. Compares `HEAD` with `origin/main`
+4. If different, analyzes changed files to determine rebuild scope
+5. Emits `system:update_available` event with scope information
+
+### Triggering Update
+
+1. User sees update banner in web UI
+2. User clicks "Update Now"
+3. `POST /api/self-update/apply` is called
+4. Server emits `system:update_applying` event
+5. Server drains active sessions (waits for completion or timeout)
+6. Server writes rebuild scope to `.update-scope` file
+7. Server exits with code 100
+
+### Rebuild and Restart
+
+1. Wrapper script (`tasks-runner.sh`) catches exit code 100
+2. Runs `git pull origin main`
+3. Reads `.update-scope` to determine what to rebuild
+4. Rebuilds necessary components
+5. Restarts the server
+
+## Rebuild Scopes
+
+The update system intelligently determines what needs rebuilding:
+
+| Scope | Description | Rebuild Steps |
+|-------|-------------|---------------|
+| `none` | No rebuild needed | Just restart |
+| `frontend` | Only web UI changed | `bun install && bun run build` |
+| `server` | Rust crates changed | `cargo build --release` |
+| `container` | Supervisor/Dockerfile changed | `make container-image` |
+| `server_and_frontend` | Both server and UI | Both rebuilds |
+| `server_and_container` | Server and container | Both rebuilds |
+| `all` | Major changes | Full rebuild |
+
+### Scope Detection
+
+Files are mapped to scopes by pattern:
+
+```
+web/**           → frontend
+crates/**        → server
+Cargo.toml       → server
+Cargo.lock       → server
+crates/supervisor/** → container
+Containerfile    → container
+```
+
+## Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TASKS_UPDATE_CHECK_ENABLED` | Enable update checking | `true` |
+| `TASKS_UPDATE_CHECK_INTERVAL` | Check interval (seconds) | `300` |
+| `TASKS_UPDATE_AUTO_APPLY` | Auto-apply updates | `false` |
+| `TASKS_UPDATE_SESSION_TIMEOUT` | Session drain timeout (seconds) | `300` |
+
+## API Endpoints
+
+### GET /api/self-update
+
+Returns current update status.
+
+**Response:**
+```json
+{
+  "update_available": true,
+  "current_commit": "abc1234",
+  "latest_commit": "def5678",
+  "rebuild_scope": "server",
+  "changed_files": ["crates/server/src/lib.rs"],
+  "checked_at": "2024-01-15T10:30:00Z"
+}
+```
+
+### POST /api/self-update/apply
+
+Triggers an update. Returns immediately; actual update happens asynchronously.
+
+**Response:**
+```json
+{
+  "status": "applying",
+  "message": "Update initiated, server will restart shortly"
+}
+```
+
+## Events
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `system:update_available` | `{commit, scope, files}` | New version detected |
+| `system:update_applying` | `{commit, scope}` | Update in progress |
+
+## Wrapper Script
+
+The `scripts/tasks-runner.sh` wrapper provides:
+
+### Core Features
+- Runs server in a loop
+- Catches exit code 100 for updates
+- Pulls changes and rebuilds based on scope
+- Restarts server after update
+
+### Robustness Features (Phase 4)
+
+#### Build Failure Handling
+- Backs up current binary before rebuild
+- Falls back to backup on build failure
+- Logs error and emits event
+
+#### Network Failure Handling
+- Exponential backoff on `git fetch` failures
+- Initial delay: 5 seconds
+- Maximum delay: 5 minutes
+- Tracks consecutive failures
+
+#### Partial Update Recovery
+- Writes state file during multi-step update
+- Can resume from last successful step
+- Cleans up partial state
+
+#### Signal Handling
+- Forwards SIGTERM/SIGINT to server
+- Graceful shutdown on signals
+- PID file management
+
+#### Logging
+- Logs to `$DATA_DIR/runner.log`
+- Log rotation at 10MB
+- Timestamps on all entries
+
+#### Health Checks
+- Polls health endpoint after restart
+- Confirms server is operational
+- Retries with backoff
+
+## Deployment
+
+### systemd (Linux)
+
+```ini
+# /etc/systemd/system/tasks.service
+[Unit]
+Description=Tasks Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/path/to/tasks-runner.sh --web
+Restart=on-failure
+User=tasks
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### launchd (macOS)
+
+```xml
+<!-- ~/Library/LaunchAgents/com.tasks.plist -->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.tasks</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/path/to/tasks-runner.sh</string>
+    <string>--web</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+</dict>
+</plist>
+```
+
+## Security Considerations
+
+### Git Operations
+- Only pulls from configured origin
+- Requires fast-forward merges only
+- No force pushes or rebases
+
+### Build Isolation
+- Builds run in project directory
+- No network access during build (except cargo/npm)
+- Environment controlled by wrapper
+
+### Rollback
+- Backup binary retained for one update cycle
+- Can manually restore from backup
+- Git history available for revert
+
+## Error Handling
+
+| Error | Recovery |
+|-------|----------|
+| Network failure | Exponential backoff, continue current version |
+| Build failure | Restore backup binary, continue |
+| Merge conflict | Exit with error, require manual intervention |
+| Timeout | Force restart, log warning |
+
+## Implementation Phases
+
+1. **Phase 1**: Core infrastructure - UpdateChecker, scope detection, wrapper script
+2. **Phase 2**: API endpoints and events
+3. **Phase 3**: Frontend UI components
+4. **Phase 4**: Robustness, error handling, deployment
+
+---
+
+*See [Deployment Guide](../app/deployment.md) for production setup instructions.*

--- a/scripts/com.tasks.plist
+++ b/scripts/com.tasks.plist
@@ -49,8 +49,6 @@
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
         <key>RUST_LOG</key>
         <string>info</string>
-        <key>HOME</key>
-        <string>~</string>
     </dict>
 
     <!-- Start at login -->

--- a/scripts/com.tasks.plist
+++ b/scripts/com.tasks.plist
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Tasks Server launchd plist for macOS
+
+  Installation (user agent - runs as current user):
+    1. Copy to ~/Library/LaunchAgents/com.tasks.plist
+    2. Edit paths below to match your setup
+    3. Create environment file: ~/.config/tasks/env
+    4. Load: launchctl load ~/Library/LaunchAgents/com.tasks.plist
+    5. Start: launchctl start com.tasks
+
+  Installation (system daemon - runs as dedicated user):
+    1. Copy to /Library/LaunchDaemons/com.tasks.plist
+    2. Edit paths and add UserName key
+    3. Load: sudo launchctl load /Library/LaunchDaemons/com.tasks.plist
+
+  Environment file (~/.config/tasks/env):
+    GITHUB_TOKEN=ghp_xxxx
+    ANTHROPIC_API_KEY=sk-ant-xxxx
+
+  Logs: tail -f ~/.local/state/tasks/runner.log
+  Status: launchctl list | grep tasks
+  Unload: launchctl unload ~/Library/LaunchAgents/com.tasks.plist
+-->
+<plist version="1.0">
+<dict>
+    <!-- Service identifier -->
+    <key>Label</key>
+    <string>com.tasks</string>
+
+    <!-- Program to run -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <!-- Source environment and run wrapper script -->
+        <string>source ~/.config/tasks/env 2>/dev/null || true; cd ~/Developer/tasks &amp;&amp; ./scripts/tasks-runner.sh --web</string>
+    </array>
+
+    <!-- Working directory -->
+    <key>WorkingDirectory</key>
+    <string>~/Developer/tasks</string>
+
+    <!-- Environment variables -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>RUST_LOG</key>
+        <string>info</string>
+        <key>HOME</key>
+        <string>~</string>
+    </dict>
+
+    <!-- Start at login -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Keep running (restart on exit) -->
+    <key>KeepAlive</key>
+    <dict>
+        <!-- Only restart on crash, not clean exit -->
+        <key>SuccessfulExit</key>
+        <false/>
+        <!-- Don't restart if network is down -->
+        <key>NetworkState</key>
+        <true/>
+    </dict>
+
+    <!-- Throttle restarts: wait 10 seconds between attempts -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- Logging -->
+    <key>StandardOutPath</key>
+    <string>~/.local/state/tasks/launchd-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>~/.local/state/tasks/launchd-stderr.log</string>
+
+    <!-- Resource limits -->
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>65536</integer>
+    </dict>
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>65536</integer>
+    </dict>
+
+    <!-- Process settings -->
+    <key>ProcessType</key>
+    <string>Interactive</string>
+
+    <!-- Nice level (lower = higher priority) -->
+    <key>Nice</key>
+    <integer>0</integer>
+
+    <!-- Exit timeout: allow 60 seconds for graceful shutdown -->
+    <key>ExitTimeOut</key>
+    <integer>60</integer>
+</dict>
+</plist>

--- a/scripts/tasks-runner.sh
+++ b/scripts/tasks-runner.sh
@@ -23,7 +23,7 @@
 #
 # Environment:
 #   TASKS_DATA_DIR        — Data directory (default: ~/.local/state/tasks)
-#   TASKS_MAX_RETRIES     — Max network retry attempts (default: 10)
+#   TASKS_NET_MAX_RETRIES — Max network retry attempts (default: 10)
 #   TASKS_RETRY_DELAY     — Initial retry delay in seconds (default: 5)
 #   TASKS_MAX_RETRY_DELAY — Maximum retry delay in seconds (default: 300)
 #   TASKS_HEALTH_TIMEOUT  — Health check timeout in seconds (default: 30)
@@ -56,7 +56,7 @@ STATE_FILE="$DATA_DIR/.update-state"
 BACKUP_DIR="$DATA_DIR/backup"
 
 # Retry configuration
-MAX_RETRIES="${TASKS_MAX_RETRIES:-10}"
+MAX_RETRIES="${TASKS_NET_MAX_RETRIES:-10}"
 RETRY_DELAY="${TASKS_RETRY_DELAY:-5}"
 MAX_RETRY_DELAY="${TASKS_MAX_RETRY_DELAY:-300}"
 HEALTH_TIMEOUT="${TASKS_HEALTH_TIMEOUT:-30}"
@@ -410,15 +410,20 @@ resume_update() {
             return 1
             ;;
         fetching|merging)
-            log_info "Resuming update from state: $state"
-            # Start over from fetch
+            log_info "Resuming update from state: $state (restarting fetch)"
+            if pull_updates; then
+                local scope
+                scope=$(read_scope)
+                rebuild "$scope" && cleanup_state
+            fi
             return 0
             ;;
         building:*)
             local scope="${state#building:}"
             log_info "Resuming build from state: $scope"
-            # Continue from where we left off
-            rebuild "$scope"
+            if rebuild "$scope"; then
+                cleanup_state
+            fi
             return $?
             ;;
         *)
@@ -483,8 +488,15 @@ main() {
 
         # Run the server in background so we can track PID
         set +e
-        cargo run --release --package tasks-app -- run "$@" &
+        if [[ -x ./target/release/tasks-app ]]; then
+            ./target/release/tasks-app run "$@" &
+        else
+            cargo run --release --package tasks-app -- run "$@" &
+        fi
         SERVER_PID=$!
+
+        # Run health check in background (non-blocking, just logging)
+        health_check &
 
         # Wait for server to exit
         wait $SERVER_PID
@@ -505,9 +517,6 @@ main() {
 
                 # Small delay before restart
                 sleep 2
-
-                # Health check after restart (non-blocking, just logging)
-                # The health check will run once server starts in next iteration
             else
                 cleanup_state
                 log_error "Update failed, restarting server with current version..."

--- a/scripts/tasks-runner.sh
+++ b/scripts/tasks-runner.sh
@@ -1,0 +1,531 @@
+#!/usr/bin/env bash
+#
+# tasks-runner.sh — Wrapper script for running the Tasks server with self-update support.
+#
+# This script runs the server in a loop. When the server exits with code 100,
+# it indicates an update is available. The script then:
+# 1. Pulls the latest changes from origin/main
+# 2. Reads the rebuild scope from .update-scope
+# 3. Rebuilds the necessary components
+# 4. Restarts the server
+#
+# Phase 4 robustness features:
+# - Build failure handling with binary backup and fallback
+# - Network failure handling with exponential backoff
+# - Partial update recovery via state files
+# - Signal handling (SIGTERM, SIGINT)
+# - PID file management
+# - Logging to file with rotation
+# - Health check after restart
+#
+# Usage:
+#   ./scripts/tasks-runner.sh [--web] [args...]
+#
+# Environment:
+#   TASKS_DATA_DIR        — Data directory (default: ~/.local/state/tasks)
+#   TASKS_MAX_RETRIES     — Max network retry attempts (default: 10)
+#   TASKS_RETRY_DELAY     — Initial retry delay in seconds (default: 5)
+#   TASKS_MAX_RETRY_DELAY — Maximum retry delay in seconds (default: 300)
+#   TASKS_HEALTH_TIMEOUT  — Health check timeout in seconds (default: 30)
+#   TASKS_LOG_MAX_SIZE    — Max log file size in bytes (default: 10485760 = 10MB)
+#
+
+set -euo pipefail
+
+# Colors for output (only when stdout is a terminal)
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+fi
+
+# Configuration
+DATA_DIR="${TASKS_DATA_DIR:-$HOME/.local/state/tasks}"
+LOG_FILE="$DATA_DIR/runner.log"
+PID_FILE="$DATA_DIR/tasks.pid"
+SCOPE_FILE="$DATA_DIR/.update-scope"
+STATE_FILE="$DATA_DIR/.update-state"
+BACKUP_DIR="$DATA_DIR/backup"
+
+# Retry configuration
+MAX_RETRIES="${TASKS_MAX_RETRIES:-10}"
+RETRY_DELAY="${TASKS_RETRY_DELAY:-5}"
+MAX_RETRY_DELAY="${TASKS_MAX_RETRY_DELAY:-300}"
+HEALTH_TIMEOUT="${TASKS_HEALTH_TIMEOUT:-30}"
+LOG_MAX_SIZE="${TASKS_LOG_MAX_SIZE:-10485760}"
+
+# Exit code indicating update needed
+UPDATE_EXIT_CODE=100
+
+# Track server PID
+SERVER_PID=""
+
+# Track consecutive network failures
+NETWORK_FAILURES=0
+
+# Logging functions
+timestamp() {
+    date '+%Y-%m-%d %H:%M:%S'
+}
+
+log() {
+    local level="$1"
+    shift
+    local msg="[$(timestamp)] [$level] $*"
+    echo -e "$msg" >> "$LOG_FILE"
+    case "$level" in
+        INFO)  echo -e "${BLUE}[tasks-runner]${NC} $*" ;;
+        OK)    echo -e "${GREEN}[tasks-runner]${NC} $*" ;;
+        WARN)  echo -e "${YELLOW}[tasks-runner]${NC} $*" ;;
+        ERROR) echo -e "${RED}[tasks-runner]${NC} $*" ;;
+    esac
+}
+
+log_info()  { log INFO "$@"; }
+log_success() { log OK "$@"; }
+log_warn()  { log WARN "$@"; }
+log_error() { log ERROR "$@"; }
+
+# Rotate log file if too large
+rotate_log() {
+    if [[ -f "$LOG_FILE" ]]; then
+        local size
+        size=$(stat -f%z "$LOG_FILE" 2>/dev/null || stat -c%s "$LOG_FILE" 2>/dev/null || echo 0)
+        if [[ $size -gt $LOG_MAX_SIZE ]]; then
+            mv "$LOG_FILE" "$LOG_FILE.1"
+            log_info "Log rotated (was $size bytes)"
+        fi
+    fi
+}
+
+# PID file management
+write_pid() {
+    echo $$ > "$PID_FILE"
+    log_info "PID file written: $$"
+}
+
+check_stale_pid() {
+    if [[ -f "$PID_FILE" ]]; then
+        local old_pid
+        old_pid=$(cat "$PID_FILE")
+        if kill -0 "$old_pid" 2>/dev/null; then
+            log_error "Another instance is running (PID $old_pid)"
+            exit 1
+        else
+            log_warn "Removing stale PID file (PID $old_pid not running)"
+            rm -f "$PID_FILE"
+        fi
+    fi
+}
+
+cleanup_pid() {
+    rm -f "$PID_FILE"
+}
+
+# Signal handling
+setup_signal_handlers() {
+    trap 'handle_signal SIGTERM' SIGTERM
+    trap 'handle_signal SIGINT' SIGINT
+    trap 'cleanup_pid' EXIT
+}
+
+handle_signal() {
+    local signal="$1"
+    log_info "Received $signal"
+
+    if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        log_info "Forwarding $signal to server (PID $SERVER_PID)"
+        kill -"${signal#SIG}" "$SERVER_PID" 2>/dev/null || true
+
+        # Wait for server to exit gracefully
+        local timeout=30
+        while kill -0 "$SERVER_PID" 2>/dev/null && [[ $timeout -gt 0 ]]; do
+            sleep 1
+            ((timeout--))
+        done
+
+        if kill -0 "$SERVER_PID" 2>/dev/null; then
+            log_warn "Server did not exit, sending SIGKILL"
+            kill -9 "$SERVER_PID" 2>/dev/null || true
+        fi
+    fi
+
+    cleanup_pid
+    exit 0
+}
+
+# Update state management
+write_state() {
+    echo "$1" > "$STATE_FILE"
+}
+
+read_state() {
+    if [[ -f "$STATE_FILE" ]]; then
+        cat "$STATE_FILE"
+    else
+        echo "none"
+    fi
+}
+
+cleanup_state() {
+    rm -f "$STATE_FILE" "$SCOPE_FILE"
+}
+
+# Read rebuild scope from file
+read_scope() {
+    if [[ -f "$SCOPE_FILE" ]]; then
+        cat "$SCOPE_FILE"
+    else
+        echo "all"
+    fi
+}
+
+# Network operations with exponential backoff
+git_fetch_with_retry() {
+    local attempt=0
+    local delay=$RETRY_DELAY
+
+    while [[ $attempt -lt $MAX_RETRIES ]]; do
+        if git fetch origin main 2>&1; then
+            NETWORK_FAILURES=0
+            return 0
+        fi
+
+        ((attempt++))
+        ((NETWORK_FAILURES++))
+
+        if [[ $attempt -lt $MAX_RETRIES ]]; then
+            # Only log/emit event on first failure or after recovery
+            if [[ $NETWORK_FAILURES -eq 1 ]]; then
+                log_warn "Network failure, will retry with backoff"
+            fi
+
+            log_warn "git fetch failed (attempt $attempt/$MAX_RETRIES), retrying in ${delay}s..."
+            sleep "$delay"
+
+            # Exponential backoff
+            delay=$((delay * 2))
+            if [[ $delay -gt $MAX_RETRY_DELAY ]]; then
+                delay=$MAX_RETRY_DELAY
+            fi
+        fi
+    done
+
+    log_error "git fetch failed after $MAX_RETRIES attempts"
+    return 1
+}
+
+# Pull latest changes
+pull_updates() {
+    log_info "Pulling latest changes from origin/main..."
+    write_state "fetching"
+
+    if ! git_fetch_with_retry; then
+        log_error "Failed to fetch from origin"
+        return 1
+    fi
+
+    write_state "merging"
+
+    if ! git merge --ff-only origin/main; then
+        log_error "Failed to merge origin/main (non-fast-forward)"
+        log_error "Manual intervention required"
+        return 1
+    fi
+
+    log_success "Successfully pulled updates"
+    return 0
+}
+
+# Binary backup for rollback
+backup_binary() {
+    local binary_path="target/release/tasks-app"
+
+    if [[ -f "$binary_path" ]]; then
+        mkdir -p "$BACKUP_DIR"
+        cp "$binary_path" "$BACKUP_DIR/tasks-app.backup"
+        log_info "Backed up binary to $BACKUP_DIR/tasks-app.backup"
+        return 0
+    fi
+
+    return 1
+}
+
+restore_binary() {
+    local backup_path="$BACKUP_DIR/tasks-app.backup"
+    local binary_path="target/release/tasks-app"
+
+    if [[ -f "$backup_path" ]]; then
+        cp "$backup_path" "$binary_path"
+        log_warn "Restored binary from backup"
+        return 0
+    fi
+
+    log_error "No backup binary available"
+    return 1
+}
+
+# Rebuild based on scope
+rebuild() {
+    local scope="$1"
+    local build_failed=0
+
+    log_info "Rebuilding with scope: $scope"
+    write_state "building:$scope"
+
+    # Backup current binary before rebuild
+    backup_binary || true
+
+    case "$scope" in
+        none)
+            log_info "No rebuild needed"
+            ;;
+        frontend)
+            log_info "Rebuilding frontend..."
+            write_state "building:frontend"
+            if command -v bun &> /dev/null; then
+                if ! (cd web && bun install && bun run build); then
+                    log_error "Frontend build failed"
+                    build_failed=1
+                fi
+            else
+                log_warn "bun not found, skipping frontend rebuild"
+            fi
+            ;;
+        server)
+            log_info "Rebuilding server..."
+            write_state "building:server"
+            if ! cargo build --release --package tasks-app; then
+                log_error "Server build failed"
+                build_failed=1
+            fi
+            ;;
+        container)
+            log_info "Rebuilding container image..."
+            write_state "building:container"
+            if ! make container-image; then
+                log_error "Container image build failed"
+                build_failed=1
+            fi
+            ;;
+        server_and_frontend)
+            log_info "Rebuilding server and frontend..."
+            write_state "building:server"
+            if ! cargo build --release --package tasks-app; then
+                log_error "Server build failed"
+                build_failed=1
+            fi
+            if [[ $build_failed -eq 0 ]]; then
+                write_state "building:frontend"
+                if command -v bun &> /dev/null; then
+                    if ! (cd web && bun install && bun run build); then
+                        log_error "Frontend build failed"
+                        build_failed=1
+                    fi
+                else
+                    log_warn "bun not found, skipping frontend rebuild"
+                fi
+            fi
+            ;;
+        server_and_container)
+            log_info "Rebuilding server and container..."
+            write_state "building:server"
+            if ! cargo build --release --package tasks-app; then
+                log_error "Server build failed"
+                build_failed=1
+            fi
+            if [[ $build_failed -eq 0 ]]; then
+                write_state "building:container"
+                if ! make container-image; then
+                    log_error "Container image build failed"
+                    build_failed=1
+                fi
+            fi
+            ;;
+        all)
+            log_info "Full rebuild..."
+            write_state "building:server"
+            if ! cargo build --release --package tasks-app; then
+                log_error "Server build failed"
+                build_failed=1
+            fi
+            if [[ $build_failed -eq 0 ]]; then
+                write_state "building:frontend"
+                if command -v bun &> /dev/null; then
+                    if ! (cd web && bun install && bun run build); then
+                        log_error "Frontend build failed"
+                        build_failed=1
+                    fi
+                else
+                    log_warn "bun not found, skipping frontend rebuild"
+                fi
+            fi
+            if [[ $build_failed -eq 0 ]]; then
+                write_state "building:container"
+                if ! make container-image; then
+                    log_error "Container image build failed"
+                    build_failed=1
+                fi
+            fi
+            ;;
+        *)
+            log_warn "Unknown scope '$scope', performing server rebuild"
+            write_state "building:server"
+            if ! cargo build --release --package tasks-app; then
+                log_error "Server build failed"
+                build_failed=1
+            fi
+            ;;
+    esac
+
+    if [[ $build_failed -eq 1 ]]; then
+        log_error "Build failed, attempting to restore backup"
+        if restore_binary; then
+            log_warn "Using backup binary, will retry update on next check"
+        else
+            log_error "Cannot restore backup, server may fail to start"
+        fi
+        return 1
+    fi
+
+    log_success "Rebuild complete"
+    return 0
+}
+
+# Resume partial update
+resume_update() {
+    local state
+    state=$(read_state)
+
+    case "$state" in
+        none)
+            return 1
+            ;;
+        fetching|merging)
+            log_info "Resuming update from state: $state"
+            # Start over from fetch
+            return 0
+            ;;
+        building:*)
+            local scope="${state#building:}"
+            log_info "Resuming build from state: $scope"
+            # Continue from where we left off
+            rebuild "$scope"
+            return $?
+            ;;
+        *)
+            log_warn "Unknown state: $state, cleaning up"
+            cleanup_state
+            return 1
+            ;;
+    esac
+}
+
+# Health check after restart
+health_check() {
+    local port="${TASKS_WEB_PORT:-4800}"
+    local url="http://localhost:$port/api/mode"
+    local attempts=0
+    local max_attempts=$((HEALTH_TIMEOUT / 2))
+
+    log_info "Waiting for server to become healthy..."
+
+    while [[ $attempts -lt $max_attempts ]]; do
+        if curl -sf "$url" > /dev/null 2>&1; then
+            log_success "Server is healthy"
+            return 0
+        fi
+        sleep 2
+        ((attempts++))
+    done
+
+    log_warn "Health check timed out after ${HEALTH_TIMEOUT}s"
+    return 1
+}
+
+# Main loop
+main() {
+    log_info "Starting Tasks server runner"
+    log_info "Data directory: $DATA_DIR"
+
+    # Rotate log if needed
+    rotate_log
+
+    # Ensure directories exist
+    mkdir -p "$DATA_DIR"
+    mkdir -p "$BACKUP_DIR"
+
+    # Check for stale PID
+    check_stale_pid
+
+    # Write our PID
+    write_pid
+
+    # Setup signal handlers
+    setup_signal_handlers
+
+    # Check for interrupted update to resume
+    if resume_update; then
+        log_info "Resumed from interrupted update"
+    fi
+
+    while true; do
+        log_info "Starting server..."
+        rotate_log
+
+        # Run the server in background so we can track PID
+        set +e
+        cargo run --release --package tasks-app -- run "$@" &
+        SERVER_PID=$!
+
+        # Wait for server to exit
+        wait $SERVER_PID
+        exit_code=$?
+        SERVER_PID=""
+        set -e
+
+        if [[ $exit_code -eq $UPDATE_EXIT_CODE ]]; then
+            log_info "Server requested update restart (exit code $UPDATE_EXIT_CODE)"
+
+            # Read the scope before cleaning up
+            scope=$(read_scope)
+
+            # Pull and rebuild
+            if pull_updates && rebuild "$scope"; then
+                cleanup_state
+                log_success "Update complete, restarting server..."
+
+                # Small delay before restart
+                sleep 2
+
+                # Health check after restart (non-blocking, just logging)
+                # The health check will run once server starts in next iteration
+            else
+                cleanup_state
+                log_error "Update failed, restarting server with current version..."
+                sleep 2
+            fi
+        else
+            if [[ $exit_code -eq 0 ]]; then
+                log_info "Server exited normally"
+            else
+                log_error "Server exited with code $exit_code"
+            fi
+            break
+        fi
+    done
+
+    log_info "Tasks runner exiting"
+    exit ${exit_code:-0}
+}
+
+# Run main with all arguments
+main "$@"

--- a/scripts/tasks-runner.sh
+++ b/scripts/tasks-runner.sh
@@ -449,7 +449,7 @@ health_check() {
             return 0
         fi
         sleep 2
-        ((attempts++))
+        attempts=$((attempts + 1))
     done
 
     log_warn "Health check timed out after ${HEALTH_TIMEOUT}s"

--- a/scripts/tasks.service
+++ b/scripts/tasks.service
@@ -1,0 +1,83 @@
+# Tasks Server systemd unit file
+#
+# Installation:
+#   1. Copy to /etc/systemd/system/tasks.service
+#   2. Create environment file: /etc/tasks/env
+#   3. Create tasks user: sudo useradd -r -s /bin/false tasks
+#   4. Enable: sudo systemctl enable tasks
+#   5. Start: sudo systemctl start tasks
+#
+# Environment file (/etc/tasks/env):
+#   GITHUB_TOKEN=ghp_xxxx
+#   ANTHROPIC_API_KEY=sk-ant-xxxx
+#   TASKS_DATA_DIR=/var/lib/tasks
+#
+# Logs: journalctl -u tasks -f
+
+[Unit]
+Description=Tasks - Human-in-the-loop coding agent orchestrator
+Documentation=https://github.com/iamnbutler/tasks
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+# User and group (create with: useradd -r -s /bin/false tasks)
+User=tasks
+Group=tasks
+
+# Working directory (clone the repo here)
+WorkingDirectory=/opt/tasks
+
+# Environment
+EnvironmentFile=/etc/tasks/env
+
+# Data directory
+Environment=TASKS_DATA_DIR=/var/lib/tasks
+Environment=RUST_LOG=info
+
+# Main process
+ExecStart=/opt/tasks/scripts/tasks-runner.sh --web
+
+# Graceful shutdown
+TimeoutStopSec=60
+KillMode=mixed
+KillSignal=SIGTERM
+
+# Restart policy
+Restart=on-failure
+RestartSec=10
+RestartPreventExitStatus=0
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+MemoryDenyWriteExecute=false
+
+# Allow write to data directory
+ReadWritePaths=/var/lib/tasks
+
+# Allow network access
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+# Resource limits
+LimitNOFILE=65536
+MemoryMax=16G
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=tasks
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/tasks.service
+++ b/scripts/tasks.service
@@ -64,8 +64,8 @@ RestrictRealtime=true
 RestrictSUIDSGID=true
 MemoryDenyWriteExecute=false
 
-# Allow write to data directory
-ReadWritePaths=/var/lib/tasks
+# Allow write to data directory and repo (for self-update)
+ReadWritePaths=/var/lib/tasks /opt/tasks
 
 # Allow network access
 RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX


### PR DESCRIPTION
## Summary

Implements Phase 4 of the self-update mechanism (#305) with production-ready robustness features and deployment configurations.

- Adds wrapper script with build failure handling, network retry with exponential backoff, and partial update recovery
- Adds systemd and launchd service files for production deployment
- Adds comprehensive design document and deployment guide

## Deliverables

### Build Failure Handling
- Wrapper script detects build failures during update
- Backs up current binary before rebuild attempt
- Falls back to backup binary if build fails
- Logs errors to `$DATA_DIR/runner.log`

### Network Failure Handling
- Exponential backoff on git fetch/pull failures (5s initial, 5m max)
- Tracks consecutive failures to avoid spamming
- Configurable via `TASKS_MAX_RETRIES` and `TASKS_RETRY_DELAY`

### Partial Update Recovery
- Tracks update state in `.update-state` file
- Can resume from last successful step if interrupted
- Cleans up state files on successful completion

### Service Files
- `scripts/tasks.service` - systemd unit for Linux with security hardening
- `scripts/com.tasks.plist` - launchd plist for macOS

### Wrapper Script Features
- Logging to file with rotation (10MB max)
- Signal handling (SIGTERM, SIGINT forwarded to server)
- PID file management with stale PID detection
- Health check integration after restart

### Documentation
- `docs/design/self-update.md` - Full design document
- `docs/app/deployment.md` - Production deployment guide
- Updated configuration.md with self-update and wrapper variables

## Dependencies

This phase provides the robustness layer for the self-update mechanism. The core features will be implemented in:
- Phase 1: Core infrastructure (#319, PR #356)
- Phase 2: API endpoints and events (#320, PR #357)
- Phase 3: Frontend UI (#321, PR #358)

## Test plan

- [ ] Verify wrapper script starts server correctly: `./scripts/tasks-runner.sh --web`
- [ ] Verify PID file is created at `~/.local/state/tasks/tasks.pid`
- [ ] Verify logs are written to `~/.local/state/tasks/runner.log`
- [ ] Test signal handling: `kill -TERM $(cat ~/.local/state/tasks/tasks.pid)`
- [ ] Review systemd service file structure
- [ ] Review launchd plist structure

Closes #322

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)