### PR TITLE
Add automation runs history view with status badges and detail panel

### DIFF
--- a/web/src/pages/automations/automation-runs-panel.tsx
+++ b/web/src/pages/automations/automation-runs-panel.tsx
@@ -1,0 +1,329 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Loader2,
+  X,
+} from "lucide-react";
+import { fetchAutomationRuns } from "@/lib/api";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import type { Automation, AutomationRun } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Run status badge configuration
+// ---------------------------------------------------------------------------
+
+type RunStatus = AutomationRun["status"];
+
+const runStatusConfig: Record<
+  RunStatus,
+  { label: string; icon: React.ElementType; className: string }
+> = {
+  pending: {
+    label: "Pending",
+    icon: Clock,
+    className: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
+  },
+  running: {
+    label: "Running",
+    icon: Loader2,
+    className: "bg-blue-500/20 text-blue-400 border-blue-500/30",
+  },
+  completed: {
+    label: "Completed",
+    icon: Check,
+    className: "bg-green-500/20 text-green-400 border-green-500/30",
+  },
+  failed: {
+    label: "Failed",
+    icon: AlertCircle,
+    className: "bg-red-500/20 text-red-400 border-red-500/30",
+  },
+};
+
+function RunStatusBadge({ status }: { status: RunStatus }) {
+  const config = runStatusConfig[status];
+  const Icon = config.icon;
+  const isRunning = status === "running";
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn("text-xs gap-1 py-0.5", config.className)}
+    >
+      <Icon
+        className={cn("h-3 w-3", isRunning && "animate-spin")}
+      />
+      {config.label}
+    </Badge>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Duration formatting
+// ---------------------------------------------------------------------------
+
+function formatDuration(startedAt: string, completedAt?: string): string {
+  const start = new Date(startedAt).getTime();
+  const end = completedAt ? new Date(completedAt).getTime() : Date.now();
+  const diffMs = end - start;
+
+  if (diffMs < 1000) return "<1s";
+  if (diffMs < 60000) return `${Math.floor(diffMs / 1000)}s`;
+  if (diffMs < 3600000) {
+    const mins = Math.floor(diffMs / 60000);
+    const secs = Math.floor((diffMs % 60000) / 1000);
+    return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
+  }
+  const hours = Math.floor(diffMs / 3600000);
+  const mins = Math.floor((diffMs % 3600000) / 60000);
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+// ---------------------------------------------------------------------------
+// Run detail view
+// ---------------------------------------------------------------------------
+
+function RunDetailView({ run }: { run: AutomationRun }) {
+  const hasOutput = run.output && run.output.trim().length > 0;
+  const hasError = run.error && run.error.trim().length > 0;
+
+  return (
+    <div className="space-y-3 pt-2 pb-1">
+      {/* Timestamps */}
+      <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
+        <div>
+          <span className="font-medium text-foreground/80">Started:</span>{" "}
+          <span title={new Date(run.started_at).toLocaleString()}>
+            {formatRelativeTime(run.started_at)}
+          </span>
+        </div>
+        {run.completed_at && (
+          <div>
+            <span className="font-medium text-foreground/80">Completed:</span>{" "}
+            <span title={new Date(run.completed_at).toLocaleString()}>
+              {formatRelativeTime(run.completed_at)}
+            </span>
+          </div>
+        )}
+        <div>
+          <span className="font-medium text-foreground/80">Duration:</span>{" "}
+          {formatDuration(run.started_at, run.completed_at)}
+        </div>
+      </div>
+
+      {/* Error message */}
+      {hasError && (
+        <div className="space-y-1">
+          <div className="text-xs font-medium text-red-400">Error</div>
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-2">
+            <pre className="text-xs text-red-300 whitespace-pre-wrap break-words font-mono">
+              {run.error}
+            </pre>
+          </div>
+        </div>
+      )}
+
+      {/* Output */}
+      {hasOutput && (
+        <Collapsible defaultOpen={run.status === "completed" && !hasError}>
+          <div className="space-y-1">
+            <CollapsibleTrigger className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors group">
+              <ChevronRight className="h-3 w-3 transition-transform group-data-[state=open]:rotate-90" />
+              Output
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <ScrollArea className="max-h-60 rounded-md border border-border bg-muted/50">
+                <pre className="p-2 text-xs whitespace-pre-wrap break-words font-mono">
+                  {run.output}
+                </pre>
+              </ScrollArea>
+            </CollapsibleContent>
+          </div>
+        </Collapsible>
+      )}
+
+      {/* No output */}
+      {!hasOutput && !hasError && run.status === "completed" && (
+        <div className="text-xs text-muted-foreground italic">
+          No output recorded
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Run row
+// ---------------------------------------------------------------------------
+
+function RunRow({ run }: { run: AutomationRun }) {
+  const [expanded, setExpanded] = useState(false);
+
+  // Auto-expand if this is a running or recently failed run
+  useEffect(() => {
+    if (run.status === "running" || run.status === "failed") {
+      setExpanded(true);
+    }
+  }, [run.status]);
+
+  return (
+    <Collapsible open={expanded} onOpenChange={setExpanded}>
+      <div className="border-b border-border last:border-b-0">
+        <CollapsibleTrigger className="flex items-center gap-3 w-full px-3 py-2 hover:bg-accent/30 transition-colors text-left">
+          <ChevronRight
+            className={cn(
+              "h-3.5 w-3.5 text-muted-foreground transition-transform shrink-0",
+              expanded && "rotate-90"
+            )}
+          />
+          <RunStatusBadge status={run.status} />
+          <span
+            className="text-xs text-muted-foreground flex-1"
+            title={new Date(run.started_at).toLocaleString()}
+          >
+            {formatRelativeTime(run.started_at)}
+          </span>
+          {(run.status === "completed" || run.status === "failed") && (
+            <span className="text-xs text-muted-foreground/70">
+              {formatDuration(run.started_at, run.completed_at)}
+            </span>
+          )}
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="px-3 pb-2 pl-9">
+            <RunDetailView run={run} />
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AutomationRunsPanel
+// ---------------------------------------------------------------------------
+
+interface AutomationRunsPanelProps {
+  automation: Automation;
+  onClose: () => void;
+}
+
+export function AutomationRunsPanel({
+  automation,
+  onClose,
+}: AutomationRunsPanelProps) {
+  const [runs, setRuns] = useState<AutomationRun[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadRuns = useCallback(async () => {
+    try {
+      const data = await fetchAutomationRuns(automation.id);
+      // Sort by started_at descending (most recent first)
+      const sorted = [...data].sort(
+        (a, b) =>
+          new Date(b.started_at).getTime() - new Date(a.started_at).getTime()
+      );
+      setRuns(sorted);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load runs");
+    } finally {
+      setLoading(false);
+    }
+  }, [automation.id]);
+
+  // Initial load
+  useEffect(() => {
+    loadRuns();
+  }, [loadRuns]);
+
+  // Auto-refresh when there are running runs
+  useEffect(() => {
+    const hasRunningRun = runs.some((r) => r.status === "running");
+    if (!hasRunningRun) return;
+
+    const interval = setInterval(loadRuns, 2000);
+    return () => clearInterval(interval);
+  }, [runs, loadRuns]);
+
+  return (
+    <div className="flex flex-col h-full border-l border-border bg-background">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-4 py-2.5 shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <h2 className="text-sm font-semibold truncate">{automation.name}</h2>
+          <span className="text-xs text-muted-foreground shrink-0">
+            Run History
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 shrink-0"
+          onClick={onClose}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Content */}
+      <ScrollArea className="flex-1">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+            <AlertCircle className="h-8 w-8 text-red-400 mb-2" />
+            <p className="text-sm text-red-400">{error}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-3"
+              onClick={() => {
+                setLoading(true);
+                loadRuns();
+              }}
+            >
+              Retry
+            </Button>
+          </div>
+        ) : runs.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+            <Clock className="h-8 w-8 text-muted-foreground mb-2" />
+            <p className="text-sm text-muted-foreground">No runs yet</p>
+            <p className="text-xs text-muted-foreground/70 mt-1">
+              Trigger this automation to see run history
+            </p>
+          </div>
+        ) : (
+          <div>
+            {runs.map((run) => (
+              <RunRow key={run.id} run={run} />
+            ))}
+          </div>
+        )}
+      </ScrollArea>
+
+      {/* Footer with run count */}
+      {!loading && !error && runs.length > 0 && (
+        <div className="border-t border-border px-4 py-2 text-xs text-muted-foreground shrink-0">
+          {runs.length} {runs.length === 1 ? "run" : "runs"}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/automations/index.ts
+++ b/web/src/pages/automations/index.ts
@@ -1,1 +1,3 @@
 export { AutomationFormDialog } from "./automation-form-dialog";
+export { AutomationRunsPanel } from "./automation-runs-panel";
+export { AutomationsPage } from "./page";

--- a/web/src/pages/automations/page.tsx
+++ b/web/src/pages/automations/page.tsx
@@ -2,8 +2,10 @@ import { useState } from "react";
 import {
   Calendar,
   Clock,
+  History,
   MoreHorizontal,
   Pause,
+  Pencil,
   Play,
   PlayCircle,
   Plus,
@@ -33,6 +35,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { Automation, AutomationState } from "@/lib/types";
+import { AutomationRunsPanel } from "./automation-runs-panel";
+import { AutomationFormDialog } from "./automation-form-dialog";
 
 // ---------------------------------------------------------------------------
 // State badge configuration
@@ -89,21 +93,30 @@ function TriggerDisplay({ trigger }: { trigger: Automation["trigger"] }) {
 function AutomationRow({
   automation,
   projectName,
+  isSelected,
+  onSelect,
+  onEdit,
   onRefresh,
 }: {
   automation: Automation;
   projectName: string;
+  isSelected: boolean;
+  onSelect: () => void;
+  onEdit: () => void;
   onRefresh: () => Promise<void>;
 }) {
   const [running, setRunning] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
-  async function handleRun() {
+  async function handleRun(e: React.MouseEvent) {
+    e.stopPropagation();
     setRunning(true);
     try {
       await triggerAutomation(automation.id);
       await onRefresh();
+      // Select this automation to show the new run
+      onSelect();
     } catch (error) {
       console.error("Failed to run automation:", error);
     } finally {
@@ -136,7 +149,13 @@ function AutomationRow({
 
   return (
     <>
-      <div className="flex items-center gap-4 px-4 py-3 border-b border-border hover:bg-accent/30 transition-colors">
+      <div
+        className={cn(
+          "flex items-center gap-4 px-4 py-3 border-b border-border hover:bg-accent/30 transition-colors cursor-pointer",
+          isSelected && "bg-accent/50"
+        )}
+        onClick={onSelect}
+      >
         {/* Icon */}
         <div className="flex h-8 w-8 items-center justify-center rounded-md bg-accent shrink-0">
           <Workflow className="h-4 w-4 text-muted-foreground" />
@@ -161,7 +180,7 @@ function AutomationRow({
         </div>
 
         {/* Actions */}
-        <div className="flex items-center gap-1 shrink-0">
+        <div className="flex items-center gap-1 shrink-0" onClick={(e) => e.stopPropagation()}>
           <Button
             variant="ghost"
             size="icon"
@@ -180,6 +199,15 @@ function AutomationRow({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={onSelect}>
+                <History className="mr-2 h-3.5 w-3.5" />
+                View Runs
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onEdit}>
+                <Pencil className="mr-2 h-3.5 w-3.5" />
+                Edit
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem onClick={handleToggleState}>
                 {automation.state === "active" ? (
                   <>
@@ -260,52 +288,107 @@ export function AutomationsPage() {
   const { filteredAutomations, selectedProject, snapshot, refreshAutomations } = useAppState();
   const projects = snapshot?.projects ?? [];
 
+  // State for selected automation (to show runs panel)
+  const [selectedAutomation, setSelectedAutomation] = useState<Automation | null>(null);
+  // State for form dialog
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingAutomation, setEditingAutomation] = useState<Automation | undefined>(undefined);
+
   // Map project IDs to repo names
   const projectIdToRepo: Record<string, string> = {};
   for (const p of projects) {
     projectIdToRepo[p.id] = p.repo;
   }
 
-  const projectName = selectedProject
-    ? projectIdToRepo[selectedProject] ?? "Project"
-    : "All Projects";
+  // Keep selected automation in sync with latest data
+  const currentSelectedAutomation = selectedAutomation
+    ? filteredAutomations.find((a) => a.id === selectedAutomation.id) ?? null
+    : null;
+
+  function handleOpenCreate() {
+    setEditingAutomation(undefined);
+    setFormOpen(true);
+  }
+
+  function handleOpenEdit(automation: Automation) {
+    setEditingAutomation(automation);
+    setFormOpen(true);
+  }
+
+  function handleFormSuccess() {
+    refreshAutomations();
+  }
 
   return (
-    <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
-        <div className="flex items-center gap-3">
-          <h1 className="text-sm font-semibold">
-            {selectedProject ? projectIdToRepo[selectedProject] ?? "Automations" : "Automations"}
-          </h1>
-          <span className="text-xs text-muted-foreground">
-            {filteredAutomations.length} {filteredAutomations.length === 1 ? "automation" : "automations"}
-          </span>
+    <div className="flex h-full">
+      {/* Main list */}
+      <div className={cn(
+        "flex flex-col h-full transition-all",
+        currentSelectedAutomation ? "flex-1" : "w-full"
+      )}>
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+          <div className="flex items-center gap-3">
+            <h1 className="text-sm font-semibold">
+              {selectedProject ? projectIdToRepo[selectedProject] ?? "Automations" : "Automations"}
+            </h1>
+            <span className="text-xs text-muted-foreground">
+              {filteredAutomations.length} {filteredAutomations.length === 1 ? "automation" : "automations"}
+            </span>
+          </div>
+
+          <Button
+            size="sm"
+            className="h-7 text-xs gap-1"
+            onClick={handleOpenCreate}
+            disabled={projects.length === 0}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New Automation
+          </Button>
         </div>
 
-        <Button size="sm" className="h-7 text-xs gap-1" disabled>
-          <Plus className="h-3.5 w-3.5" />
-          New Automation
-        </Button>
+        {/* List */}
+        <ScrollArea className="flex-1">
+          {filteredAutomations.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <div>
+              {filteredAutomations.map((automation) => (
+                <AutomationRow
+                  key={automation.id}
+                  automation={automation}
+                  projectName={projectIdToRepo[automation.project_id] ?? automation.project_id}
+                  isSelected={currentSelectedAutomation?.id === automation.id}
+                  onSelect={() => setSelectedAutomation(automation)}
+                  onEdit={() => handleOpenEdit(automation)}
+                  onRefresh={refreshAutomations}
+                />
+              ))}
+            </div>
+          )}
+        </ScrollArea>
       </div>
 
-      {/* List */}
-      <ScrollArea className="flex-1">
-        {filteredAutomations.length === 0 ? (
-          <EmptyState />
-        ) : (
-          <div>
-            {filteredAutomations.map((automation) => (
-              <AutomationRow
-                key={automation.id}
-                automation={automation}
-                projectName={projectIdToRepo[automation.project_id] ?? automation.project_id}
-                onRefresh={refreshAutomations}
-              />
-            ))}
-          </div>
-        )}
-      </ScrollArea>
+      {/* Runs panel (side drawer) */}
+      {currentSelectedAutomation && (
+        <div className="w-96 shrink-0">
+          <AutomationRunsPanel
+            automation={currentSelectedAutomation}
+            onClose={() => setSelectedAutomation(null)}
+          />
+        </div>
+      )}
+
+      {/* Create/Edit dialog */}
+      <AutomationFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        projects={projects}
+        selectedProjectId={selectedProject ?? undefined}
+        automation={editingAutomation}
+        onSuccess={handleFormSuccess}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add `AutomationRunsPanel` component displaying run history for each automation
- Color-coded status badges: pending (yellow), running (blue with pulse animation), completed (green), failed (red)
- Relative timestamps with hover tooltip showing absolute time
- Duration display for completed and failed runs
- Collapsible output sections with full output/error viewing
- Auto-refresh every 2 seconds when runs are in progress
- Clickable automation rows to open runs panel
- Added View Runs and Edit menu options
- Enabled New Automation button with form dialog

## Test plan

- [ ] Click on an automation in the list to see the runs panel
- [ ] Verify status badges display correct colors for each run status
- [ ] Hover over timestamps to see absolute time tooltip
- [ ] Check that running automation shows pulse animation and auto-refreshes
- [ ] Click on a run to expand and see full output/error
- [ ] Trigger an automation and verify new run appears in the panel
- [ ] Test Edit option opens the automation form dialog
- [ ] Verify New Automation button creates new automations

Closes #389

---
Generated with [Claude Code](https://claude.ai/code)