### PR TITLE
Refresh runs panel after triggering automation

### DIFF
--- a/web/src/pages/automations/automation-runs-panel.tsx
+++ b/web/src/pages/automations/automation-runs-panel.tsx
@@ -218,11 +218,14 @@ function RunRow({ run }: { run: AutomationRun }) {
 interface AutomationRunsPanelProps {
   automation: Automation;
   onClose: () => void;
+  /** Increment this to trigger a refresh (e.g., after triggering a run) */
+  refreshKey?: number;
 }
 
 export function AutomationRunsPanel({
   automation,
   onClose,
+  refreshKey,
 }: AutomationRunsPanelProps) {
   const [runs, setRuns] = useState<AutomationRun[]>([]);
   const [loading, setLoading] = useState(true);
@@ -245,10 +248,10 @@ export function AutomationRunsPanel({
     }
   }, [automation.id]);
 
-  // Initial load
+  // Initial load and refresh when refreshKey changes
   useEffect(() => {
     loadRuns();
-  }, [loadRuns]);
+  }, [loadRuns, refreshKey]);
 
   // Auto-refresh when there are running runs
   useEffect(() => {

--- a/web/src/pages/automations/page.tsx
+++ b/web/src/pages/automations/page.tsx
@@ -97,6 +97,7 @@ function AutomationRow({
   onSelect,
   onEdit,
   onRefresh,
+  onRunTriggered,
 }: {
   automation: Automation;
   projectName: string;
@@ -104,6 +105,7 @@ function AutomationRow({
   onSelect: () => void;
   onEdit: () => void;
   onRefresh: () => Promise<void>;
+  onRunTriggered: () => void;
 }) {
   const [running, setRunning] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -117,6 +119,8 @@ function AutomationRow({
       await onRefresh();
       // Select this automation to show the new run
       onSelect();
+      // Signal that a run was triggered to refresh the runs panel
+      onRunTriggered();
     } catch (error) {
       console.error("Failed to run automation:", error);
     } finally {
@@ -293,6 +297,8 @@ export function AutomationsPage() {
   // State for form dialog
   const [formOpen, setFormOpen] = useState(false);
   const [editingAutomation, setEditingAutomation] = useState<Automation | undefined>(undefined);
+  // Key to trigger runs panel refresh after triggering an automation
+  const [runsRefreshKey, setRunsRefreshKey] = useState(0);
 
   // Map project IDs to repo names
   const projectIdToRepo: Record<string, string> = {};
@@ -363,6 +369,7 @@ export function AutomationsPage() {
                   onSelect={() => setSelectedAutomation(automation)}
                   onEdit={() => handleOpenEdit(automation)}
                   onRefresh={refreshAutomations}
+                  onRunTriggered={() => setRunsRefreshKey((k) => k + 1)}
                 />
               ))}
             </div>
@@ -376,6 +383,7 @@ export function AutomationsPage() {
           <AutomationRunsPanel
             automation={currentSelectedAutomation}
             onClose={() => setSelectedAutomation(null)}
+            refreshKey={runsRefreshKey}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary

- Adds `refreshKey` prop to `AutomationRunsPanel` that triggers a re-fetch when incremented
- When an automation is triggered via the Run button, the runs panel now immediately refreshes to show the new "running" run
- The existing auto-refresh logic (every 2 seconds while a run is running) continues to update the panel until the run completes

## How it works

1. User clicks Run button on an automation
2. `handleRun()` triggers the automation via API (creates a run with "running" status)
3. After triggering, `onRunTriggered()` increments `runsRefreshKey`
4. `AutomationRunsPanel` receives the new `refreshKey` value
5. The `useEffect` triggers `loadRuns()` because `refreshKey` changed
6. The panel displays runs including the new "running" entry with spinner

## Test plan

- [ ] Open an automation's runs panel
- [ ] Click the Run button on that automation
- [ ] Verify a new run appears immediately with "Running" status and spinner
- [ ] Wait for the run to complete and verify status updates to "Completed" or "Failed"

Fixes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)