### PR TITLE
Add env-based repo/org blocklist

### DIFF
--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -57,6 +57,10 @@ pub struct AppConfig {
     pub web: bool,
     /// Web server port (default: 4800).
     pub web_port: u16,
+    /// Blocked repositories (`owner/repo` patterns, from `BLOCKED_REPOS`).
+    pub blocked_repos: Vec<String>,
+    /// Blocked organizations (from `BLOCKED_ORGS`).
+    pub blocked_orgs: Vec<String>,
 }
 
 impl AppConfig {
@@ -170,6 +174,20 @@ impl AppConfig {
             .and_then(|s| s.parse().ok())
             .unwrap_or(300u64);
 
+        let blocked_repos = std::env::var("BLOCKED_REPOS")
+            .unwrap_or_default()
+            .split(',')
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>();
+
+        let blocked_orgs = std::env::var("BLOCKED_ORGS")
+            .unwrap_or_default()
+            .split(',')
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>();
+
         Ok(Self {
             data_dir,
             github_token,
@@ -199,6 +217,27 @@ impl AppConfig {
             update_check_interval: Duration::from_secs(update_check_interval_secs),
             update_auto_apply,
             update_session_timeout: Duration::from_secs(update_session_timeout_secs),
+            blocked_repos,
+            blocked_orgs,
         })
+    }
+
+    /// Check if a repo (`owner/repo`) is blocked. Returns an error message if blocked.
+    pub fn is_repo_blocked(&self, repo: &str) -> Option<String> {
+        Self::check_repo_blocked(&self.blocked_repos, &self.blocked_orgs, repo)
+    }
+
+    /// Static check against explicit blocklists.
+    pub fn check_repo_blocked(blocked_repos: &[String], blocked_orgs: &[String], repo: &str) -> Option<String> {
+        let repo_lower = repo.to_lowercase();
+        if blocked_repos.contains(&repo_lower) {
+            return Some(format!("repository '{repo}' is blocked"));
+        }
+        if let Some(org) = repo_lower.split('/').next() {
+            if blocked_orgs.iter().any(|o| o == &org) {
+                return Some(format!("organization '{org}' is blocked"));
+            }
+        }
+        None
     }
 }

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -2,6 +2,24 @@
 
 use std::time::Duration;
 
+/// Parse a comma-separated env var into a lowercased, trimmed list of non-empty strings.
+fn parse_csv_env(var: &str) -> Vec<String> {
+    std::env::var(var)
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Load blocklist from env and check a repo against it.
+/// Returns an error message if blocked, `None` if allowed.
+pub fn check_blocklist(repo: &str) -> Option<String> {
+    let blocked_repos = parse_csv_env("BLOCKED_REPOS");
+    let blocked_orgs = parse_csv_env("BLOCKED_ORGS");
+    AppConfig::check_repo_blocked(&blocked_repos, &blocked_orgs, repo)
+}
+
 /// Top-level app configuration.
 pub struct AppConfig {
     /// Data directory (default: `~/.local/state/tasks`).
@@ -174,19 +192,8 @@ impl AppConfig {
             .and_then(|s| s.parse().ok())
             .unwrap_or(300u64);
 
-        let blocked_repos = std::env::var("BLOCKED_REPOS")
-            .unwrap_or_default()
-            .split(',')
-            .map(|s| s.trim().to_lowercase())
-            .filter(|s| !s.is_empty())
-            .collect::<Vec<_>>();
-
-        let blocked_orgs = std::env::var("BLOCKED_ORGS")
-            .unwrap_or_default()
-            .split(',')
-            .map(|s| s.trim().to_lowercase())
-            .filter(|s| !s.is_empty())
-            .collect::<Vec<_>>();
+        let blocked_repos = parse_csv_env("BLOCKED_REPOS");
+        let blocked_orgs = parse_csv_env("BLOCKED_ORGS");
 
         Ok(Self {
             data_dir,
@@ -223,11 +230,6 @@ impl AppConfig {
     }
 
     /// Check if a repo (`owner/repo`) is blocked. Returns an error message if blocked.
-    pub fn is_repo_blocked(&self, repo: &str) -> Option<String> {
-        Self::check_repo_blocked(&self.blocked_repos, &self.blocked_orgs, repo)
-    }
-
-    /// Static check against explicit blocklists.
     pub fn check_repo_blocked(blocked_repos: &[String], blocked_orgs: &[String], repo: &str) -> Option<String> {
         let repo_lower = repo.to_lowercase();
         if blocked_repos.contains(&repo_lower) {

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -37,6 +37,24 @@ fn cmd_add_project(repo: &str) -> Result<(), String> {
         return Err(format!("Invalid repo format: {repo} (expected owner/repo)"));
     }
 
+    // Check blocklist (load env vars; .env may not be loaded yet for CLI commands)
+    dotenvy::dotenv().ok();
+    let blocked_repos: Vec<String> = std::env::var("BLOCKED_REPOS")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let blocked_orgs: Vec<String> = std::env::var("BLOCKED_ORGS")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if let Some(reason) = AppConfig::check_repo_blocked(&blocked_repos, &blocked_orgs, repo) {
+        return Err(reason);
+    }
+
     let store = open_store()?;
     let project = Project::new(repo, repo);
     store

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -37,21 +37,9 @@ fn cmd_add_project(repo: &str) -> Result<(), String> {
         return Err(format!("Invalid repo format: {repo} (expected owner/repo)"));
     }
 
-    // Check blocklist (load env vars; .env may not be loaded yet for CLI commands)
+    // Check blocklist (.env may not be loaded yet for CLI commands)
     dotenvy::dotenv().ok();
-    let blocked_repos: Vec<String> = std::env::var("BLOCKED_REPOS")
-        .unwrap_or_default()
-        .split(',')
-        .map(|s| s.trim().to_lowercase())
-        .filter(|s| !s.is_empty())
-        .collect();
-    let blocked_orgs: Vec<String> = std::env::var("BLOCKED_ORGS")
-        .unwrap_or_default()
-        .split(',')
-        .map(|s| s.trim().to_lowercase())
-        .filter(|s| !s.is_empty())
-        .collect();
-    if let Some(reason) = AppConfig::check_repo_blocked(&blocked_repos, &blocked_orgs, repo) {
+    if let Some(reason) = config::check_blocklist(repo) {
         return Err(reason);
     }
 

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -2011,6 +2011,8 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
             automation_executor,
             update_state: update_state.clone(),
             update_tx: update_tx.clone(),
+            blocked_repos: config.blocked_repos.clone(),
+            blocked_orgs: config.blocked_orgs.clone(),
         };
         let web_port = config.web_port;
 

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -43,6 +43,8 @@ pub struct ApiState {
     pub automation_executor: Option<Arc<server::AutomationExecutor>>,
     pub update_state: Arc<UpdateState>,
     pub update_tx: tokio::sync::mpsc::Sender<()>,
+    pub blocked_repos: Vec<String>,
+    pub blocked_orgs: Vec<String>,
 }
 
 /// Build the API router.
@@ -499,6 +501,9 @@ async fn add_project(
             req.repo
         )));
     }
+    if let Some(reason) = crate::config::AppConfig::check_repo_blocked(&state.blocked_repos, &state.blocked_orgs, &req.repo) {
+        return Err(ApiError::Forbidden(reason));
+    }
     let id = uuid::Uuid::new_v4().to_string();
     let project = models::project::Project::new(&id, &req.repo);
     state.server.add_project(project.clone()).await;
@@ -565,6 +570,11 @@ async fn bootstrap_project(
         .create_repository(&repo_name, description)
         .await
         .map_err(ApiError::GitHubApi)?;
+
+    // Check blocklist against the created repo's full name
+    if let Some(reason) = crate::config::AppConfig::check_repo_blocked(&state.blocked_repos, &state.blocked_orgs, &created_repo.full_name) {
+        return Err(ApiError::Forbidden(reason));
+    }
 
     // Add the project to tracking
     let project_id = uuid::Uuid::new_v4().to_string();
@@ -1624,6 +1634,7 @@ async fn list_automation_run_events(
 enum ApiError {
     Server(server::ServerError),
     BadRequest(String),
+    Forbidden(String),
     MergeQueue(String),
     SessionManager(String),
     NotFound(String),
@@ -1640,6 +1651,7 @@ impl IntoResponse for ApiError {
         let (status, message) = match self {
             ApiError::Server(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
             ApiError::BadRequest(e) => (StatusCode::BAD_REQUEST, e),
+            ApiError::Forbidden(e) => (StatusCode::FORBIDDEN, e),
             ApiError::MergeQueue(e) => (StatusCode::BAD_REQUEST, e),
             ApiError::SessionManager(e) => (StatusCode::BAD_REQUEST, e),
             ApiError::NotFound(e) => (StatusCode::NOT_FOUND, e),

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -557,6 +557,16 @@ async fn bootstrap_project(
         derive_repo_name(prompt)
     };
 
+    // Check blocklist before creating the repo to avoid orphaned repos
+    let owner_login = client
+        .get_authenticated_user_login()
+        .await
+        .map_err(ApiError::GitHubApi)?;
+    let prospective_full_name = format!("{owner_login}/{repo_name}");
+    if let Some(reason) = crate::config::AppConfig::check_repo_blocked(&state.blocked_repos, &state.blocked_orgs, &prospective_full_name) {
+        return Err(ApiError::Forbidden(reason));
+    }
+
     // Create the repository
     let description_text;
     let description = if prompt.chars().count() > 200 {
@@ -570,11 +580,6 @@ async fn bootstrap_project(
         .create_repository(&repo_name, description)
         .await
         .map_err(ApiError::GitHubApi)?;
-
-    // Check blocklist against the created repo's full name
-    if let Some(reason) = crate::config::AppConfig::check_repo_blocked(&state.blocked_repos, &state.blocked_orgs, &created_repo.full_name) {
-        return Err(ApiError::Forbidden(reason));
-    }
 
     // Add the project to tracking
     let project_id = uuid::Uuid::new_v4().to_string();

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -1111,6 +1111,25 @@ impl GitHubClient {
         )))
     }
 
+    /// Get the login of the authenticated user (`GET /user`).
+    pub async fn get_authenticated_user_login(&self) -> Result<String, GitHubError> {
+        self.wait_for_rate_limit().await;
+        let url = format!("{}/user", self.base_url);
+        let response = self.http.get(&url).send().await?;
+        self.update_rate_limit(&response);
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(format!("GET /user failed ({status}): {text}")));
+        }
+        #[derive(Deserialize)]
+        struct UserResponse { login: String }
+        let user: UserResponse = response.json().await.map_err(|e| {
+            GitHubError::Decode(format!("failed to parse user response: {e}"))
+        })?;
+        Ok(user.login)
+    }
+
     // -----------------------------------------------------------------------
     // Nested pagination helpers
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `BLOCKED_REPOS` (comma-separated `owner/repo`) and `BLOCKED_ORGS` (comma-separated org names) environment variables
- CLI `add-project` rejects blocked repos with a clear error message
- `POST /api/projects` returns 403 for blocked repos
- `POST /api/projects/bootstrap` checks after repo creation
- All comparisons are case-insensitive

Closes #444

## Test plan

- [ ] Set `BLOCKED_REPOS=githubnext/ace` in `.env`, verify `add-project githubnext/ace` is rejected
- [ ] Set `BLOCKED_ORGS=githubnext` in `.env`, verify `add-project githubnext/anything` is rejected
- [ ] Verify unblocked repos can still be added normally
- [ ] Verify `POST /api/projects` returns 403 with blocked repo