### PR TITLE
Add containers view to see all active sessions

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -48,6 +48,7 @@ pub struct ApiState {
 pub fn router(state: ApiState) -> Router {
     let api = Router::new()
         .route("/snapshot", get(snapshot))
+        .route("/sessions", get(list_sessions))
         .route("/tasks", get(list_tasks))
         .route("/tasks/{id}", get(get_task))
         .route("/tasks/{id}", axum::routing::patch(update_task))
@@ -105,6 +106,27 @@ struct SnapshotResponse {
 struct SlotUtilization {
     active: u32,
     max: u32,
+}
+
+/// Session info for the /api/sessions endpoint.
+#[derive(Serialize)]
+struct SessionInfo {
+    /// Task ID this session is executing.
+    task_id: String,
+    /// Container ID for this session.
+    container_id: String,
+    /// Task title (from task data).
+    task_title: String,
+    /// Current task state.
+    task_state: models::task::TaskState,
+    /// Project ID for the task.
+    project_id: String,
+    /// Project repo name (owner/repo).
+    project_repo: Option<String>,
+    /// Session start time (ISO 8601).
+    started_at: chrono::DateTime<chrono::Utc>,
+    /// Session uptime in seconds.
+    uptime_secs: u64,
 }
 
 #[derive(Serialize)]
@@ -331,6 +353,51 @@ async fn snapshot(State(state): State<ApiState>) -> Json<SnapshotResponse> {
         },
         human_present: state.server.is_human_present(),
     })
+}
+
+/// GET /api/sessions — List active container sessions.
+///
+/// Returns information about all currently running sessions including
+/// container ID, associated task info, and uptime.
+async fn list_sessions(State(state): State<ApiState>) -> Json<Vec<SessionInfo>> {
+    let Some(sm) = state.session_manager.as_ref() else {
+        return Json(Vec::new());
+    };
+
+    // Get session info snapshots (already sorted by uptime descending)
+    let session_snapshots = sm.session_info().await;
+
+    // Read server state for task/project info
+    let server_state = state.server.state.read().await;
+    let wall_clock_now = chrono::Utc::now();
+
+    let sessions: Vec<SessionInfo> = session_snapshots
+        .into_iter()
+        .filter_map(|snapshot| {
+            let task = server_state.tasks.get(&snapshot.task_id)?;
+            let project_repo = server_state
+                .projects
+                .get(&task.project)
+                .map(|p| p.repo.clone());
+
+            // Approximate start time by subtracting uptime from current wall clock
+            let uptime_duration = chrono::Duration::seconds(snapshot.uptime_secs as i64);
+            let started_at = wall_clock_now - uptime_duration;
+
+            Some(SessionInfo {
+                task_id: snapshot.task_id,
+                container_id: snapshot.container_id,
+                task_title: task.title.clone(),
+                task_state: task.state.clone(),
+                project_id: task.project.clone(),
+                project_repo,
+                started_at,
+                uptime_secs: snapshot.uptime_secs,
+            })
+        })
+        .collect();
+
+    Json(sessions)
 }
 
 /// GET /api/tasks — List all tasks.

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -9,4 +9,4 @@ mod manager;
 
 pub use accounting::{TokenParser, TokenTracker, TokenUsage};
 pub use interpreter::{OutputInterpreter, OutputSignal, emit_signal_events};
-pub use manager::{SessionManager, SessionManagerError, SessionHandle};
+pub use manager::{SessionManager, SessionManagerError, SessionHandle, SessionInfoSnapshot};

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -41,6 +41,17 @@ pub(crate) enum SessionCommand {
     Stop,
 }
 
+/// Snapshot of session info for external consumption.
+#[derive(Debug, Clone)]
+pub struct SessionInfoSnapshot {
+    /// Task ID this session is executing.
+    pub task_id: String,
+    /// Container ID for this session.
+    pub container_id: String,
+    /// Session uptime in seconds.
+    pub uptime_secs: u64,
+}
+
 /// Handle for a running session — tracks metadata and communication channel.
 pub struct SessionHandle {
     /// The task this session is executing.
@@ -138,6 +149,28 @@ impl<R: ContainerRuntime + Send + Sync + 'static> SessionManager<R> {
             .values()
             .max_by_key(|h| h.started_at)
             .map(|h| h.task_id.clone())
+    }
+
+    /// Get session info for all active sessions.
+    ///
+    /// Returns a list of (task_id, container_id, uptime_secs) tuples for all
+    /// active sessions, ordered by longest-running first.
+    pub async fn session_info(&self) -> Vec<SessionInfoSnapshot> {
+        let sessions = self.sessions.read().await;
+        let now = std::time::Instant::now();
+
+        let mut info: Vec<SessionInfoSnapshot> = sessions
+            .values()
+            .map(|h| SessionInfoSnapshot {
+                task_id: h.task_id.clone(),
+                container_id: h.container_id.clone(),
+                uptime_secs: now.duration_since(h.started_at).as_secs(),
+            })
+            .collect();
+
+        // Sort by uptime descending (longest-running first)
+        info.sort_by(|a, b| b.uptime_secs.cmp(&a.uptime_secs));
+        info
     }
 
     /// Send a chat message to a running session (spec §9.2).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { Layout } from "@/components/layout";
 import { DashboardPage } from "@/pages/dashboard/page";
 import { TasksPage } from "@/pages/tasks/page";
 import { TaskDetailPage } from "@/pages/task-detail";
+import { ContainersPage } from "@/pages/containers/page";
 import { MergeQueuePage } from "@/pages/merge-queue/page";
 import { OrchestratorPage } from "@/pages/orchestrator/page";
 import { EventsPage } from "@/pages/events/page";
@@ -16,6 +17,7 @@ export function App() {
           <Route path="/" element={<DashboardPage />} />
           <Route path="/tasks" element={<TasksPage />} />
           <Route path="/tasks/:id" element={<TaskDetailPage />} />
+          <Route path="/containers" element={<ContainersPage />} />
           <Route path="/merge-queue" element={<MergeQueuePage />} />
           <Route path="/orchestrator" element={<OrchestratorPage />} />
           <Route path="/events" element={<EventsPage />} />

--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -13,6 +13,7 @@ import {
   Square,
   Pause,
   Play,
+  Container,
 } from "lucide-react";
 import { useAppState } from "@/hooks/use-app-state";
 import { addProject, deleteProject, setMode } from "@/lib/api";
@@ -423,6 +424,7 @@ export function Layout() {
             <div className="space-y-0.5 px-1">
               <SidebarNavItem to="/" icon={LayoutDashboard} label="Dashboard" end />
               <SidebarNavItem to="/tasks" icon={ListTodo} label="Tasks" />
+              <SidebarNavItem to="/containers" icon={Container} label="Containers" />
               <SidebarNavItem to="/merge-queue" icon={GitMerge} label="Merge Queue" />
             </div>
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,6 +3,7 @@ import type {
   MergeQueueEntry,
   Mode,
   Project,
+  Session,
   Snapshot,
   Task,
   UpdateStatus,
@@ -45,6 +46,10 @@ export function fetchProjects(): Promise<Project[]> {
 
 export function fetchMergeQueue(): Promise<MergeQueueEntry[]> {
   return request<MergeQueueEntry[]>("/api/merge-queue");
+}
+
+export function fetchSessions(): Promise<Session[]> {
+  return request<Session[]>("/api/sessions");
 }
 
 export function fetchMode(): Promise<{ mode: Mode }> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -95,6 +95,18 @@ export interface SlotUtilization {
   max: number;
 }
 
+/** Active container session info. */
+export interface Session {
+  task_id: string;
+  container_id: string;
+  task_title: string;
+  task_state: TaskState;
+  project_id: string;
+  project_repo: string | null;
+  started_at: string;
+  uptime_secs: number;
+}
+
 export interface Snapshot {
   mode: Mode;
   projects: Project[];

--- a/web/src/pages/containers/page.tsx
+++ b/web/src/pages/containers/page.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useState, useCallback } from "react";
+import { Link } from "react-router-dom";
+import { Container, RefreshCw, Clock, Box, Activity } from "lucide-react";
+import { fetchSessions } from "@/lib/api";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { Session, TaskState } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// State badge (reuse task state styling)
+// ---------------------------------------------------------------------------
+
+const stateConfig: Record<TaskState, { label: string; className: string }> = {
+  waiting: { label: "Waiting", className: "bg-slate-500/15 text-slate-400 border-slate-500/30" },
+  blocked: { label: "Blocked", className: "bg-orange-500/15 text-orange-400 border-orange-500/30" },
+  running: { label: "Running", className: "bg-green-500/15 text-green-400 border-green-500/30 animate-pulse" },
+  question: { label: "Question", className: "bg-purple-500/15 text-purple-400 border-purple-500/30" },
+  testing: { label: "Testing", className: "bg-cyan-500/15 text-cyan-400 border-cyan-500/30 animate-pulse" },
+  awaiting_merge: { label: "Awaiting Merge", className: "bg-blue-500/15 text-blue-400 border-blue-500/30" },
+  conflict: { label: "Conflict", className: "bg-red-500/15 text-red-400 border-red-500/30" },
+  changes_requested: { label: "Changes Requested", className: "bg-amber-500/15 text-amber-400 border-amber-500/30" },
+  completed: { label: "Completed", className: "bg-emerald-500/15 text-emerald-400 border-emerald-500/30" },
+  failed: { label: "Failed", className: "bg-red-500/15 text-red-400 border-red-500/30" },
+  cancelled: { label: "Cancelled", className: "bg-slate-500/15 text-slate-400 border-slate-500/30" },
+};
+
+function StateBadge({ state }: { state: TaskState }) {
+  const config = stateConfig[state] ?? { label: state, className: "" };
+  return (
+    <Badge variant="outline" className={config.className}>
+      {config.label}
+    </Badge>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Format uptime
+// ---------------------------------------------------------------------------
+
+function formatUptime(secs: number): string {
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ${secs % 60}s`;
+  const hours = Math.floor(mins / 60);
+  const remainingMins = mins % 60;
+  if (hours < 24) return `${hours}h ${remainingMins}m`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ${hours % 24}h`;
+}
+
+// ---------------------------------------------------------------------------
+// Containers Page
+// ---------------------------------------------------------------------------
+
+export function ContainersPage() {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadSessions = useCallback(async (showRefreshing = false) => {
+    if (showRefreshing) setRefreshing(true);
+    try {
+      const data = await fetchSessions();
+      setSessions(data);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load sessions");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  // Initial load
+  useEffect(() => {
+    loadSessions();
+  }, [loadSessions]);
+
+  // Auto-refresh every 5 seconds
+  useEffect(() => {
+    const interval = setInterval(() => loadSessions(), 5000);
+    return () => clearInterval(interval);
+  }, [loadSessions]);
+
+  const handleRefresh = () => loadSessions(true);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full py-32">
+        <p className="text-muted-foreground text-sm">Loading...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full py-32 gap-4">
+        <p className="text-red-400 text-sm">{error}</p>
+        <Button variant="outline" size="sm" onClick={handleRefresh}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+        <div className="flex items-center gap-3">
+          <h1 className="text-sm font-semibold">Containers</h1>
+          <span className="text-xs text-muted-foreground">
+            {sessions.length} active
+          </span>
+        </div>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleRefresh}
+          disabled={refreshing}
+          className="h-7 text-xs gap-1"
+        >
+          <RefreshCw className={cn("h-3.5 w-3.5", refreshing && "animate-spin")} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Content */}
+      <ScrollArea className="flex-1">
+        {sessions.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-32 gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <Box className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <div className="text-center">
+              <p className="text-sm font-medium">No active containers</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Containers will appear here when tasks are running
+              </p>
+            </div>
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[140px]">Container</TableHead>
+                <TableHead>Task</TableHead>
+                <TableHead className="w-[140px]">State</TableHead>
+                <TableHead className="w-[140px]">Project</TableHead>
+                <TableHead className="w-[100px] text-right">Uptime</TableHead>
+                <TableHead className="w-[100px] text-right">Started</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sessions.map((session) => (
+                <TableRow key={session.container_id}>
+                  {/* Container ID */}
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <Container className="h-4 w-4 text-muted-foreground shrink-0" />
+                      <span className="font-mono text-xs text-muted-foreground truncate">
+                        {session.container_id.slice(0, 12)}
+                      </span>
+                    </div>
+                  </TableCell>
+
+                  {/* Task title + link */}
+                  <TableCell>
+                    <Link
+                      to={`/tasks/${session.task_id}`}
+                      className="text-sm hover:underline truncate block max-w-[400px]"
+                    >
+                      {session.task_title}
+                    </Link>
+                  </TableCell>
+
+                  {/* Task state */}
+                  <TableCell>
+                    <StateBadge state={session.task_state} />
+                  </TableCell>
+
+                  {/* Project */}
+                  <TableCell>
+                    <span className="text-sm text-muted-foreground">
+                      {session.project_repo
+                        ? session.project_repo.split("/")[1] ?? session.project_repo
+                        : session.project_id.slice(0, 8)}
+                    </span>
+                  </TableCell>
+
+                  {/* Uptime */}
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-1.5">
+                      <Activity className="h-3.5 w-3.5 text-green-500" />
+                      <span className="text-xs font-mono text-muted-foreground">
+                        {formatUptime(session.uptime_secs)}
+                      </span>
+                    </div>
+                  </TableCell>
+
+                  {/* Started at */}
+                  <TableCell className="text-right">
+                    <span className="text-xs text-muted-foreground whitespace-nowrap">
+                      {formatRelativeTime(session.started_at)}
+                    </span>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </ScrollArea>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a new **Containers** page accessible from the sidebar navigation at `/containers`
- Shows all active container sessions with container ID, task info, state, project, uptime, and start time
- Auto-refreshes every 5 seconds to show live container status
- Backend: New `GET /api/sessions` endpoint exposing session info via `SessionManager.session_info()` method

## Implementation

**Backend (Rust):**
- Added `SessionInfoSnapshot` struct to `crates/session/src/manager.rs` with task_id, container_id, and uptime_secs
- Added `session_info()` method to `SessionManager` to return session data
- Added `GET /api/sessions` endpoint in `crates/app/src/web.rs` returning enriched session info with task/project details

**Frontend (React):**
- Added `Session` type in `web/src/lib/types.ts`
- Added `fetchSessions()` function in `web/src/lib/api.ts`
- Created `ContainersPage` component in `web/src/pages/containers/page.tsx` with table view
- Added route in `App.tsx` and navigation link in sidebar

## Limitations

Real-time metrics (CPU, memory, disk usage) are not currently available from the container runtime. The view shows available session metadata including uptime and task state. Future work could extend the runtime to expose resource metrics.

## Test plan

- [ ] Verify `/containers` page loads and shows "No active containers" when no sessions are running
- [ ] Start a task and verify the container appears in the list with correct info
- [ ] Verify auto-refresh updates the uptime counter
- [ ] Verify clicking a task title navigates to the task detail page

Closes #366

---
Generated with [Claude Code](https://claude.com/claude-code)