### PR TITLE
Show running automations immediately in run history panel

### DIFF
--- a/web/src/pages/automations/automation-runs-panel.tsx
+++ b/web/src/pages/automations/automation-runs-panel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef, useImperativeHandle, forwardRef } from "react";
 import {
   AlertCircle,
   Check,
@@ -215,18 +215,24 @@ function RunRow({ run }: { run: AutomationRun }) {
 // AutomationRunsPanel
 // ---------------------------------------------------------------------------
 
+export interface AutomationRunsPanelHandle {
+  refresh: () => void;
+}
+
 interface AutomationRunsPanelProps {
   automation: Automation;
   onClose: () => void;
 }
 
-export function AutomationRunsPanel({
-  automation,
-  onClose,
-}: AutomationRunsPanelProps) {
+export const AutomationRunsPanel = forwardRef<AutomationRunsPanelHandle, AutomationRunsPanelProps>(
+  function AutomationRunsPanel({ automation, onClose }, ref) {
   const [runs, setRuns] = useState<AutomationRun[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Track if there's a running run for polling interval adjustment
+  const runsRef = useRef<AutomationRun[]>([]);
+  runsRef.current = runs;
 
   const loadRuns = useCallback(async () => {
     try {
@@ -245,15 +251,48 @@ export function AutomationRunsPanel({
     }
   }, [automation.id]);
 
-  // Initial load + regular polling
-  // Always poll so new runs appear even if triggered externally.
-  // Poll faster (2s) when a run is in progress, otherwise every 5s.
+  // Expose refresh method via ref
+  useImperativeHandle(ref, () => ({
+    refresh: loadRuns,
+  }), [loadRuns]);
+
+  // Initial load
   useEffect(() => {
     loadRuns();
-    const hasRunningRun = runs.some((r) => r.status === "running");
-    const interval = setInterval(loadRuns, hasRunningRun ? 2000 : 5000);
-    return () => clearInterval(interval);
-  }, [runs, loadRuns]);
+  }, [loadRuns]);
+
+  // Polling: poll faster (2s) when a run is in progress, otherwise slower (5s)
+  // Use a ref to track the current interval timing
+  const intervalRef = useRef<number | null>(null);
+  const currentIntervalMs = useRef<number>(5000);
+
+  useEffect(() => {
+    // Function to set up the polling interval
+    const setupInterval = (ms: number) => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+      }
+      currentIntervalMs.current = ms;
+      intervalRef.current = window.setInterval(async () => {
+        await loadRuns();
+        // After load, check if we need to adjust the interval
+        const hasRunningRun = runsRef.current.some((r) => r.status === "running");
+        const targetMs = hasRunningRun ? 2000 : 5000;
+        if (targetMs !== currentIntervalMs.current) {
+          setupInterval(targetMs);
+        }
+      }, ms);
+    };
+
+    // Start with faster polling initially to catch new runs quickly
+    setupInterval(2000);
+
+    return () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [loadRuns]);
 
   return (
     <div className="flex flex-col h-full border-l border-border bg-background">
@@ -322,4 +361,4 @@ export function AutomationRunsPanel({
       )}
     </div>
   );
-}
+});

--- a/web/src/pages/automations/page.tsx
+++ b/web/src/pages/automations/page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import {
   Calendar,
   Clock,
@@ -49,7 +49,7 @@ import {
   ActionsCell,
 } from "@/components/ui/list-row";
 import type { Automation, AutomationState } from "@/lib/types";
-import { AutomationRunsPanel } from "./automation-runs-panel";
+import { AutomationRunsPanel, type AutomationRunsPanelHandle } from "./automation-runs-panel";
 import { AutomationFormDialog } from "./automation-form-dialog";
 
 // ---------------------------------------------------------------------------
@@ -111,6 +111,7 @@ function AutomationRow({
   onSelect,
   onEdit,
   onRefresh,
+  onRefreshRuns,
 }: {
   automation: Automation;
   projectName: string;
@@ -118,6 +119,7 @@ function AutomationRow({
   onSelect: () => void;
   onEdit: () => void;
   onRefresh: () => Promise<void>;
+  onRefreshRuns: () => void;
 }) {
   const [running, setRunning] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -131,6 +133,9 @@ function AutomationRow({
       await onRefresh();
       // Select this automation to show the new run
       onSelect();
+      // Immediately refresh the runs panel to show the new running state
+      // Use a small delay to ensure the panel has mounted if it wasn't selected before
+      setTimeout(() => onRefreshRuns(), 50);
     } catch (error) {
       console.error("Failed to run automation:", error);
     } finally {
@@ -297,6 +302,13 @@ export function AutomationsPage() {
   const [formOpen, setFormOpen] = useState(false);
   const [editingAutomation, setEditingAutomation] = useState<Automation | undefined>(undefined);
 
+  // Ref for the runs panel to trigger refresh after triggering an automation
+  const runsPanelRef = useRef<AutomationRunsPanelHandle>(null);
+
+  const refreshRunsPanel = () => {
+    runsPanelRef.current?.refresh();
+  };
+
   // Map project IDs to repo names
   const projectIdToRepo: Record<string, string> = {};
   for (const p of projects) {
@@ -357,6 +369,7 @@ export function AutomationsPage() {
             onSelect={() => setSelectedAutomation(automation)}
             onEdit={() => handleOpenEdit(automation)}
             onRefresh={refreshAutomations}
+            onRefreshRuns={refreshRunsPanel}
           />
         ))}
       </div>
@@ -365,6 +378,7 @@ export function AutomationsPage() {
 
   const runsPanel = currentSelectedAutomation ? (
     <AutomationRunsPanel
+      ref={runsPanelRef}
       automation={currentSelectedAutomation}
       onClose={() => setSelectedAutomation(null)}
     />


### PR DESCRIPTION
## Summary

- Adds immediate refresh of the run history panel after triggering an automation, so users see the "Running" state right away instead of waiting for the next poll
- Fixes the polling logic to properly adjust intervals (2s when running, 5s otherwise) without causing excessive state updates
- Uses React refs to expose a refresh method from the panel component, allowing the parent to trigger updates

## Changes

**`automation-runs-panel.tsx`:**
- Convert to `forwardRef` to expose `refresh()` method via `AutomationRunsPanelHandle`
- Use `useRef` to track runs state for polling without triggering effect re-runs
- Fix polling to start at 2s interval and dynamically adjust based on running state
- Separate initial load from polling interval setup

**`page.tsx`:**
- Add ref to `AutomationRunsPanel` component
- Add `refreshRunsPanel()` callback that calls the panel's `refresh()` method
- Call refresh with 50ms delay after triggering to ensure panel has mounted

## Test plan

- [ ] Trigger an automation and verify the run appears immediately with "Running" badge (blue, spinner icon)
- [ ] Verify the duration counter updates live while running
- [ ] Verify the panel refreshes every ~2s while a run is in progress
- [ ] Verify the panel refreshes every ~5s when no runs are in progress
- [ ] Verify completed/failed runs show proper status, output, and timing

Fixes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)