### PR TITLE
Fix automation runs panel to show running state immediately

### DIFF
--- a/web/src/pages/automations/automation-runs-panel.tsx
+++ b/web/src/pages/automations/automation-runs-panel.tsx
@@ -218,11 +218,14 @@ function RunRow({ run }: { run: AutomationRun }) {
 interface AutomationRunsPanelProps {
   automation: Automation;
   onClose: () => void;
+  /** Increment to force an immediate refresh of runs */
+  refreshKey?: number;
 }
 
 export function AutomationRunsPanel({
   automation,
   onClose,
+  refreshKey,
 }: AutomationRunsPanelProps) {
   const [runs, setRuns] = useState<AutomationRun[]>([]);
   const [loading, setLoading] = useState(true);
@@ -245,15 +248,19 @@ export function AutomationRunsPanel({
     }
   }, [automation.id]);
 
-  // Initial load + regular polling
-  // Always poll so new runs appear even if triggered externally.
-  // Poll faster (2s) when a run is in progress, otherwise every 5s.
+  // Compute whether there's a running run for dynamic polling interval
+  const hasRunningRun = runs.some((r) => r.status === "running");
+
+  // Initial load on mount and when refreshKey changes (after trigger)
   useEffect(() => {
     loadRuns();
-    const hasRunningRun = runs.some((r) => r.status === "running");
+  }, [loadRuns, refreshKey]);
+
+  // Polling: faster when a run is in progress, otherwise slower
+  useEffect(() => {
     const interval = setInterval(loadRuns, hasRunningRun ? 2000 : 5000);
     return () => clearInterval(interval);
-  }, [runs, loadRuns]);
+  }, [hasRunningRun, loadRuns]);
 
   return (
     <div className="flex flex-col h-full border-l border-border bg-background">

--- a/web/src/pages/automations/page.tsx
+++ b/web/src/pages/automations/page.tsx
@@ -111,6 +111,7 @@ function AutomationRow({
   onSelect,
   onEdit,
   onRefresh,
+  onRunTriggered,
 }: {
   automation: Automation;
   projectName: string;
@@ -118,6 +119,7 @@ function AutomationRow({
   onSelect: () => void;
   onEdit: () => void;
   onRefresh: () => Promise<void>;
+  onRunTriggered?: () => void;
 }) {
   const [running, setRunning] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -131,6 +133,8 @@ function AutomationRow({
       await onRefresh();
       // Select this automation to show the new run
       onSelect();
+      // Notify parent to refresh the runs panel
+      onRunTriggered?.();
     } catch (error) {
       console.error("Failed to run automation:", error);
     } finally {
@@ -296,6 +300,8 @@ export function AutomationsPage() {
   // State for form dialog
   const [formOpen, setFormOpen] = useState(false);
   const [editingAutomation, setEditingAutomation] = useState<Automation | undefined>(undefined);
+  // Counter to force runs panel refresh after triggering
+  const [runsRefreshKey, setRunsRefreshKey] = useState(0);
 
   // Map project IDs to repo names
   const projectIdToRepo: Record<string, string> = {};
@@ -357,6 +363,7 @@ export function AutomationsPage() {
             onSelect={() => setSelectedAutomation(automation)}
             onEdit={() => handleOpenEdit(automation)}
             onRefresh={refreshAutomations}
+            onRunTriggered={() => setRunsRefreshKey((k) => k + 1)}
           />
         ))}
       </div>
@@ -367,6 +374,7 @@ export function AutomationsPage() {
     <AutomationRunsPanel
       automation={currentSelectedAutomation}
       onClose={() => setSelectedAutomation(null)}
+      refreshKey={runsRefreshKey}
     />
   ) : undefined;
 


### PR DESCRIPTION
## Summary

- Fix polling logic in `AutomationRunsPanel` that incorrectly depended on `runs` state, which could cause constant re-execution of the effect
- Add `refreshKey` prop that triggers immediate refresh when a run is triggered
- Wire up notification from `AutomationRow` to the parent so the runs panel refreshes instantly after clicking run

## Problem

When triggering an automation, the run history panel would show "No runs yet" until the next polling cycle (up to 5 seconds), giving users no feedback that anything was happening.

## Solution

1. **Fixed polling useEffect bug**: The previous code had `runs` in the dependency array, which meant every time runs were fetched and state was updated, the effect would re-run. Split into two effects:
   - One for initial load and manual refresh triggers
   - One for setting up the polling interval

2. **Added immediate refresh mechanism**: When user clicks the run button:
   - `triggerAutomation()` creates the run on the backend
   - `onRunTriggered()` callback increments `runsRefreshKey` in parent
   - Panel's effect triggers on `refreshKey` change, immediately fetching latest runs

## Test plan

- [ ] Trigger an automation and verify the run appears immediately in the history panel
- [ ] Verify the "Running" badge with spinner is visible while execution is in progress
- [ ] Verify polling continues and updates to "Completed" or "Failed" when done
- [ ] Verify the panel doesn't constantly re-fetch (check network tab)

Fixes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)