### PR TITLE
Fix project filtering UX: stay on current page when selecting project

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { NavLink, Outlet } from "react-router-dom";
 import {
   LayoutDashboard,
   ListTodo,
@@ -162,7 +162,6 @@ function SidebarNavItem({
 
 function ProjectList() {
   const { snapshot, refreshSnapshot, selectedProject, setSelectedProject } = useAppState();
-  const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(true);
   const [addOpen, setAddOpen] = useState(false);
   const [newRepo, setNewRepo] = useState("");
@@ -222,7 +221,7 @@ function ProjectList() {
     } else {
       setSelectedProject(projectId);
     }
-    navigate("/tasks");
+    // Don't navigate - let the user filter the current page
   };
 
   const handleBootstrap = async () => {
@@ -309,7 +308,6 @@ function ProjectList() {
           <button
             onClick={() => {
               setSelectedProject(null);
-              navigate("/tasks");
             }}
             className={cn(
               "flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors",


### PR DESCRIPTION
## Summary

- Fixed the sidebar project selection behavior to stay on the current page instead of navigating to Tasks
- This allows users to filter automations, tasks, and merge queue by project from whichever page they're viewing
- Removed unused `useNavigate` import after the change

## Context

Previously, clicking a project in the sidebar would always navigate to `/tasks`, making it awkward to filter automations by project. The filtering logic already existed in `useAppState()` (via `filteredAutomations`), but the navigation made it hard to use.

## Test plan

- [ ] Navigate to the Automations page
- [ ] Click on a project in the sidebar
- [ ] Verify you stay on Automations and the list is filtered to that project's automations
- [ ] Click "All Projects" and verify the filter is cleared
- [ ] Repeat for Tasks and Merge Queue pages

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)