### PR TITLE
Update container image with Python, bun, jq and latest Claude model

### DIFF
--- a/crates/supervisor/src/main.rs
+++ b/crates/supervisor/src/main.rs
@@ -172,7 +172,7 @@ async fn start_agent(
             "--print".to_string(),
             "--verbose".to_string(),
             "--model".to_string(),
-            "claude-opus-4-5".to_string(),
+            "claude-opus-4-6".to_string(),
             "--output-format".to_string(),
             "stream-json".to_string(),
             "--dangerously-skip-permissions".to_string(),

--- a/src/runtime/Dockerfile
+++ b/src/runtime/Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \
     unzip \
+    jq \
+    python3 \
+    python3-pip \
+    python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub CLI
@@ -27,6 +31,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
+
+# bun (JavaScript package manager/runtime)
+RUN curl -fsSL https://bun.sh/install | bash && \
+    mv /root/.bun/bin/bun /usr/local/bin/bun && \
+    chmod +x /usr/local/bin/bun && \
+    rm -rf /root/.bun
 
 # Claude Code
 RUN npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary
- Add Python 3.x with pip and venv to the container image (spec compliance - `session-runtime.md` §6 lists Python as a required runtime)
- Add bun package manager for JavaScript projects (this project uses bun, agents need it)
- Add jq for JSON manipulation in shell scripts
- Update default agent model from `claude-opus-4-5` to `claude-opus-4-6`

## Context

Review of the container image found several gaps since initial implementation:
1. **Python was missing** despite being listed in the spec
2. **bun was missing** despite the project itself using it
3. **Model version was outdated** - still using 4-5 when 4-6 is available

Full review findings: https://github.com/iamnbutler/tasks/issues/426#issuecomment-4119682500

## Test plan
- [ ] Rebuild container image with `make container-image`
- [ ] Verify Python is available: `python3 --version`
- [ ] Verify bun is available: `bun --version`
- [ ] Verify jq is available: `jq --version`
- [ ] Run a test session and confirm agent uses claude-opus-4-6

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)