### PR TITLE
Include merge queue context when orchestrator reviews PRs

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -1392,18 +1392,54 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                     (task, project)
                 };
 
-                let (entry, entry_head_sha) = {
+                let (entry, entry_head_sha, queue_context) = {
                     let state = orch_server.state.read().await;
-                    match state.merge_queue.get(&entry_id) {
-                        Some(e) => (e.clone(), e.head_sha.clone()),
+                    let entry = match state.merge_queue.get(&entry_id) {
+                        Some(e) => e.clone(),
                         None => continue,
-                    }
+                    };
+                    let entry_head_sha: Option<String> = entry.head_sha.clone();
+
+                    // Build queue context: summaries of other PRs in the queue
+                    // This helps the orchestrator understand dependencies between PRs
+                    let mut queue_context: Vec<tasks_orchestrator::QueueEntrySummary> = state
+                        .merge_queue
+                        .entries()
+                        .iter()
+                        .filter(|other_entry| other_entry.id != entry_id) // Exclude current entry
+                        .map(|other_entry| {
+                            // Get task title for this entry
+                            let task_title = state
+                                .tasks
+                                .get(&other_entry.task_id)
+                                .map(|t| t.title.clone())
+                                .unwrap_or_else(|| "(unknown task)".to_string());
+                            tasks_orchestrator::QueueEntrySummary::from_entry(
+                                other_entry,
+                                &task_title,
+                                other_entry.queue_position,
+                            )
+                        })
+                        .collect();
+
+                    // Sort by queue position (entries without position come last)
+                    queue_context.sort_by(|a, b| {
+                        match (a.queue_position, b.queue_position) {
+                            (Some(pa), Some(pb)) => pa.cmp(&pb),
+                            (Some(_), None) => std::cmp::Ordering::Less,
+                            (None, Some(_)) => std::cmp::Ordering::Greater,
+                            (None, None) => a.queued_at.cmp(&b.queued_at),
+                        }
+                    });
+
+                    (entry, entry_head_sha, queue_context)
                 };
 
                 let context = tasks_orchestrator::EvaluationContext {
                     entry,
                     task: task.clone(),
                     project,
+                    queue_context,
                 };
 
                 // Evaluate

--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -183,6 +183,7 @@ impl Orchestrator for ClaudeOrchestrator {
             &context.task.title,
             context.task.description.as_deref(),
             diff.as_deref(),
+            &context.queue_context,
         );
 
         let config = CompletionConfig::new(&self.model).with_max_tokens(MAX_TOKENS);
@@ -252,6 +253,7 @@ impl Orchestrator for ClaudeOrchestrator {
             diff.as_deref().unwrap_or("(no diff available)"),
             &pass1.reasoning,
             &files,
+            &context.queue_context,
         );
 
         let config = CompletionConfig::new(&self.model).with_max_tokens(MAX_TOKENS);

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -22,5 +22,5 @@ pub use orchestrator::Orchestrator;
 pub use prompt::parse_pr_url;
 pub use types::{
     ConflictContext, ConflictResolution, ConflictTriage, EvaluationContext, OperatingMode,
-    QualityEvaluation,
+    QualityEvaluation, QueueEntrySummary,
 };

--- a/crates/orchestrator/src/mock.rs
+++ b/crates/orchestrator/src/mock.rs
@@ -113,6 +113,7 @@ mod tests {
             entry: MergeQueueEntry::new("mq-1", "task-1", "https://github.com/owner/repo/pull/1"),
             task: Task::new("task-1", TaskSource::Internal, "Test task", "proj-1"),
             project: Project::new("proj-1", "owner/repo"),
+            queue_context: Vec::new(),
         }
     }
 

--- a/crates/orchestrator/src/prompt.rs
+++ b/crates/orchestrator/src/prompt.rs
@@ -6,6 +6,7 @@
 //! - Conflicts: Are there merge conflicts?
 //! - Conventions: Does the change meet project standards?
 
+use crate::types::QueueEntrySummary;
 use tasks_github::model::{Issue, PullRequest, MergeableState, ReviewDecision};
 
 /// Build the system prompt for quality evaluation.
@@ -23,10 +24,12 @@ Read the diff carefully. Evaluate:
 2. **Correctness**: Are there obvious bugs, missing error handling, or incomplete changes? For removals: is anything left that depends on the removed code? For additions: does the new code handle edge cases?
 3. **Completeness**: Does the diff cover all aspects of the issue, or are there gaps?
 4. **Conflicts/CI**: Check mergeable state and review status from the metadata.
+5. **Queue context**: Consider other PRs in the merge queue. If this PR appears to depend on changes from another PR that hasn't merged yet, or if issues you see would be resolved by a PR ahead in the queue, factor that into your decision.
 
 After reading the diff, decide:
 - If the change is obviously correct and complete → approve or reject immediately
 - If you're unsure or the change is substantial → request deeper review
+- If the PR depends on another queued PR → approve with a note, or hold feedback until dependencies merge
 
 **Response format for Pass 1 (JSON):**
 {
@@ -62,7 +65,8 @@ Response format for Pass 2 is the same, but `needs_deeper_review` must be false.
 - Look at what the diff actually does, not what the PR says it does.
 - For feature removals: check if anything in the diff's context still references the removed feature.
 - For large diffs: if truncated, lean toward requesting deeper review rather than approving blind.
-- Be concise but specific. If rejecting, point to exact lines/hunks in the diff."#.to_string()
+- Be concise but specific. If rejecting, point to exact lines/hunks in the diff.
+- Consider queue ordering: if a "missing function" or "undefined reference" issue might be resolved by a PR ahead in the queue, mention this in your reasoning rather than rejecting outright."#.to_string()
 }
 
 /// Build the user prompt with PR and issue context.
@@ -72,6 +76,7 @@ pub fn build_evaluation_prompt(
     task_title: &str,
     task_description: Option<&str>,
     diff: Option<&str>,
+    queue_context: &[QueueEntrySummary],
 ) -> String {
     let mut prompt = String::new();
 
@@ -173,6 +178,23 @@ pub fn build_evaluation_prompt(
         prompt.push('\n');
     }
 
+    // Queue context — other PRs in the merge queue
+    if !queue_context.is_empty() {
+        prompt.push_str("## Merge Queue Context\n\n");
+        prompt.push_str("Other PRs currently in the merge queue (ordered by position):\n\n");
+        for entry in queue_context {
+            let position = entry
+                .queue_position
+                .map(|p| format!("#{}", p))
+                .unwrap_or_else(|| "-".to_string());
+            prompt.push_str(&format!(
+                "- **PR #{}**: {} (status: {:?}, position: {})\n",
+                entry.pr_number, entry.task_title, entry.status, position
+            ));
+        }
+        prompt.push_str("\nConsider whether this PR might depend on or conflict with any of the above.\n\n");
+    }
+
     // The diff — this is what the review is actually about
     if let Some(diff) = diff {
         prompt.push_str("## Diff\n\n");
@@ -206,9 +228,10 @@ pub fn build_deep_review_prompt(
     diff: &str,
     review_reasoning: &str,
     files: &[(String, String)],
+    queue_context: &[QueueEntrySummary],
 ) -> String {
     // Start with the same base prompt
-    let mut prompt = build_evaluation_prompt(pr, issue, task_title, task_description, Some(diff));
+    let mut prompt = build_evaluation_prompt(pr, issue, task_title, task_description, Some(diff), queue_context);
 
     // Add the reviewer's reasoning from pass 1
     prompt.push_str("\n## Previous Review Notes\n\n");
@@ -394,7 +417,7 @@ mod tests {
     #[test]
     fn test_build_evaluation_prompt_basic() {
         let pr = test_pr();
-        let prompt = build_evaluation_prompt(&pr, None, "Fix auth bug", None, None);
+        let prompt = build_evaluation_prompt(&pr, None, "Fix auth bug", None, None, &[]);
 
         // Should contain task info
         assert!(prompt.contains("Fix auth bug"));
@@ -422,6 +445,7 @@ mod tests {
             "Fix auth bug",
             Some("Fix the timeout issue"),
             None,
+            &[],
         );
 
         // Should contain issue info
@@ -438,7 +462,7 @@ mod tests {
         let mut pr = test_pr();
         pr.mergeable = Some(MergeableState::Conflicting);
 
-        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None);
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[]);
         assert!(prompt.contains("has conflicts"));
     }
 
@@ -447,14 +471,14 @@ mod tests {
         let mut pr = test_pr();
         pr.review_decision = Some(ReviewDecision::ChangesRequested);
 
-        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None);
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[]);
         assert!(prompt.contains("Changes requested"));
     }
 
     #[test]
     fn test_build_evaluation_prompt_with_reviews() {
         let pr = test_pr();
-        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None);
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[]);
 
         // Should contain review info
         assert!(prompt.contains("@testuser"));
@@ -478,6 +502,7 @@ mod tests {
             "Fix auth bug",
             None,
             Some("diff --git a/src/auth.rs b/src/auth.rs\n-old\n+new"),
+            &[],
         );
         assert!(prompt.contains("## Diff"));
         assert!(prompt.contains("-old"));
@@ -487,7 +512,7 @@ mod tests {
     #[test]
     fn test_build_evaluation_prompt_no_diff_notes_absence() {
         let pr = test_pr();
-        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None);
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[]);
         assert!(prompt.contains("No diff available"));
     }
 
@@ -505,10 +530,55 @@ mod tests {
             "diff content here",
             "I need to see src/auth.rs to verify the login flow is complete",
             &files,
+            &[],
         );
         assert!(prompt.contains("## Requested Files"));
         assert!(prompt.contains("src/auth.rs"));
         assert!(prompt.contains("fn login()"));
         assert!(prompt.contains("Previous Review Notes"));
+    }
+
+    #[test]
+    fn test_build_evaluation_prompt_with_queue_context() {
+        use crate::types::QueueEntrySummary;
+        use models::merge_queue::MergeStatus;
+        use chrono::Utc;
+
+        let pr = test_pr();
+        let queue_context = vec![
+            QueueEntrySummary {
+                pr_url: "https://github.com/owner/repo/pull/40".to_string(),
+                pr_number: 40,
+                task_title: "Add logging feature".to_string(),
+                status: MergeStatus::Approved,
+                queued_at: Utc::now(),
+                queue_position: Some(1),
+            },
+            QueueEntrySummary {
+                pr_url: "https://github.com/owner/repo/pull/41".to_string(),
+                pr_number: 41,
+                task_title: "Fix database connection".to_string(),
+                status: MergeStatus::Pending,
+                queued_at: Utc::now(),
+                queue_position: Some(2),
+            },
+        ];
+
+        let prompt = build_evaluation_prompt(&pr, None, "Test task", None, None, &queue_context);
+
+        // Should contain queue context section
+        assert!(prompt.contains("## Merge Queue Context"));
+        assert!(prompt.contains("PR #40"));
+        assert!(prompt.contains("Add logging feature"));
+        assert!(prompt.contains("PR #41"));
+        assert!(prompt.contains("Fix database connection"));
+        assert!(prompt.contains("Consider whether this PR might depend on"));
+    }
+
+    #[test]
+    fn test_system_prompt_mentions_queue_context() {
+        let prompt = system_prompt();
+        assert!(prompt.contains("Queue context"));
+        assert!(prompt.contains("queue ordering"));
     }
 }

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -4,10 +4,54 @@
 //! QualityEvaluation: what the orchestrator returns.
 //! ConflictTriage: conflict resolution decision (spec §7.4).
 
-use models::merge_queue::{ConflictInfo, ConflictType, MergeQueueEntry};
+use chrono::{DateTime, Utc};
+use models::merge_queue::{ConflictInfo, ConflictType, MergeQueueEntry, MergeStatus};
 use models::project::Project;
 use models::task::Task;
 use serde::{Deserialize, Serialize};
+
+/// Summary of another merge queue entry for context during evaluation.
+///
+/// When evaluating a PR, the orchestrator receives summaries of other PRs
+/// in the queue. This helps identify dependencies or ordering issues —
+/// e.g., if a PR builds on changes from another PR that hasn't merged yet.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueEntrySummary {
+    /// GitHub PR URL.
+    pub pr_url: String,
+    /// PR number (parsed from URL).
+    pub pr_number: u64,
+    /// Title of the associated task.
+    pub task_title: String,
+    /// Current status of this queue entry.
+    pub status: MergeStatus,
+    /// When this entry was added to the queue.
+    pub queued_at: DateTime<Utc>,
+    /// Position in queue (1 = first to merge). Only set for Pending/Approved entries.
+    pub queue_position: Option<u32>,
+}
+
+impl QueueEntrySummary {
+    /// Create a summary from a merge queue entry and its associated task title.
+    pub fn from_entry(entry: &MergeQueueEntry, task_title: &str, queue_position: Option<u32>) -> Self {
+        // Parse PR number from URL (e.g., "https://github.com/owner/repo/pull/123")
+        let pr_number = entry
+            .pr_url
+            .rsplit('/')
+            .next()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        Self {
+            pr_url: entry.pr_url.clone(),
+            pr_number,
+            task_title: task_title.to_string(),
+            status: entry.status,
+            queued_at: entry.queued_at,
+            queue_position,
+        }
+    }
+}
 
 /// Context for evaluating a merge queue entry.
 ///
@@ -21,6 +65,9 @@ pub struct EvaluationContext {
     pub task: Task,
     /// The project this task belongs to.
     pub project: Project,
+    /// Summaries of other PRs in the queue (for context).
+    /// Sorted by queue position (PRs ahead of current entry come first).
+    pub queue_context: Vec<QueueEntrySummary>,
 }
 
 /// Verdict from the orchestrator's quality evaluation.


### PR DESCRIPTION
## Summary

- When evaluating a PR, the orchestrator now receives summaries of other PRs in the merge queue
- This helps the orchestrator understand dependencies between PRs and avoid rejecting PRs that depend on changes from PRs ahead in the queue
- The system prompt now instructs the orchestrator to consider queue ordering when evaluating issues

## Changes

- Add `QueueEntrySummary` struct to hold summary info about queue entries (PR number, task title, status, queue position)
- Add `queue_context: Vec<QueueEntrySummary>` field to `EvaluationContext`
- Update system prompt to instruct consideration of queue ordering
- Update evaluation prompts to include "Merge Queue Context" section showing other PRs
- Build queue context in run_loop when creating evaluation context

## Test plan

- [x] All orchestrator tests pass
- [x] All workspace tests pass (excluding desktop crate which needs system libs)
- [x] Manual verification: queue context is built correctly from merge queue entries

Fixes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)