### PR TITLE
Add Merging status for active merge operations

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -1386,6 +1386,11 @@ pub async fn run(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
                     if mode == server::Mode::Play {
                         // Execute the merge on GitHub (Play mode = continuous merge authority)
                         if let Some((owner, repo, number)) = tasks_orchestrator::parse_pr_url(&pr_url) {
+                            // Transition to Merging before the API call for visibility
+                            if let Err(e) = orch_server.mark_entry_merging(&entry_id, &pr_url).await {
+                                error!(entry_id = %entry_id, error = %e, "failed to mark entry as merging");
+                            }
+
                             match merge_github.merge_pull_request(&owner, &repo, number).await {
                                 Ok(true) => {
                                     info!(entry_id = %entry_id, pr_url = %pr_url, "PR merged successfully");

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -494,6 +494,11 @@ async fn flush_merge_queue(State(state): State<ApiState>) -> Result<Json<Vec<Str
     let client = tasks_github::client::GitHubClient::new(&github_token);
     for (entry_id, pr_url) in &entries_to_merge {
         if let Some((owner, repo, number)) = tasks_orchestrator::parse_pr_url(pr_url) {
+            // Transition to Merging before the API call for visibility
+            if let Err(e) = state.server.mark_entry_merging(entry_id, pr_url).await {
+                tracing::error!(entry_id = %entry_id, error = %e, "failed to mark entry as merging");
+            }
+
             match client.merge_pull_request(&owner, &repo, number).await {
                 Ok(true) => {
                     tracing::info!(entry_id = %entry_id, pr_url = %pr_url, "PR merged via flush");
@@ -556,6 +561,11 @@ async fn approve_merge(
         let github_token = std::env::var("GITHUB_TOKEN").unwrap_or_default();
         if !github_token.is_empty() {
             if let Some((owner, repo, number)) = tasks_orchestrator::parse_pr_url(&pr_url) {
+                // Transition to Merging before the API call for visibility
+                if let Err(e) = state.server.mark_entry_merging(&id, &pr_url).await {
+                    tracing::error!(entry_id = %id, error = %e, "failed to mark entry as merging");
+                }
+
                 let client = tasks_github::client::GitHubClient::new(&github_token);
                 match client.merge_pull_request(&owner, &repo, number).await {
                     Ok(true) => {

--- a/crates/desktop/src/api.rs
+++ b/crates/desktop/src/api.rs
@@ -66,6 +66,7 @@ pub fn merge_status_display_name(status: &MergeStatus) -> &'static str {
     match status {
         MergeStatus::Pending => "Pending",
         MergeStatus::Approved => "Approved",
+        MergeStatus::Merging => "Merging",
         MergeStatus::Rejected => "Rejected",
         MergeStatus::Merged => "Merged",
         MergeStatus::Conflict => "Conflict",

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -48,6 +48,8 @@ pub enum EventType {
     // Merge events
     MergeQueued,
     MergeApproved,
+    /// Merge in progress — GitHub API call executing.
+    MergeMerging,
     MergeRejected,
     MergeChangesRequested,
     MergeCompleted,
@@ -115,6 +117,7 @@ impl EventType {
             Self::HumanMessage => "human:message",
             Self::MergeQueued => "merge:queued",
             Self::MergeApproved => "merge:approved",
+            Self::MergeMerging => "merge:merging",
             Self::MergeRejected => "merge:rejected",
             Self::MergeChangesRequested => "merge:changes_requested",
             Self::MergeCompleted => "merge:completed",
@@ -195,6 +198,7 @@ impl TryFrom<String> for EventType {
             "human:message" => Ok(Self::HumanMessage),
             "merge:queued" => Ok(Self::MergeQueued),
             "merge:approved" => Ok(Self::MergeApproved),
+            "merge:merging" => Ok(Self::MergeMerging),
             "merge:rejected" => Ok(Self::MergeRejected),
             "merge:changes_requested" => Ok(Self::MergeChangesRequested),
             "merge:completed" => Ok(Self::MergeCompleted),

--- a/crates/models/src/merge_queue.rs
+++ b/crates/models/src/merge_queue.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 pub enum MergeStatus {
     Pending,
     Approved,
+    /// Actively being merged — GitHub API call in progress.
+    Merging,
     Rejected,
     Merged,
     Conflict,

--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -89,6 +89,15 @@ impl MergeQueue {
         Ok(())
     }
 
+    /// Mark an entry as actively merging (GitHub API call in progress).
+    pub fn mark_merging(&mut self, id: &str) -> Result<(), MergeQueueError> {
+        let entry = self
+            .get_mut(id)
+            .ok_or_else(|| MergeQueueError::NotFound(id.to_string()))?;
+        entry.status = MergeStatus::Merging;
+        Ok(())
+    }
+
     /// Reject an entry (spec Section 7.1 step 5).
     pub fn reject(&mut self, id: &str) -> Result<(), MergeQueueError> {
         let entry = self

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1000,6 +1000,34 @@ impl Server {
         Ok(())
     }
 
+    /// Mark a merge queue entry as actively merging (GitHub API call in progress).
+    /// Emits `merge:merging` event.
+    pub async fn mark_entry_merging(
+        &self,
+        entry_id: &str,
+        pr_url: &str,
+    ) -> Result<(), ServerError> {
+        let task_id = {
+            let mut state = self.state.write().await;
+            state
+                .merge_queue
+                .mark_merging(entry_id)
+                .map_err(|e| ServerError::StoreError(e.to_string()))?;
+            let entry = state.merge_queue.get(entry_id)
+                .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
+            entry.task_id.clone()
+        };
+
+        let event = Event::new(
+            EventType::MergeMerging,
+            &task_id,
+            Actor::System,
+            serde_json::json!({ "entry_id": entry_id, "pr_url": pr_url }),
+        );
+        self.event_bus.publish(event).await?;
+        Ok(())
+    }
+
     /// Mark a merge queue entry as merged and transition the linked task
     /// to Completed. Emits `merge:completed` and `task:state:completed`.
     pub async fn mark_entry_merged(

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -807,9 +807,10 @@ mod tests {
         for (id, status) in [
             ("m1", MergeStatus::Pending),
             ("m2", MergeStatus::Approved),
-            ("m3", MergeStatus::Rejected),
-            ("m4", MergeStatus::Merged),
-            ("m5", MergeStatus::Conflict),
+            ("m3", MergeStatus::Merging),
+            ("m4", MergeStatus::Rejected),
+            ("m5", MergeStatus::Merged),
+            ("m6", MergeStatus::Conflict),
         ] {
             let mut entry = MergeQueueEntry::new(id, "t1", "https://github.com/test/repo/pull/1");
             entry.status = status;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -61,6 +61,7 @@ export interface Project {
 export type MergeStatus =
   | "pending"
   | "approved"
+  | "merging"
   | "rejected"
   | "merged"
   | "conflict"

--- a/web/src/pages/dashboard/page.tsx
+++ b/web/src/pages/dashboard/page.tsx
@@ -68,6 +68,7 @@ const taskChartConfig: ChartConfig = Object.fromEntries(
 const mergeStatusColors: Record<MergeStatus, string> = {
   pending: "hsl(45, 93%, 47%)",
   approved: "hsl(142, 71%, 45%)",
+  merging: "hsl(187, 71%, 55%)",
   rejected: "hsl(0, 84%, 60%)",
   merged: "hsl(217, 91%, 60%)",
   conflict: "hsl(0, 84%, 60%)",
@@ -77,6 +78,7 @@ const mergeStatusColors: Record<MergeStatus, string> = {
 const mergeStatusLabels: Record<MergeStatus, string> = {
   pending: "Pending",
   approved: "Approved",
+  merging: "Merging",
   rejected: "Rejected",
   merged: "Merged",
   conflict: "Conflict",

--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -17,6 +17,8 @@ function statusBadge(status: MergeStatus) {
       return <Badge variant="outline" className="bg-yellow-500/15 text-yellow-400 border-yellow-500/30">{status}</Badge>;
     case "approved":
       return <Badge variant="outline" className="bg-green-500/15 text-green-400 border-green-500/30">{status}</Badge>;
+    case "merging":
+      return <Badge variant="outline" className="bg-cyan-500/15 text-cyan-400 border-cyan-500/30 animate-pulse">{status}</Badge>;
     case "rejected":
       return <Badge variant="outline" className="bg-red-500/15 text-red-400 border-red-500/30">{status}</Badge>;
     case "merged":
@@ -37,10 +39,11 @@ function statusBadge(status: MergeStatus) {
 const statusSortOrder: Record<MergeStatus, number> = {
   changes_requested: 0, // Changes requested shown first (needs attention)
   conflict: 1,
-  approved: 2,
-  rejected: 3,
-  merged: 4,
-  pending: 5,
+  merging: 2, // Actively merging — shows current operation
+  approved: 3,
+  rejected: 4,
+  merged: 5,
+  pending: 6,
 };
 
 export { statusSortOrder };


### PR DESCRIPTION
## Summary

- Adds `Merging` status to `MergeStatus` enum for visibility into active merge operations
- Transitions entries to `Merging` before GitHub API call, then to `Merged` or `Conflict` based on result
- Updates UI with pulsing cyan badge for active merge status

## Changes

**Backend:**
- Add `Merging` variant to `MergeStatus` enum in `crates/models/src/merge_queue.rs`
- Add `mark_merging` method to `MergeQueue` in `crates/server/src/merge_queue.rs`
- Add `mark_entry_merging` method to server State with `merge:merging` event
- Add `MergeMerging` event type in `crates/events/src/event.rs`
- Transition to `Merging` before merge API call in:
  - Orchestrator run loop (Play mode)
  - Flush endpoint (Pause mode)
  - Manual approve endpoint (Play mode)

**Frontend:**
- Add `merging` to `MergeStatus` TypeScript type
- Add cyan/pulse badge styling for `merging` status
- Update sort order: merging entries appear above approved
- Update dashboard chart with merging status color/label

## Test plan

- [ ] Start server in Play mode, observe entries transition `Approved` → `Merging` → `Merged`
- [ ] Verify `merging` badge displays with pulse animation
- [ ] Check merge queue sorting places `Merging` entries above `Approved`
- [ ] Confirm dashboard chart includes `Merging` status

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)