### PR TITLE
Add cooldown for rejected PRs to prevent immediate re-queuing

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -52,7 +52,6 @@ const REJECTED_PR_COOLDOWN: Duration = Duration::from_secs(10 * 60);
 /// 2. Cleanup removes Rejected entry
 /// 3. Poll loop finds open PR, creates new Pending entry
 /// 4. Orchestrator re-evaluates (non-deterministically may approve)
-#[derive(Default)]
 struct RejectedPrCooldown {
     /// Map of pr_url -> (head_sha, rejection_time)
     entries: HashMap<String, (String, Instant)>,
@@ -1879,6 +1878,8 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                 head_sha = %sha,
                                 "recorded PR rejection in cooldown tracker (issue closed)"
                             );
+                        } else {
+                            warn!("Cannot record rejection cooldown for {}: entry has no head_sha", pr_url);
                         }
                     } else {
                         // Issue is still open — normal rejection with re-dispatch.
@@ -1958,6 +1959,8 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                 head_sha = %sha,
                                 "recorded PR rejection in cooldown tracker"
                             );
+                        } else {
+                            warn!("Cannot record rejection cooldown for {}: entry has no head_sha", pr_url);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes the race condition where rejected PRs get re-queued and potentially approved seconds later:

- Add `RejectedPrCooldown` tracker shared between the poll loop and orchestrator loop
- When a PR is rejected, record `(pr_url, head_sha, timestamp)` in the tracker
- Poll loop checks this before creating new merge queue entries
- PRs rejected within 10 minutes with the same `head_sha` are blocked from re-queuing
- New commits (different `head_sha`) bypass the cooldown and get queued normally
- Stale entries are cleaned up after the cooldown period expires

## Test plan

- [ ] Verify build passes with `cargo build`
- [ ] When a PR is rejected, it should not be re-queued until either:
  - The cooldown period (10 min) expires, OR
  - The agent pushes new commits (different head_sha)
- [ ] PRs with new commits after rejection should be queued immediately

Closes #439