### PR TITLE
Add automation run detail page with chat/event view

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -92,6 +92,8 @@ pub fn router(state: ApiState) -> Router {
         .route("/automations/{id}", axum::routing::patch(update_automation))
         .route("/automations/{id}", axum::routing::delete(delete_automation))
         .route("/automations/{id}/runs", get(list_automation_runs))
+        .route("/automations/{id}/runs/{run_id}", get(get_automation_run))
+        .route("/automations/{id}/runs/{run_id}/events", get(get_automation_run_events))
         .route("/automations/{id}/run", post(trigger_automation));
 
     Router::new()
@@ -1475,6 +1477,68 @@ async fn list_automation_runs(
         .map_err(ApiError::Server)?;
 
     Ok(Json(runs))
+}
+
+/// Path parameters for automation run endpoints.
+#[derive(Deserialize)]
+struct AutomationRunPath {
+    id: String,
+    run_id: String,
+}
+
+/// GET /api/automations/:id/runs/:run_id — Get a specific automation run.
+async fn get_automation_run(
+    State(state): State<ApiState>,
+    Path(params): Path<AutomationRunPath>,
+) -> Result<Json<models::automation::AutomationRun>, ApiError> {
+    // Verify automation exists
+    {
+        let server_state = state.server.state.read().await;
+        if !server_state.automations.contains_key(&params.id) {
+            return Err(ApiError::NotFound(format!("automation not found: {}", params.id)));
+        }
+    }
+
+    // Get all runs and find the requested one
+    let runs = state
+        .server
+        .list_automation_runs(&params.id)
+        .map_err(ApiError::Server)?;
+
+    let run = runs
+        .into_iter()
+        .find(|r| r.id == params.run_id)
+        .ok_or_else(|| ApiError::NotFound(format!("run not found: {}", params.run_id)))?;
+
+    Ok(Json(run))
+}
+
+/// GET /api/automations/:id/runs/:run_id/events — Get events for an automation run.
+///
+/// Returns events from the automation run's session. The session ID uses the
+/// format `automation-run:{run_id}` for container sessions.
+async fn get_automation_run_events(
+    State(state): State<ApiState>,
+    Path(params): Path<AutomationRunPath>,
+) -> Result<Json<Vec<events::Event>>, ApiError> {
+    // Verify automation exists
+    {
+        let server_state = state.server.state.read().await;
+        if !server_state.automations.contains_key(&params.id) {
+            return Err(ApiError::NotFound(format!("automation not found: {}", params.id)));
+        }
+    }
+
+    // For container sessions, the task ID is "automation-run:{run_id}"
+    let session_id = format!("automation-run:{}", params.run_id);
+
+    state
+        .server
+        .event_bus
+        .read_task(&session_id)
+        .await
+        .map(Json)
+        .map_err(|e| ApiError::Server(server::ServerError::EventStore(e)))
 }
 
 /// POST /api/automations/:id/run — Manually trigger an automation run.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { TaskDetailPage } from "@/pages/task-detail";
 import { MergeQueuePage } from "@/pages/merge-queue/page";
 import { ContainersPage } from "@/pages/containers/page";
 import { AutomationsPage } from "@/pages/automations/page";
+import { AutomationRunDetailPage } from "@/pages/automations/automation-run-detail";
 import { OrchestratorPage } from "@/pages/orchestrator/page";
 import { EventsPage } from "@/pages/events/page";
 
@@ -21,6 +22,7 @@ export function App() {
           <Route path="/merge-queue" element={<MergeQueuePage />} />
           <Route path="/containers" element={<ContainersPage />} />
           <Route path="/automations" element={<AutomationsPage />} />
+          <Route path="/automations/:automationId/runs/:runId" element={<AutomationRunDetailPage />} />
           <Route path="/orchestrator" element={<OrchestratorPage />} />
           <Route path="/events" element={<EventsPage />} />
         </Route>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -311,3 +311,21 @@ export function triggerAutomation(id: string): Promise<AutomationRun> {
     method: "POST",
   });
 }
+
+export function fetchAutomationRun(
+  automationId: string,
+  runId: string
+): Promise<AutomationRun> {
+  return request<AutomationRun>(
+    `/api/automations/${automationId}/runs/${runId}`
+  );
+}
+
+export function fetchAutomationRunEvents(
+  automationId: string,
+  runId: string
+): Promise<Event[]> {
+  return request<Event[]>(
+    `/api/automations/${automationId}/runs/${runId}/events`
+  );
+}

--- a/web/src/pages/automations/automation-run-detail.tsx
+++ b/web/src/pages/automations/automation-run-detail.tsx
@@ -1,0 +1,826 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  AlertCircle,
+  Bot,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  FileText,
+  Loader2,
+  StopCircle,
+  Terminal,
+  User,
+  RotateCcw,
+  MessageSquare,
+  Workflow,
+} from "lucide-react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import {
+  fetchAutomationRun,
+  fetchAutomationRunEvents,
+  fetchAutomations,
+  subscribeEvents,
+} from "@/lib/api";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { Automation, AutomationRun, Event } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Run status badge
+// ---------------------------------------------------------------------------
+
+type RunStatus = AutomationRun["status"];
+
+const runStatusConfig: Record<
+  RunStatus,
+  { label: string; icon: React.ElementType; className: string }
+> = {
+  pending: {
+    label: "Pending",
+    icon: Clock,
+    className: "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
+  },
+  running: {
+    label: "Running",
+    icon: Loader2,
+    className: "bg-blue-500/20 text-blue-400 border-blue-500/30",
+  },
+  completed: {
+    label: "Completed",
+    icon: Check,
+    className: "bg-green-500/20 text-green-400 border-green-500/30",
+  },
+  failed: {
+    label: "Failed",
+    icon: AlertCircle,
+    className: "bg-red-500/20 text-red-400 border-red-500/30",
+  },
+};
+
+function RunStatusBadge({ status }: { status: RunStatus }) {
+  const config = runStatusConfig[status];
+  const Icon = config.icon;
+  const isRunning = status === "running";
+
+  return (
+    <Badge variant="outline" className={cn("gap-1", config.className)}>
+      <Icon className={cn("h-3.5 w-3.5", isRunning && "animate-spin")} />
+      {config.label}
+    </Badge>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Parse agent events (same as task-detail.tsx)
+// ---------------------------------------------------------------------------
+
+interface ParsedBlock {
+  kind:
+    | "text"
+    | "thinking"
+    | "tool_use"
+    | "tool_result"
+    | "error"
+    | "system"
+    | "lifecycle"
+    | "human_message"
+    | "session_boundary";
+  content: string;
+  toolName?: string;
+  filePath?: string;
+  timestamp?: string;
+}
+
+const lifecycleLabels: Record<string, string> = {
+  "task:created": "Run started",
+  "task:state:running": "Agent started",
+  "task:state:question": "Agent has a question",
+  "task:state:waiting": "Run waiting",
+  "task:state:blocked": "Run blocked",
+  "task:state:testing": "Running tests",
+  "task:state:completed": "Run completed",
+  "task:state:failed": "Run failed",
+  "task:state:cancelled": "Run cancelled",
+};
+
+function parseAgentEvents(events: Event[]): ParsedBlock[] {
+  const blocks: ParsedBlock[] = [];
+  let runningCount = 0;
+
+  for (const event of events) {
+    if (event.type === "task:state:running") {
+      runningCount++;
+      if (runningCount > 1) {
+        blocks.push({
+          kind: "session_boundary",
+          content: "New session started (retry)",
+          timestamp: event.ts,
+        });
+      }
+    }
+
+    if (event.type.startsWith("task:")) {
+      const label = lifecycleLabels[event.type];
+      if (label) {
+        blocks.push({ kind: "lifecycle", content: label, timestamp: event.ts });
+      }
+      continue;
+    }
+
+    if (event.type === "human:message") {
+      const message = event.data?.message as string | undefined;
+      if (message) {
+        blocks.push({
+          kind: "human_message",
+          content: message,
+          timestamp: event.ts,
+        });
+      }
+      continue;
+    }
+
+    if (event.type === "agent:error") {
+      blocks.push({
+        kind: "error",
+        content:
+          typeof event.data?.text === "string"
+            ? event.data.text
+            : JSON.stringify(event.data),
+        timestamp: event.ts,
+      });
+      continue;
+    }
+
+    const raw = event.data?.text;
+    if (typeof raw !== "string") continue;
+
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      if (raw.trim()) blocks.push({ kind: "text", content: raw });
+      continue;
+    }
+
+    if (msg.type === "system") continue;
+
+    if (msg.type === "result") {
+      const result = msg.result as Record<string, unknown> | undefined;
+      if (typeof result?.text === "string" && result.text) {
+        blocks.push({ kind: "text", content: result.text });
+      }
+      continue;
+    }
+
+    const message = msg.message as Record<string, unknown> | undefined;
+    const contentBlocks = (message?.content ?? msg.content) as
+      | unknown[]
+      | undefined;
+    if (!Array.isArray(contentBlocks)) continue;
+
+    for (const block of contentBlocks) {
+      if (typeof block !== "object" || block === null) continue;
+      const b = block as Record<string, unknown>;
+
+      if (b.type === "thinking") continue;
+
+      if (b.type === "text" && typeof b.text === "string") {
+        if (b.text.trim()) {
+          blocks.push({ kind: "text", content: b.text, timestamp: event.ts });
+        }
+        continue;
+      }
+
+      if (b.type === "tool_use") {
+        const name = typeof b.name === "string" ? b.name : "tool";
+        const input = (b.input ?? {}) as Record<string, unknown>;
+        const filePath =
+          input.file_path ?? input.filePath ?? input.path ?? input.pattern;
+        const command = input.command;
+        const description = input.description;
+        const detail = filePath ?? command ?? description;
+        blocks.push({
+          kind: "tool_use",
+          content: detail ? String(detail) : "",
+          toolName: name,
+          filePath: filePath ? String(filePath) : undefined,
+          timestamp: event.ts,
+        });
+        continue;
+      }
+
+      if (b.type === "tool_result") {
+        const content = typeof b.content === "string" ? b.content : "";
+        if (!content) continue;
+        const lines = content.split("\n");
+        const preview =
+          lines.length > 30
+            ? lines.slice(0, 25).join("\n") +
+              `\n... (${lines.length} total lines)`
+            : content;
+        blocks.push({
+          kind: "tool_result",
+          content: preview,
+          timestamp: event.ts,
+        });
+        continue;
+      }
+    }
+  }
+
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Block view components
+// ---------------------------------------------------------------------------
+
+function formatMessageTime(ts?: string): string | null {
+  if (!ts) return null;
+  try {
+    return new Date(ts).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return null;
+  }
+}
+
+function ToolResultBlock({ block }: { block: ParsedBlock }) {
+  const [open, setOpen] = useState(false);
+  const isLong = block.content.split("\n").length > 5;
+  return (
+    <div className="rounded-md border border-border bg-muted/50 text-sm overflow-hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2 px-3 py-1.5 w-full text-left text-muted-foreground text-sm hover:bg-muted/80"
+      >
+        <FileText className="h-3 w-3 shrink-0" />
+        <span>Output</span>
+        {isLong &&
+          (open ? (
+            <ChevronDown className="h-3 w-3 ml-auto" />
+          ) : (
+            <ChevronRight className="h-3 w-3 ml-auto" />
+          ))}
+      </button>
+      {(open || !isLong) && (
+        <pre className="px-3 py-2 text-sm font-mono overflow-x-auto whitespace-pre-wrap max-h-64 overflow-y-auto text-muted-foreground border-t border-border">
+          {block.content}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function BlockView({ block }: { block: ParsedBlock }) {
+  const timestamp = formatMessageTime(block.timestamp);
+
+  if (block.kind === "human_message") {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[80%] flex flex-col items-end gap-1">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>You</span>
+            <User className="h-3 w-3" />
+          </div>
+          <div className="rounded-lg bg-blue-600 px-3 py-2 text-sm text-white">
+            {block.content}
+          </div>
+          {timestamp && (
+            <span className="text-xs text-muted-foreground">{timestamp}</span>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (block.kind === "session_boundary") {
+    return (
+      <div className="flex items-center gap-2 py-3 text-sm text-yellow-500">
+        <div className="h-px flex-1 bg-yellow-500/30" />
+        <RotateCcw className="h-4 w-4" />
+        <span className="font-medium">{block.content}</span>
+        <div className="h-px flex-1 bg-yellow-500/30" />
+      </div>
+    );
+  }
+
+  if (block.kind === "tool_use") {
+    return (
+      <div className="flex items-center gap-2 py-1 text-muted-foreground text-sm">
+        <Terminal className="h-3 w-3 shrink-0" />
+        <span className="font-medium">{block.toolName}</span>
+        {block.content && (
+          <span className="font-mono truncate">{block.content}</span>
+        )}
+      </div>
+    );
+  }
+
+  if (block.kind === "tool_result") {
+    return <ToolResultBlock block={block} />;
+  }
+
+  if (block.kind === "lifecycle") {
+    return (
+      <div className="flex items-center gap-2 py-1.5 text-sm text-muted-foreground">
+        <div className="h-px flex-1 bg-border" />
+        <span>{block.content}</span>
+        <div className="h-px flex-1 bg-border" />
+      </div>
+    );
+  }
+
+  if (block.kind === "error") {
+    return (
+      <div className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+        {block.content}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-2">
+      <div className="shrink-0 mt-1">
+        <div className="flex items-center justify-center h-6 w-6 rounded-full bg-muted">
+          <Bot className="h-3.5 w-3.5 text-muted-foreground" />
+        </div>
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="prose prose-sm prose-invert max-w-none">
+          <Markdown remarkPlugins={[remarkGfm]}>{block.content}</Markdown>
+        </div>
+        {timestamp && (
+          <span className="text-xs text-muted-foreground mt-1 block">
+            {timestamp}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Session view
+// ---------------------------------------------------------------------------
+
+function SessionView({ automationId, runId }: { automationId: string; runId: string }) {
+  const [rawEvents, setRawEvents] = useState<Event[]>([]);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  const [hasNewMessages, setHasNewMessages] = useState(false);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // The session ID for automation runs is "automation-run:{run_id}"
+  const sessionId = `automation-run:${runId}`;
+
+  useEffect(() => {
+    const isRelevant = (e: Event) =>
+      e.type === "agent:message" ||
+      e.type === "agent:question" ||
+      e.type === "agent:error" ||
+      e.type === "human:message" ||
+      e.type.startsWith("task:");
+
+    fetchAutomationRunEvents(automationId, runId).then((events) => {
+      setRawEvents(events.filter(isRelevant).sort((a, b) => a.ts.localeCompare(b.ts)));
+    });
+
+    // Subscribe to live events using the session ID
+    const source = subscribeEvents({ task_id: sessionId });
+    source.onmessage = (msg) => {
+      try {
+        const event: Event = JSON.parse(msg.data);
+        if (isRelevant(event)) {
+          setRawEvents((prev) => [...prev, event]);
+        }
+      } catch {
+        // ignore
+      }
+    };
+    return () => source.close();
+  }, [automationId, runId, sessionId]);
+
+  const blocks = parseAgentEvents(rawEvents);
+  const prevBlocksLength = useRef(blocks.length);
+
+  const checkIfAtBottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return true;
+    return (
+      container.scrollHeight - container.scrollTop - container.clientHeight <=
+      50
+    );
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    const atBottom = checkIfAtBottom();
+    setIsAtBottom(atBottom);
+    if (atBottom) setHasNewMessages(false);
+  }, [checkIfAtBottom]);
+
+  useEffect(() => {
+    if (blocks.length > prevBlocksLength.current) {
+      if (isAtBottom) {
+        bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+      } else {
+        setHasNewMessages(true);
+      }
+    }
+    prevBlocksLength.current = blocks.length;
+  }, [blocks.length, isAtBottom]);
+
+  const scrollToBottom = useCallback(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    setHasNewMessages(false);
+    setIsAtBottom(true);
+  }, []);
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      {/* Message stream */}
+      <div className="relative flex-1 min-h-0">
+        <div
+          ref={scrollContainerRef}
+          onScroll={handleScroll}
+          className="absolute inset-0 overflow-y-auto p-4 space-y-2"
+        >
+          {blocks.length === 0 && (
+            <p className="text-muted-foreground text-center py-8 text-sm">
+              No agent output yet.
+            </p>
+          )}
+          {blocks.map((block, i) => (
+            <BlockView key={i} block={block} />
+          ))}
+          <div ref={bottomRef} />
+        </div>
+        {hasNewMessages && (
+          <button
+            onClick={scrollToBottom}
+            className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-blue-600 text-white text-sm font-medium shadow-lg hover:bg-blue-700 transition-colors"
+          >
+            <ChevronDown className="h-4 w-4" />
+            New messages
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Duration formatting
+// ---------------------------------------------------------------------------
+
+function formatDuration(startedAt: string, completedAt?: string): string {
+  const start = new Date(startedAt).getTime();
+  const end = completedAt ? new Date(completedAt).getTime() : Date.now();
+  const diffMs = end - start;
+
+  if (diffMs < 1000) return "<1s";
+  if (diffMs < 60000) return `${Math.floor(diffMs / 1000)}s`;
+  if (diffMs < 3600000) {
+    const mins = Math.floor(diffMs / 60000);
+    const secs = Math.floor((diffMs % 60000) / 1000);
+    return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
+  }
+  const hours = Math.floor(diffMs / 3600000);
+  const mins = Math.floor((diffMs % 3600000) / 60000);
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+// ---------------------------------------------------------------------------
+// Properties sidebar
+// ---------------------------------------------------------------------------
+
+function PropertyRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-2 group">
+      <span className="text-sm text-muted-foreground shrink-0">{label}</span>
+      <div className="text-sm text-right min-w-0 flex items-center justify-end">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function PropertiesSidebar({
+  automation,
+  run,
+}: {
+  automation: Automation;
+  run: AutomationRun;
+}) {
+  return (
+    <div className="space-y-1">
+      <PropertyRow label="Status">
+        <RunStatusBadge status={run.status} />
+      </PropertyRow>
+
+      <PropertyRow label="Automation">
+        <Link
+          to="/automations"
+          className="text-blue-400 hover:underline text-sm truncate"
+        >
+          {automation.name}
+        </Link>
+      </PropertyRow>
+
+      <PropertyRow label="Started">
+        <span className="text-xs text-muted-foreground">
+          {formatRelativeTime(run.started_at)}
+        </span>
+      </PropertyRow>
+
+      {run.completed_at && (
+        <PropertyRow label="Completed">
+          <span className="text-xs text-muted-foreground">
+            {formatRelativeTime(run.completed_at)}
+          </span>
+        </PropertyRow>
+      )}
+
+      <PropertyRow label="Duration">
+        <span className="text-xs text-muted-foreground">
+          {formatDuration(run.started_at, run.completed_at)}
+        </span>
+      </PropertyRow>
+
+      <PropertyRow label="Run ID">
+        <span className="font-mono text-xs text-muted-foreground">
+          {run.id.slice(0, 12)}
+        </span>
+      </PropertyRow>
+
+      {/* Error display */}
+      {run.error && (
+        <>
+          <div className="h-px bg-border my-3" />
+          <div className="text-xs font-medium text-red-400 mb-2">Error</div>
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-2">
+            <pre className="text-xs text-red-300 whitespace-pre-wrap break-words font-mono">
+              {run.error}
+            </pre>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Run Details Tab
+// ---------------------------------------------------------------------------
+
+function RunDetailsTab({ run }: { run: AutomationRun }) {
+  const hasOutput = run.output && run.output.trim().length > 0;
+  const hasError = run.error && run.error.trim().length > 0;
+
+  return (
+    <div className="p-4 space-y-4">
+      {/* Error message */}
+      {hasError && (
+        <div className="space-y-1">
+          <div className="text-sm font-medium text-red-400">Error</div>
+          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3">
+            <pre className="text-sm text-red-300 whitespace-pre-wrap break-words font-mono">
+              {run.error}
+            </pre>
+          </div>
+        </div>
+      )}
+
+      {/* Output */}
+      {hasOutput && (
+        <div className="space-y-1">
+          <div className="text-sm font-medium text-muted-foreground">Output</div>
+          <div className="rounded-md border border-border bg-muted/50 p-3 max-h-96 overflow-auto">
+            <pre className="text-sm whitespace-pre-wrap break-words font-mono">
+              {run.output}
+            </pre>
+          </div>
+        </div>
+      )}
+
+      {/* No output message */}
+      {!hasOutput && !hasError && run.status === "completed" && (
+        <p className="text-muted-foreground text-sm">No output recorded.</p>
+      )}
+
+      {/* Pending/Running message */}
+      {(run.status === "pending" || run.status === "running") && (
+        <p className="text-muted-foreground text-sm">
+          Run is in progress. View the Chat tab for live output.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Automation Run Detail Page
+// ---------------------------------------------------------------------------
+
+export function AutomationRunDetailPage() {
+  const { automationId, runId } = useParams<{
+    automationId: string;
+    runId: string;
+  }>();
+  const [automation, setAutomation] = useState<Automation | null>(null);
+  const [run, setRun] = useState<AutomationRun | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!automationId || !runId) return;
+
+    async function load() {
+      try {
+        const [automations, runData] = await Promise.all([
+          fetchAutomations(),
+          fetchAutomationRun(automationId!, runId!),
+        ]);
+
+        const auto = automations.find((a) => a.id === automationId);
+        if (!auto) {
+          setError("Automation not found");
+          return;
+        }
+
+        setAutomation(auto);
+        setRun(runData);
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load run");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    load();
+
+    // Poll for run status updates while running
+    const interval = setInterval(async () => {
+      if (!automationId || !runId) return;
+      try {
+        const runData = await fetchAutomationRun(automationId, runId);
+        setRun(runData);
+      } catch {
+        // Ignore polling errors
+      }
+    }, 2000);
+
+    return () => clearInterval(interval);
+  }, [automationId, runId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full py-32">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error || !automation || !run) {
+    return (
+      <div className="p-4">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link to="/automations">Automations</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>Not found</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+        <p className="text-muted-foreground mt-4">{error || "Run not found."}</p>
+      </div>
+    );
+  }
+
+  const isRunActive = run.status === "running" || run.status === "pending";
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-4 py-3 shrink-0 bg-background">
+        <div className="flex items-center gap-2 min-w-0">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link
+                    to="/automations"
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    Automations
+                  </Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link
+                    to="/automations"
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    {automation.name}
+                  </Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage className="font-medium">Run</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+          <Badge
+            variant="outline"
+            className="font-mono text-xs text-muted-foreground shrink-0"
+          >
+            {run.id.slice(0, 8)}
+          </Badge>
+          <RunStatusBadge status={run.status} />
+        </div>
+      </div>
+
+      {/* Content: tabbed view + properties sidebar */}
+      <div className="flex flex-1 min-h-0">
+        {/* Main: tabbed content */}
+        <Tabs
+          defaultValue="chat"
+          className="flex-1 flex flex-col min-h-0 min-w-0"
+        >
+          {/* Tab bar */}
+          <div className="flex items-center border-b border-border px-4 shrink-0">
+            <TabsList variant="line" className="h-10">
+              <TabsTrigger value="chat" className="gap-1.5 px-3">
+                <MessageSquare className="h-3.5 w-3.5" />
+                Chat
+              </TabsTrigger>
+              <TabsTrigger value="details" className="gap-1.5 px-3">
+                <FileText className="h-3.5 w-3.5" />
+                Details
+              </TabsTrigger>
+            </TabsList>
+          </div>
+
+          {/* Chat tab */}
+          <TabsContent value="chat" className="flex-1 min-h-0 flex flex-col">
+            {automationId && runId && (
+              <SessionView automationId={automationId} runId={runId} />
+            )}
+          </TabsContent>
+
+          {/* Details tab */}
+          <TabsContent value="details" className="flex-1 min-h-0 overflow-auto">
+            <RunDetailsTab run={run} />
+          </TabsContent>
+        </Tabs>
+
+        {/* Properties sidebar */}
+        <div className="w-72 shrink-0 border-l border-border bg-muted/20">
+          <ScrollArea className="h-full">
+            <div className="p-4">
+              <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-4">
+                Properties
+              </div>
+              <PropertiesSidebar automation={automation} run={run} />
+            </div>
+          </ScrollArea>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/automations/automation-runs-panel.tsx
+++ b/web/src/pages/automations/automation-runs-panel.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
 import {
   AlertCircle,
   Check,
   ChevronDown,
   ChevronRight,
   Clock,
+  ExternalLink,
   Loader2,
   X,
 } from "lucide-react";
@@ -168,7 +170,7 @@ function RunDetailView({ run }: { run: AutomationRun }) {
 // Run row
 // ---------------------------------------------------------------------------
 
-function RunRow({ run }: { run: AutomationRun }) {
+function RunRow({ run, automationId }: { run: AutomationRun; automationId: string }) {
   const [expanded, setExpanded] = useState(false);
 
   // Auto-expand if this is a running or recently failed run
@@ -181,13 +183,15 @@ function RunRow({ run }: { run: AutomationRun }) {
   return (
     <Collapsible open={expanded} onOpenChange={setExpanded}>
       <div className="border-b border-border last:border-b-0">
-        <CollapsibleTrigger className="flex items-center gap-3 w-full px-3 py-2 hover:bg-accent/30 transition-colors text-left">
-          <ChevronRight
-            className={cn(
-              "h-3.5 w-3.5 text-muted-foreground transition-transform shrink-0",
-              expanded && "rotate-90"
-            )}
-          />
+        <div className="flex items-center gap-3 w-full px-3 py-2 hover:bg-accent/30 transition-colors text-left">
+          <CollapsibleTrigger className="p-0 border-0 bg-transparent">
+            <ChevronRight
+              className={cn(
+                "h-3.5 w-3.5 text-muted-foreground transition-transform shrink-0",
+                expanded && "rotate-90"
+              )}
+            />
+          </CollapsibleTrigger>
           <RunStatusBadge status={run.status} />
           <span
             className="text-xs text-muted-foreground flex-1"
@@ -200,7 +204,14 @@ function RunRow({ run }: { run: AutomationRun }) {
               {formatDuration(run.started_at, run.completed_at)}
             </span>
           )}
-        </CollapsibleTrigger>
+          <Link
+            to={`/automations/${automationId}/runs/${run.id}`}
+            className="p-1 rounded hover:bg-accent/50 transition-colors"
+            title="View run details"
+          >
+            <ExternalLink className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
+          </Link>
+        </div>
         <CollapsibleContent>
           <div className="px-3 pb-2 pl-9">
             <RunDetailView run={run} />
@@ -308,7 +319,7 @@ export function AutomationRunsPanel({
         ) : (
           <div>
             {runs.map((run) => (
-              <RunRow key={run.id} run={run} />
+              <RunRow key={run.id} run={run} automationId={automation.id} />
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Adds a detail page for automation runs similar to the task detail page
- Users can view live agent output/chat while an automation is running
- Events are fetched using the session ID format `automation-run:{run_id}`

## Changes
**Backend (`crates/app/src/web.rs`)**:
- Add `GET /api/automations/:id/runs/:run_id` endpoint to fetch a specific run
- Add `GET /api/automations/:id/runs/:run_id/events` endpoint to fetch events for a run

**Frontend**:
- Add `automation-run-detail.tsx` with Chat and Details tabs
- Add route `/automations/:automationId/runs/:runId`
- Add API functions `fetchAutomationRun` and `fetchAutomationRunEvents`
- Add link icon in runs panel to navigate to detail page

## Test plan
- [ ] Navigate to Automations page
- [ ] Trigger an automation to create a run
- [ ] Click the link icon on a run to open the detail page
- [ ] Verify the Chat tab shows live agent output during execution
- [ ] Verify the Details tab shows run output/error after completion
- [ ] Verify the sidebar shows run status, duration, and timestamps

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)