### PR TITLE
Wire self-update API to Phase 1 UpdateState

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -1902,6 +1902,9 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
 
     // --- 9. Optionally spawn web server ---
 
+    // Create update trigger channel (shared between API and auto-apply)
+    let (update_tx, mut update_rx) = tokio::sync::mpsc::channel::<()>(1);
+
     let web_handle = if config.web {
         // Initialize completions service for fast Haiku-based completions.
         let completions_service = tasks_agent::CompletionsService::from_env()
@@ -1918,6 +1921,8 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
             max_sessions: config.max_sessions,
             session_manager: Some(session_manager.clone()),
             completions_service,
+            update_state: update_state.clone(),
+            update_tx: update_tx.clone(),
         };
         let web_port = config.web_port;
 
@@ -1953,9 +1958,6 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     // The server can shut down due to:
     // - Ctrl-C (normal shutdown)
     // - Update trigger (exit with code 100 for restart)
-
-    // Create update trigger channel
-    let (update_tx, mut update_rx) = tokio::sync::mpsc::channel::<()>(1);
 
     // If auto-apply is enabled, spawn a task that triggers update when available
     let auto_apply_handle = if config.update_auto_apply && config.update_check_enabled {

--- a/crates/app/src/update.rs
+++ b/crates/app/src/update.rs
@@ -106,7 +106,6 @@ impl RebuildScope {
 
 /// State of an available update.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Fields used for future API endpoints and logging
 pub struct UpdateInfo {
     /// The commit SHA we're currently at.
     pub current_commit: String,

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -31,6 +31,8 @@ use server::Server;
 use server::presence::OwnedConnectionGuard;
 use models::Mode;
 
+use crate::update::UpdateState;
+
 /// Shared state for API handlers.
 #[derive(Clone)]
 pub struct ApiState {
@@ -38,6 +40,8 @@ pub struct ApiState {
     pub max_sessions: u32,
     pub session_manager: Option<Arc<tasks_session::SessionManager<runtime::AppleContainerRuntime>>>,
     pub completions_service: Option<Arc<CompletionsService>>,
+    pub update_state: Arc<UpdateState>,
+    pub update_tx: tokio::sync::mpsc::Sender<()>,
 }
 
 /// Build the API router.
@@ -193,6 +197,8 @@ struct QueryEventsParams {
 struct SelfUpdateStatusResponse {
     /// Whether an update is available.
     available: bool,
+    /// Whether an update is currently being applied.
+    applying: bool,
     /// Current commit hash (short form).
     current_commit: Option<String>,
     /// Target commit hash to update to (short form).
@@ -811,18 +817,29 @@ async fn get_task_accounting(
 /// Returns information about whether an update is available from upstream.
 /// Note: Full functionality requires Phase 1 infrastructure (#319).
 async fn get_self_update_status(
-    State(_state): State<ApiState>,
+    State(state): State<ApiState>,
 ) -> Json<SelfUpdateStatusResponse> {
-    // TODO(#319): Integrate with SelfUpdateManager from Phase 1
-    // For now, return a stub response indicating no update mechanism is configured
-    Json(SelfUpdateStatusResponse {
-        available: false,
-        current_commit: None,
-        target_commit: None,
-        rebuild_scope: None,
-        commit_summary: None,
-        last_checked: None,
-    })
+    let applying = state.update_state.is_applying();
+    match state.update_state.get_info().await {
+        Some(info) => Json(SelfUpdateStatusResponse {
+            available: true,
+            applying,
+            current_commit: Some(info.current_commit[..7.min(info.current_commit.len())].to_string()),
+            target_commit: Some(info.available_commit[..7.min(info.available_commit.len())].to_string()),
+            rebuild_scope: Some(info.scope.as_str().to_string()),
+            commit_summary: None,
+            last_checked: None,
+        }),
+        None => Json(SelfUpdateStatusResponse {
+            available: false,
+            applying,
+            current_commit: None,
+            target_commit: None,
+            rebuild_scope: None,
+            commit_summary: None,
+            last_checked: None,
+        }),
+    }
 }
 
 /// POST /api/self-update/apply — Trigger a self-update.
@@ -834,15 +851,36 @@ async fn get_self_update_status(
 ///
 /// Note: Full functionality requires Phase 1 infrastructure (#319).
 async fn apply_self_update(
-    State(_state): State<ApiState>,
+    State(state): State<ApiState>,
     Json(req): Json<ApplySelfUpdateRequest>,
 ) -> Result<Json<ApplySelfUpdateResponse>, ApiError> {
-    // TODO(#319): Integrate with SelfUpdateManager from Phase 1
-    tracing::debug!(force = req.force, "self-update apply called (stub, #319 not yet integrated)");
+    // Already applying?
+    if state.update_state.is_applying() {
+        return Ok(Json(ApplySelfUpdateResponse {
+            status: "already_applying".to_string(),
+            message: "An update is already being applied.".to_string(),
+        }));
+    }
+
+    // No update available?
+    if !state.update_state.is_available().await {
+        return Ok(Json(ApplySelfUpdateResponse {
+            status: "no_update".to_string(),
+            message: "No update available.".to_string(),
+        }));
+    }
+
+    tracing::info!(force = req.force, "self-update apply triggered via API");
+
+    // Send the update trigger — the run loop will handle shutdown and exit 100
+    if let Err(e) = state.update_tx.send(()).await {
+        tracing::error!(error = %e, "failed to send update trigger");
+        return Err(ApiError::BadRequest(format!("failed to trigger update: {e}")));
+    }
 
     Ok(Json(ApplySelfUpdateResponse {
-        status: "no_update".to_string(),
-        message: "Self-update infrastructure not yet configured. See issue #319.".to_string(),
+        status: "applying".to_string(),
+        message: "Update is being applied. The server will restart shortly.".to_string(),
     }))
 }
 


### PR DESCRIPTION
## Summary
- Connect the stub self-update API endpoints to the real `UpdateState` from Phase 1
- `GET /api/self-update` returns live update checker status (available, commits, scope)
- `POST /api/self-update/apply` triggers graceful shutdown via the update channel
- The web UI update banner now works end-to-end

## What changed
- Added `update_state` and `update_tx` to `ApiState`
- `get_self_update_status` reads from `UpdateState::get_info()`
- `apply_self_update` sends on the update trigger channel (same path as auto-apply)
- Added `applying` field to status response
- Removed `#[allow(dead_code)]` from `UpdateInfo` (fields now used)

## Test plan
- [ ] Run `cargo run -- run --web`, verify `/api/self-update` returns `available: false` when up to date
- [ ] Push a commit to main, wait for checker interval, verify status shows update available
- [ ] Click "Update Now" in web UI, verify server begins shutdown sequence