### PR TITLE
Improve UI hierarchy with prominent project selector dropdown

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -7,7 +7,7 @@ import {
   Box,
   Radio,
   Brain,
-  ChevronRight,
+  ChevronDown,
   FolderGit2,
   Plus,
   Trash2,
@@ -16,6 +16,8 @@ import {
   Play,
   Rocket,
   Workflow,
+  Check,
+  Layers,
 } from "lucide-react";
 import { useAppState } from "@/hooks/use-app-state";
 import { addProject, deleteProject, setMode, bootstrapProject } from "@/lib/api";
@@ -23,11 +25,6 @@ import { UpdateBanner } from "@/components/update-banner";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 import {
   Dialog,
   DialogContent,
@@ -44,11 +41,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import type { Mode } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -157,12 +149,11 @@ function SidebarNavItem({
 }
 
 // ---------------------------------------------------------------------------
-// Project list in sidebar
+// Project selector dropdown (prominent at top of sidebar)
 // ---------------------------------------------------------------------------
 
-function ProjectList() {
+function ProjectSelector() {
   const { snapshot, refreshSnapshot, selectedProject, setSelectedProject } = useAppState();
-  const [isOpen, setIsOpen] = useState(true);
   const [addOpen, setAddOpen] = useState(false);
   const [newRepo, setNewRepo] = useState("");
   const [adding, setAdding] = useState(false);
@@ -179,6 +170,12 @@ function ProjectList() {
   const [bootstrapResult, setBootstrapResult] = useState<{ repoUrl: string; issueUrl: string } | null>(null);
 
   const projects = snapshot?.projects ?? [];
+  const selectedProjectData = projects.find((p) => p.id === selectedProject);
+  const selectedProjectName = selectedProjectData
+    ? selectedProjectData.repo.includes("/")
+      ? selectedProjectData.repo.split("/")[1]
+      : selectedProjectData.repo
+    : null;
 
   const handleAdd = async () => {
     const repo = newRepo.trim();
@@ -215,15 +212,6 @@ function ProjectList() {
     }
   };
 
-  const handleProjectClick = (projectId: string) => {
-    if (selectedProject === projectId) {
-      setSelectedProject(null);
-    } else {
-      setSelectedProject(projectId);
-    }
-    // Don't navigate - let the user filter the current page
-  };
-
   const handleBootstrap = async () => {
     const prompt = bootstrapPrompt.trim();
     if (!prompt) return;
@@ -242,7 +230,6 @@ function ProjectList() {
         repoUrl: result.repo_url,
         issueUrl: result.issue.url,
       });
-      // Clear the form but keep the dialog open to show the result
       setBootstrapPrompt("");
       setBootstrapRepoName("");
     } catch (e) {
@@ -262,106 +249,87 @@ function ProjectList() {
 
   return (
     <>
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <div className="flex items-center justify-between px-3 py-1">
-          <CollapsibleTrigger className="flex items-center gap-1 text-xs font-medium text-muted-foreground/70 uppercase tracking-wider hover:text-muted-foreground transition-colors">
-            <ChevronRight
-              className={cn(
-                "h-3 w-3 transition-transform",
-                isOpen && "rotate-90"
+      {/* Project selector dropdown */}
+      <div className="px-2 py-2 border-b border-border">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors">
+              {selectedProject ? (
+                <>
+                  <FolderGit2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="truncate font-medium" title={selectedProjectData?.repo}>
+                    {selectedProjectName}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <Layers className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="truncate font-medium">All Projects</span>
+                  <span className="text-xs text-muted-foreground">{projects.length}</span>
+                </>
               )}
-            />
-            Projects
-          </CollapsibleTrigger>
-          <div className="flex items-center gap-0.5">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-5 w-5 text-muted-foreground/70 hover:text-foreground"
-                  onClick={() => setBootstrapOpen(true)}
-                >
-                  <Rocket className="h-3.5 w-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="right">Bootstrap new project</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-5 w-5 text-muted-foreground/70 hover:text-foreground"
-                  onClick={() => setAddOpen(true)}
-                >
-                  <Plus className="h-3.5 w-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="right">Add existing project</TooltipContent>
-            </Tooltip>
-          </div>
-        </div>
+              <ChevronDown className="ml-auto h-4 w-4 shrink-0 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-52">
+            {/* All Projects option */}
+            <DropdownMenuItem
+              onClick={() => setSelectedProject(null)}
+              className={cn(!selectedProject && "bg-accent")}
+            >
+              <Layers className="mr-2 h-4 w-4" />
+              <span className="flex-1">All Projects</span>
+              {!selectedProject && <Check className="ml-2 h-4 w-4" />}
+            </DropdownMenuItem>
 
-        <CollapsibleContent className="space-y-0.5 px-1">
-          {/* All Projects option */}
-          <button
-            onClick={() => {
-              setSelectedProject(null);
-            }}
-            className={cn(
-              "flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors",
-              !selectedProject
-                ? "bg-accent text-accent-foreground"
-                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+            {/* Divider if there are projects */}
+            {projects.length > 0 && (
+              <div className="my-1 h-px bg-border" />
             )}
-          >
-            <FolderGit2 className="h-4 w-4 shrink-0" />
-            <span className="truncate">All Projects</span>
-            <span className="ml-auto text-xs text-muted-foreground">
-              {projects.length}
-            </span>
-          </button>
 
-          {projects.map((project) => {
-            const repoName = project.repo.includes("/")
-              ? project.repo.split("/")[1]
-              : project.repo;
-            return (
-              <div
-                key={project.id}
-                className={cn(
-                  "group flex items-center rounded-md transition-colors",
-                  selectedProject === project.id
-                    ? "bg-accent text-accent-foreground"
-                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                )}
-              >
-                <button
-                  onClick={() => handleProjectClick(project.id)}
-                  className="flex flex-1 items-center gap-2 px-3 py-1.5 text-sm min-w-0"
+            {/* Individual projects */}
+            {projects.map((project) => {
+              const repoName = project.repo.includes("/")
+                ? project.repo.split("/")[1]
+                : project.repo;
+              const isSelected = selectedProject === project.id;
+              return (
+                <DropdownMenuItem
+                  key={project.id}
+                  onClick={() => setSelectedProject(project.id)}
+                  className={cn("group", isSelected && "bg-accent")}
                 >
-                  <FolderGit2 className="h-4 w-4 shrink-0" />
-                  <span className="truncate" title={project.repo}>
+                  <FolderGit2 className="mr-2 h-4 w-4" />
+                  <span className="flex-1 truncate" title={project.repo}>
                     {repoName}
                   </span>
-                </button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 shrink-0 mr-1 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-red-400 transition-opacity"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setDeleteConfirm({ id: project.id, repo: project.repo });
-                  }}
-                >
-                  <Trash2 className="h-3 w-3" />
-                </Button>
-              </div>
-            );
-          })}
-        </CollapsibleContent>
-      </Collapsible>
+                  {isSelected && <Check className="ml-2 h-4 w-4" />}
+                  <button
+                    className="ml-1 opacity-0 group-hover:opacity-100 hover:text-red-400 transition-opacity"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setDeleteConfirm({ id: project.id, repo: project.repo });
+                    }}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </DropdownMenuItem>
+              );
+            })}
+
+            {/* Add project actions */}
+            <div className="my-1 h-px bg-border" />
+            <DropdownMenuItem onClick={() => setAddOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add existing project
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => setBootstrapOpen(true)}>
+              <Rocket className="mr-2 h-4 w-4" />
+              Bootstrap new project
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
 
       {/* Add project dialog */}
       <Dialog open={addOpen} onOpenChange={setAddOpen}>
@@ -593,6 +561,9 @@ export function Layout() {
           <ModeIndicator />
         </div>
 
+        {/* Project selector - prominent at top */}
+        <ProjectSelector />
+
         {/* Navigation */}
         <ScrollArea className="flex-1">
           <div className="flex flex-col gap-4 py-2">
@@ -604,9 +575,6 @@ export function Layout() {
               <SidebarNavItem to="/containers" icon={Box} label="Containers" />
               <SidebarNavItem to="/automations" icon={Workflow} label="Automations" />
             </div>
-
-            {/* Projects */}
-            <ProjectList />
 
             {/* System */}
             <div className="space-y-1">


### PR DESCRIPTION
## Summary
- Replace collapsible projects section with a prominent dropdown at the top of the sidebar
- Make it immediately clear which project is selected and that all views are scoped to it
- Move add/bootstrap project actions into the dropdown menu for cleaner UI

## Changes
The project selector is now prominently placed between the header and navigation, making the UI hierarchy clearer:
1. **Header** - App branding and mode indicator
2. **Project Selector** - Choose which project to view (or "All Projects")  
3. **Navigation** - Dashboard, Tasks, Merge Queue, etc. (scoped to selected project)
4. **System** - Orchestrator, Events (not project-scoped)

The dropdown shows:
- Selected project name with folder icon when a project is selected
- "All Projects" with layer icon and project count when viewing all
- Checkmark indicator for current selection
- Delete button on hover for each project
- Add existing project and Bootstrap new project actions

## Test plan
- [ ] Verify dropdown opens and shows all projects
- [ ] Verify selecting a project scopes Tasks, Merge Queue, and Automations views
- [ ] Verify "All Projects" option shows all items across projects
- [ ] Verify add project dialog works from dropdown
- [ ] Verify bootstrap project dialog works from dropdown
- [ ] Verify delete project works from dropdown

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)