### PR TITLE
Check needs_eval before adding MergeQueued entries to eval queue

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -1165,8 +1165,14 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                     // When a new entry is queued, add it to the FIFO
                     EventType::MergeQueued => {
                         if let Some(entry_id) = event.data.get("entry_id").and_then(|v| v.as_str()) {
-                            // New entry — always queue it (it's fresh)
-                            if eval_queued.insert(entry_id.to_string()) {
+                            // Look up entry to check if it actually needs evaluation
+                            let skip = {
+                                let state = orch_server.state.read().await;
+                                state.merge_queue.get(entry_id)
+                                    .map(|e| !needs_eval(&evaluated_prs, e))
+                                    .unwrap_or(false)
+                            };
+                            if !skip && eval_queued.insert(entry_id.to_string()) {
                                 eval_queue.push_back(entry_id.to_string());
                                 info!(entry_id = %entry_id, queue_len = eval_queue.len(), "added entry to eval queue");
                             }


### PR DESCRIPTION
## Summary

- Fixes the `MergeQueued` event handler to check `needs_eval()` before adding entries to the evaluation queue
- Prevents re-evaluation of PRs that have already been evaluated at the same head SHA
- Eliminates unnecessary LLM calls from stale cache entries bypassing dedup

## Details

The `evaluated_prs` HashMap caches which PRs have been evaluated and at which SHA. The `needs_eval()` function checks whether a PR needs re-evaluation. However, the `MergeQueued` event handler was not using this check - it only deduplicated by entry_id within the current queue.

This allowed PRs to be queued for evaluation even when they had already been evaluated at the same SHA, wasting LLM calls.

The fix looks up the entry from state and checks `needs_eval()` before adding to the queue, consistent with:
- The fallback path in the same handler (line 1177)
- The `SystemModePlay` handler (lines 1194-1198)
- The periodic scan that seeds the queue (line 1345)

Closes #440