### PR TITLE
Add queue_position field for merge ordering visibility

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -324,7 +324,7 @@ async fn snapshot(State(state): State<ApiState>) -> Json<SnapshotResponse> {
         mode: server_state.mode,
         projects: server_state.projects.values().cloned().collect(),
         tasks: server_state.tasks.values().cloned().collect(),
-        merge_queue: server_state.merge_queue.entries().to_vec(),
+        merge_queue: server_state.merge_queue.entries_with_positions(),
         slot_utilization: SlotUtilization {
             active,
             max: state.max_sessions,
@@ -506,7 +506,7 @@ async fn list_merge_queue(
     State(state): State<ApiState>,
 ) -> Json<Vec<models::merge_queue::MergeQueueEntry>> {
     let server_state = state.server.state.read().await;
-    Json(server_state.merge_queue.entries().to_vec())
+    Json(server_state.merge_queue.entries_with_positions())
 }
 
 /// POST /api/merge-queue/flush — Flush approved entries (Pause mode only).

--- a/crates/models/src/merge_queue.rs
+++ b/crates/models/src/merge_queue.rs
@@ -102,6 +102,10 @@ pub struct MergeQueueEntry {
     /// Used to detect new commits for re-evaluation (spec Section 7.1).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub head_sha: Option<String>,
+    /// Position in merge queue (1-indexed).
+    /// Only set for Approved/Merging entries to show merge order.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queue_position: Option<u32>,
 }
 
 impl MergeQueueEntry {
@@ -115,6 +119,7 @@ impl MergeQueueEntry {
             conflict_info: None,
             changes_requested_feedback: None,
             head_sha: None,
+            queue_position: None,
         }
     }
 

--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -44,6 +44,43 @@ impl MergeQueue {
         &self.entries
     }
 
+    /// Get entries with queue positions computed for Approved/Merging entries.
+    ///
+    /// Positions are 1-indexed and assigned based on `queued_at` order.
+    /// Position 1 = next to merge.
+    pub fn entries_with_positions(&self) -> Vec<MergeQueueEntry> {
+        // First, collect indices of entries that should have positions (Approved or Merging)
+        // and sort them by queued_at
+        let mut queue_indices: Vec<usize> = self
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| matches!(e.status, MergeStatus::Approved | MergeStatus::Merging))
+            .map(|(i, _)| i)
+            .collect();
+
+        // Sort by queued_at (earliest first = position 1)
+        queue_indices.sort_by(|&a, &b| self.entries[a].queued_at.cmp(&self.entries[b].queued_at));
+
+        // Create a map from entry index to position
+        let mut position_map: std::collections::HashMap<usize, u32> =
+            std::collections::HashMap::new();
+        for (pos, &idx) in queue_indices.iter().enumerate() {
+            position_map.insert(idx, (pos + 1) as u32);
+        }
+
+        // Clone entries and set positions
+        self.entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| {
+                let mut entry = e.clone();
+                entry.queue_position = position_map.get(&i).copied();
+                entry
+            })
+            .collect()
+    }
+
     /// Get a mutable entry by ID.
     pub fn get_mut(&mut self, id: &str) -> Option<&mut MergeQueueEntry> {
         self.entries.iter_mut().find(|e| e.id == id)
@@ -464,5 +501,98 @@ mod tests {
         assert_eq!(q.entries().len(), 2);
         assert!(q.get("m1").is_some());
         assert!(q.get("m2").is_some());
+    }
+
+    #[test]
+    fn entries_with_positions_basic() {
+        let mut q = MergeQueue::new();
+        q.enqueue(entry("m1", "t1"));
+        q.enqueue(entry("m2", "t2"));
+        q.enqueue(entry("m3", "t3"));
+
+        // Approve m1 and m3, leave m2 pending
+        q.approve("m1").unwrap();
+        q.approve("m3").unwrap();
+
+        let entries = q.entries_with_positions();
+        assert_eq!(entries.len(), 3);
+
+        // m1 is approved first (by queued_at order), so position 1
+        let m1 = entries.iter().find(|e| e.id == "m1").unwrap();
+        assert_eq!(m1.queue_position, Some(1));
+
+        // m2 is pending, no position
+        let m2 = entries.iter().find(|e| e.id == "m2").unwrap();
+        assert_eq!(m2.queue_position, None);
+
+        // m3 is approved second, so position 2
+        let m3 = entries.iter().find(|e| e.id == "m3").unwrap();
+        assert_eq!(m3.queue_position, Some(2));
+    }
+
+    #[test]
+    fn entries_with_positions_merging_included() {
+        let mut q = MergeQueue::new();
+        q.enqueue(entry("m1", "t1"));
+        q.enqueue(entry("m2", "t2"));
+
+        // Approve both, then mark m1 as merging
+        q.approve("m1").unwrap();
+        q.approve("m2").unwrap();
+        q.mark_merging("m1").unwrap();
+
+        let entries = q.entries_with_positions();
+
+        // m1 (merging) should be position 1
+        let m1 = entries.iter().find(|e| e.id == "m1").unwrap();
+        assert_eq!(m1.status, MergeStatus::Merging);
+        assert_eq!(m1.queue_position, Some(1));
+
+        // m2 (approved) should be position 2
+        let m2 = entries.iter().find(|e| e.id == "m2").unwrap();
+        assert_eq!(m2.status, MergeStatus::Approved);
+        assert_eq!(m2.queue_position, Some(2));
+    }
+
+    #[test]
+    fn entries_with_positions_respects_queued_at_order() {
+        use chrono::{Duration, Utc};
+
+        let mut q = MergeQueue::new();
+
+        // Create entries with explicit timestamps (m2 queued before m1)
+        let mut e1 = MergeQueueEntry::new("m1", "t1", "https://github.com/test/repo/pull/1");
+        e1.queued_at = Utc::now();
+
+        let mut e2 = MergeQueueEntry::new("m2", "t2", "https://github.com/test/repo/pull/2");
+        e2.queued_at = Utc::now() - Duration::hours(1); // Queued earlier
+
+        // Enqueue in m1, m2 order (but m2 has earlier timestamp)
+        q.enqueue(e1);
+        q.enqueue(e2);
+
+        q.approve("m1").unwrap();
+        q.approve("m2").unwrap();
+
+        let entries = q.entries_with_positions();
+
+        // m2 was queued earlier, so it should be position 1
+        let m1 = entries.iter().find(|e| e.id == "m1").unwrap();
+        let m2 = entries.iter().find(|e| e.id == "m2").unwrap();
+
+        assert_eq!(m2.queue_position, Some(1)); // Earlier timestamp = first
+        assert_eq!(m1.queue_position, Some(2));
+    }
+
+    #[test]
+    fn entries_with_positions_no_approved() {
+        let mut q = MergeQueue::new();
+        q.enqueue(entry("m1", "t1"));
+        q.enqueue(entry("m2", "t2"));
+
+        // All entries pending, none should have positions
+        let entries = q.entries_with_positions();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|e| e.queue_position.is_none()));
     }
 }

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -211,6 +211,7 @@ impl Store {
                     conflict_info: None, // Not persisted to DB yet
                     changes_requested_feedback: None, // TODO: persist to DB
                     head_sha: None,      // Updated from GitHub on reconciliation
+                    queue_position: None, // Computed lazily on API read
                 }))
             }
             None => Ok(None),
@@ -249,6 +250,7 @@ impl Store {
                 conflict_info: None, // Not persisted to DB yet
                 changes_requested_feedback: None, // TODO: persist to DB
                 head_sha: None,      // Updated from GitHub on reconciliation
+                queue_position: None, // Computed lazily on API read
             });
         }
         Ok(entries)

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -75,6 +75,8 @@ export interface MergeQueueEntry {
   queued_at: string;
   /** Feedback when status is changes_requested */
   changes_requested_feedback?: string;
+  /** Position in merge queue (1-indexed). Only set for approved/merging entries. */
+  queue_position?: number;
 }
 
 export type Actor = "human" | "orchestrator" | "scheduler" | "agent" | "system";

--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -200,6 +200,28 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
     },
   },
 
+  // Queue position (for approved/merging entries)
+  {
+    accessorKey: "queue_position",
+    header: "Position",
+    cell: ({ row }) => {
+      const pos = row.original.queue_position;
+      if (pos === undefined || pos === null) {
+        return <span className="text-muted-foreground">&mdash;</span>;
+      }
+      return (
+        <span className="text-xs font-mono text-muted-foreground">
+          #{pos}
+        </span>
+      );
+    },
+    sortingFn: (rowA, rowB) => {
+      const a = rowA.original.queue_position ?? Infinity;
+      const b = rowB.original.queue_position ?? Infinity;
+      return a - b;
+    },
+  },
+
   // Linked issue (from task source)
   {
     id: "issue",


### PR DESCRIPTION
## Summary

- Adds `queue_position` field to `MergeQueueEntry` struct (1-indexed, only set for Approved/Merging entries)
- Implements lazy position computation based on `queued_at` timestamp order (position 1 = next to merge)
- Displays position in merge queue table in frontend

## Changes

### Backend
- Added `queue_position: Option<u32>` field to `MergeQueueEntry` in `crates/models/src/merge_queue.rs`
- Added `entries_with_positions()` method to `MergeQueue` that computes positions for Approved/Merging entries
- Updated `/api/merge-queue` and `/api/snapshot` endpoints to return entries with positions computed
- Updated store to initialize the new field

### Frontend
- Added `queue_position?: number` to TypeScript `MergeQueueEntry` interface
- Added Position column to merge queue table with custom sort

## Test plan

- [x] Added 4 unit tests for position computation logic
- [x] All existing merge queue tests pass
- [x] Frontend TypeScript compiles and builds successfully

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)