### PR TITLE
Add "Duplicate to..." feature for automations

### DIFF
--- a/web/src/pages/automations/duplicate-automation-dialog.tsx
+++ b/web/src/pages/automations/duplicate-automation-dialog.tsx
@@ -1,0 +1,180 @@
+import { useState, useEffect } from "react";
+import { Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { createAutomation, type CreateAutomationRequest } from "@/lib/api";
+import type { Automation, Project } from "@/lib/types";
+
+interface DuplicateAutomationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  automation: Automation;
+  projects: Project[];
+  onSuccess: () => void;
+}
+
+export function DuplicateAutomationDialog({
+  open,
+  onOpenChange,
+  automation,
+  projects,
+  onSuccess,
+}: DuplicateAutomationDialogProps) {
+  const [targetProjectId, setTargetProjectId] = useState<string>("");
+  const [name, setName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset form when dialog opens
+  useEffect(() => {
+    if (open) {
+      // Default to a different project if available, otherwise same project
+      const otherProjects = projects.filter((p) => p.id !== automation.project_id);
+      setTargetProjectId(otherProjects[0]?.id ?? automation.project_id);
+      setName(`${automation.name} (copy)`);
+      setError(null);
+    }
+  }, [open, automation, projects]);
+
+  async function handleDuplicate() {
+    if (!targetProjectId) {
+      setError("Please select a target project");
+      return;
+    }
+    if (!name.trim()) {
+      setError("Name is required");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const req: CreateAutomationRequest = {
+        project_id: targetProjectId,
+        name: name.trim(),
+        prompt: automation.prompt,
+        trigger: automation.trigger,
+        state: "active", // Start duplicated automation as active
+      };
+      await createAutomation(req);
+      onOpenChange(false);
+      onSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to duplicate automation");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Get project name by ID
+  const getProjectName = (projectId: string) => {
+    return projects.find((p) => p.id === projectId)?.repo ?? projectId;
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(value) => !saving && onOpenChange(value)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Copy className="h-4 w-4" />
+            Duplicate automation
+          </DialogTitle>
+          <DialogDescription>
+            Create a copy of "{automation.name}" in another project.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleDuplicate();
+          }}
+        >
+          <div className="space-y-4 py-3">
+            {/* Source info (read-only) */}
+            <div className="rounded-md border border-border bg-muted/30 p-3 space-y-1">
+              <p className="text-xs text-muted-foreground">Copying from</p>
+              <p className="text-sm font-medium">{getProjectName(automation.project_id)}</p>
+            </div>
+
+            {/* Target project selector */}
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium">Target Project</label>
+              <Select
+                value={targetProjectId}
+                onValueChange={(v) => {
+                  setTargetProjectId(v);
+                  setError(null);
+                }}
+                disabled={saving}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select a project" />
+                </SelectTrigger>
+                <SelectContent>
+                  {projects.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>
+                      {p.repo}
+                      {p.id === automation.project_id && (
+                        <span className="ml-2 text-muted-foreground">(same)</span>
+                      )}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Name */}
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium">Name</label>
+              <Input
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  setError(null);
+                }}
+                disabled={saving}
+              />
+              <p className="text-xs text-muted-foreground">
+                The prompt and trigger settings will be copied.
+              </p>
+            </div>
+
+            {/* Error message */}
+            {error && <p className="text-sm text-red-400">{error}</p>}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={saving || !name.trim() || !targetProjectId}>
+              {saving ? "Duplicating..." : "Duplicate"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/pages/automations/index.ts
+++ b/web/src/pages/automations/index.ts
@@ -1,3 +1,4 @@
 export { AutomationFormDialog } from "./automation-form-dialog";
 export { AutomationRunsPanel } from "./automation-runs-panel";
 export { AutomationsPage } from "./page";
+export { DuplicateAutomationDialog } from "./duplicate-automation-dialog";

--- a/web/src/pages/automations/page.tsx
+++ b/web/src/pages/automations/page.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import {
   Calendar,
   Clock,
+  Copy,
   History,
   MoreHorizontal,
   Pause,
@@ -48,9 +49,10 @@ import {
   ProjectCell,
   ActionsCell,
 } from "@/components/ui/list-row";
-import type { Automation, AutomationState } from "@/lib/types";
+import type { Automation, AutomationState, Project } from "@/lib/types";
 import { AutomationRunsPanel } from "./automation-runs-panel";
 import { AutomationFormDialog } from "./automation-form-dialog";
+import { DuplicateAutomationDialog } from "./duplicate-automation-dialog";
 
 // ---------------------------------------------------------------------------
 // State badge configuration
@@ -107,6 +109,7 @@ function TriggerDisplay({ trigger }: { trigger: Automation["trigger"] }) {
 function AutomationRow({
   automation,
   projectName,
+  projects,
   isSelected,
   onSelect,
   onEdit,
@@ -114,6 +117,7 @@ function AutomationRow({
 }: {
   automation: Automation;
   projectName: string;
+  projects: Project[];
   isSelected: boolean;
   onSelect: () => void;
   onEdit: () => void;
@@ -122,6 +126,7 @@ function AutomationRow({
   const [running, setRunning] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [duplicateOpen, setDuplicateOpen] = useState(false);
 
   async function handleRun(e: React.MouseEvent) {
     e.stopPropagation();
@@ -215,6 +220,10 @@ function AutomationRow({
                 <Pencil className="mr-2 h-3.5 w-3.5" />
                 Edit
               </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setDuplicateOpen(true)}>
+                <Copy className="mr-2 h-3.5 w-3.5" />
+                Duplicate to...
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={handleToggleState}>
                 {automation.state === "active" ? (
@@ -265,6 +274,15 @@ function AutomationRow({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Duplicate automation dialog */}
+      <DuplicateAutomationDialog
+        open={duplicateOpen}
+        onOpenChange={setDuplicateOpen}
+        automation={automation}
+        projects={projects}
+        onSuccess={onRefresh}
+      />
     </>
   );
 }
@@ -353,6 +371,7 @@ export function AutomationsPage() {
             key={automation.id}
             automation={automation}
             projectName={projectIdToRepo[automation.project_id] ?? automation.project_id}
+            projects={projects}
             isSelected={currentSelectedAutomation?.id === automation.id}
             onSelect={() => setSelectedAutomation(automation)}
             onEdit={() => handleOpenEdit(automation)}


### PR DESCRIPTION
## Summary
- Adds a "Duplicate to..." option in the automation row dropdown menu
- Creates a new dialog (`DuplicateAutomationDialog`) for selecting target project and renaming the copy
- Copies the automation's name (with "(copy)" suffix), prompt, and trigger settings to the target project
- Defaults to selecting a different project if available

## Test plan
- [ ] Create an automation in one project
- [ ] Open the dropdown menu and click "Duplicate to..."
- [ ] Verify the dialog shows the source project and allows selecting a target project
- [ ] Verify the name field is pre-filled with "{original name} (copy)"
- [ ] Duplicate to another project and verify the new automation is created
- [ ] Duplicate to the same project (marked as "(same)") and verify it works

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)