### PR TITLE
Disable output-based Question state detection

### DIFF
--- a/crates/session/src/interpreter.rs
+++ b/crates/session/src/interpreter.rs
@@ -64,10 +64,17 @@ impl OutputInterpreter {
 
         let trimmed = text.trim();
 
-        // Check for question patterns first (highest priority for blocking)
-        if let Some(signal) = self.detect_question(trimmed) {
-            return signal;
-        }
+        // Note: Question detection is disabled (see #415).
+        //
+        // The output-based question detection was producing too many false positives.
+        // Agents frequently use question-like language ("should I...", "please provide...")
+        // while explaining their work, not when actually blocked waiting for input.
+        // Since agents don't have an explicit protocol to signal "I'm blocked", and they
+        // continue working even after outputting question-like text, the pattern matching
+        // approach is fundamentally unreliable.
+        //
+        // The Question state infrastructure is preserved for potential future use
+        // (e.g., if agents gain an explicit "waiting for input" signal).
 
         // Check for failure patterns
         if let Some(signal) = self.detect_failure(trimmed) {
@@ -84,10 +91,18 @@ impl OutputInterpreter {
 
     /// Detect question patterns in output.
     ///
-    /// High-confidence patterns that indicate the agent is waiting for human input:
+    /// NOTE: This method is currently unused (see #415). The output-based question
+    /// detection was producing too many false positives because agents use question-like
+    /// language while working, not when actually blocked waiting for input.
+    ///
+    /// The method is preserved in case a more reliable detection mechanism is developed
+    /// (e.g., combined with agent pause signals or tool calls).
+    ///
+    /// Original design: High-confidence patterns that indicate the agent is waiting for human input:
     /// - Explicit prompts asking for input
     /// - Multiple choice questions
     /// - Permission requests
+    #[allow(dead_code)]
     fn detect_question(&self, text: &str) -> Option<OutputSignal> {
         let lower = text.to_lowercase();
 
@@ -408,50 +423,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn detect_explicit_question_prompts() {
+    fn question_patterns_not_detected() {
+        // Question detection is disabled (see #415) because output-based pattern
+        // matching produced too many false positives. Agents use question-like
+        // language while working, not when actually blocked waiting for input.
         let mut interpreter = OutputInterpreter::new();
 
-        let questions = [
+        let question_like_text = [
             "Please provide the path to the config file.",
-            "Please specify which database you want to use.",
-            "Please confirm you want to delete these files.",
-            "Which option would you prefer?",
             "Should I proceed with the refactoring?",
-            "Would you like me to run the tests first?",
+            "What would you like me to do next?",
             "Can you provide more context about the bug?",
-            "I need clarification on the expected behavior.",
         ];
 
-        for q in questions {
+        for q in question_like_text {
             let signal = interpreter.interpret(q);
             assert!(
-                matches!(signal, OutputSignal::Question { .. }),
-                "Should detect question: {}",
+                matches!(signal, OutputSignal::Message),
+                "Question detection is disabled, should return Message: {}",
                 q
             );
         }
-    }
-
-    #[test]
-    fn detect_direct_questions_to_user() {
-        let mut interpreter = OutputInterpreter::new();
-
-        // Questions directed at the user (should detect)
-        let signal = interpreter.interpret("What would you like me to do next?");
-        assert!(matches!(signal, OutputSignal::Question { .. }));
-
-        let signal = interpreter.interpret("Should I push your changes to the remote?");
-        assert!(matches!(signal, OutputSignal::Question { .. }));
-
-        // Reset interpreter for clean test
-        interpreter.clear();
-
-        // Questions not directed at user (should NOT detect)
-        let signal = interpreter.interpret("What is the capital of France?");
-        assert!(matches!(signal, OutputSignal::Message));
-
-        let signal = interpreter.interpret("How does this function work?");
-        assert!(matches!(signal, OutputSignal::Message));
     }
 
     #[test]
@@ -561,12 +553,4 @@ mod tests {
         assert!(matches!(signal, OutputSignal::Message));
     }
 
-    #[test]
-    fn question_priority_over_completion() {
-        let mut interpreter = OutputInterpreter::new();
-
-        // A question about completion should be detected as question
-        let signal = interpreter.interpret("Should I mark this task as complete?");
-        assert!(matches!(signal, OutputSignal::Question { .. }));
-    }
 }

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -1064,9 +1064,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stdout_question_emits_question_events() {
-        // When agent output contains a question pattern, we should emit
-        // agent:question and task:state:question events (spec §9.3).
+    async fn stdout_question_like_text_treated_as_message() {
+        // Question detection is disabled (see #415) because output-based pattern
+        // matching produced too many false positives. Question-like text should
+        // only emit the base agent:message event, no question-related events.
         let (bus, mut rx) = test_event_bus().await;
         let mut interpreter = OutputInterpreter::new();
         let mut token_tracker = TokenTracker::new();
@@ -1078,19 +1079,12 @@ mod tests {
 
         handle_supervisor_event("task-1", &event, &bus, &mut interpreter, &mut token_tracker).await;
 
-        // First event is the base agent:message
+        // Should only receive the base agent:message event
         let msg_event = rx.recv().await.unwrap();
         assert_eq!(msg_event.event_type, events::EventType::AgentMessage);
 
-        // Second event is agent:question
-        let question_event = rx.recv().await.unwrap();
-        assert_eq!(question_event.event_type, events::EventType::AgentQuestion);
-        assert_eq!(question_event.data["source"], "output_interpretation");
-
-        // Third event is task:state:question
-        let state_event = rx.recv().await.unwrap();
-        assert_eq!(state_event.event_type, events::EventType::TaskStateQuestion);
-        assert_eq!(state_event.data["reason"], "agent_question");
+        // No additional events (question detection is disabled)
+        assert!(rx.try_recv().is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Disables the output-based Question state detection that was producing false positives
- Agents frequently output question-like language while working (not when blocked), causing incorrect state transitions
- Preserves the Question state infrastructure for potential future use with explicit agent signals

Fixes #415

## Background

The `OutputInterpreter` was pattern matching agent stdout for phrases like "should I...", "please provide...", etc. This approach was fundamentally flawed because:

1. Agents use question-like language while explaining their work, not when actually blocked
2. Agents don't have an explicit protocol to signal "I'm waiting for input"
3. Agents continue working even after outputting text that matched question patterns

As noted in the issue: "Not once has this status actually indicated an agent has a question, and every time I've checked the agent is just working away."

## Changes

- Disabled `detect_question()` in `OutputInterpreter` (method preserved for future use)
- Added documentation explaining why detection is disabled
- Updated tests to verify question-like text is now treated as regular messages
- All existing infrastructure (Question state, event types, UI elements) remains intact

## Test plan

- [x] All 35 session tests pass
- [x] All 27 dispatcher tests pass (including Question state handling tests)
- [x] Full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)