### PR TITLE
Fix automation session time limits and awaiting_merge handling

### DIFF
--- a/crates/app/src/automation_runner.rs
+++ b/crates/app/src/automation_runner.rs
@@ -5,6 +5,7 @@
 //! has tool access, git, and a real working directory.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
@@ -13,7 +14,7 @@ use uuid::Uuid;
 use events::EventBus;
 use runtime::AppleContainerRuntime;
 use server::Server;
-use tasks_session::SessionManager;
+use tasks_session::{SessionLimits, SessionManager};
 
 /// Prefix used for automation session IDs.
 const SESSION_PREFIX: &str = "automation-run:";
@@ -22,11 +23,17 @@ const SESSION_PREFIX: &str = "automation-run:";
 ///
 /// Creates a session with the ID `automation-run:{run_id}`. If the session
 /// fails to start, the run is marked as failed via `server.fail_automation_run()`.
+///
+/// The `soft_limit` and `hard_limit` parameters allow customization of the
+/// session time limits. Automation sessions typically use shorter limits
+/// (25m soft, 30m hard) than regular task sessions.
 pub async fn execute_automation_run(
     session_manager: &SessionManager<AppleContainerRuntime>,
     server: &Arc<Server>,
     run_id: &str,
     automation_id: &str,
+    soft_limit: Duration,
+    hard_limit: Duration,
 ) {
     // Look up the automation to get its prompt and project.
     let (prompt, project_id) = {
@@ -71,15 +78,38 @@ pub async fn execute_automation_run(
 
     let session_id = format!("{SESSION_PREFIX}{run_id}");
 
+    // Prepend time limit notice to the prompt so agent can plan accordingly
+    let hard_limit_mins = hard_limit.as_secs() / 60;
+    let prompt_with_notice = format!(
+        "[TIME LIMIT] This automation session has a {hard_limit_mins}-minute hard limit. \
+        Plan your work to complete within this time. If you cannot finish, prioritize \
+        the most important changes and commit partial progress.\n\n{prompt}"
+    );
+
     info!(
         run_id = %run_id,
         automation_id = %automation_id,
         session_id = %session_id,
+        soft_limit_secs = soft_limit.as_secs(),
+        hard_limit_secs = hard_limit.as_secs(),
         "starting automation container session"
     );
 
+    let time_limits = SessionLimits {
+        soft_limit: Some(soft_limit),
+        hard_limit: Some(hard_limit),
+    };
+
     if let Err(e) = session_manager
-        .start_session(session_id, repo_url, branch, prompt, None, None)
+        .start_session_with_limits(
+            session_id,
+            repo_url,
+            branch,
+            prompt_with_notice,
+            None,
+            None,
+            time_limits,
+        )
         .await
     {
         error!(
@@ -112,10 +142,12 @@ pub fn run_id_from_session(session_id: &str) -> Option<&str> {
 /// and updates automation run records accordingly.
 ///
 /// When a session with an `automation-run:` prefix reaches a terminal state
-/// (`TaskStateCompleted` or `TaskStateFailed`), this listener calls
-/// `server.complete_automation_run()` or `server.fail_automation_run()`.
-/// We use `TaskStateCompleted` (not `TaskStateAwaitingMerge`) as the
-/// terminal event because automations don't go through the merge queue.
+/// (`TaskStateCompleted`, `TaskStateAwaitingMerge`, or `TaskStateFailed`), this
+/// listener calls `server.complete_automation_run()` or `server.fail_automation_run()`.
+///
+/// Both `TaskStateCompleted` and `TaskStateAwaitingMerge` are treated as successful
+/// completion — the agent may create a PR and wait for merge, which is a valid
+/// successful outcome for an automation run.
 pub fn spawn_automation_event_listener(
     event_bus: &EventBus,
     server: Arc<Server>,
@@ -133,8 +165,9 @@ pub fn spawn_automation_event_listener(
                     };
 
                     match event.event_type {
-                        // Agent exited successfully
-                        events::EventType::TaskStateCompleted => {
+                        // Agent exited successfully (with or without a PR)
+                        events::EventType::TaskStateCompleted
+                        | events::EventType::TaskStateAwaitingMerge => {
                             info!(
                                 run_id = %run_id,
                                 event_type = %event.event_type.as_str(),

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -55,6 +55,10 @@ pub struct AppConfig {
     pub session_soft_limit: Duration,
     /// Session hard time limit (default: 1h15m).
     pub session_hard_limit: Duration,
+    /// Automation session soft time limit (default: 25m).
+    pub automation_soft_limit: Duration,
+    /// Automation session hard time limit (default: 30m).
+    pub automation_hard_limit: Duration,
     /// Minimum session duration to count as "progress" (default: 60s, spec §13.1).
     pub progress_threshold: Duration,
     /// Memory usage percentage at which to warn (default: 75%).
@@ -208,6 +212,8 @@ impl AppConfig {
             container_memory,
             session_soft_limit: Duration::from_secs(3600),
             session_hard_limit: Duration::from_secs(4500),
+            automation_soft_limit: Duration::from_secs(25 * 60), // 25 minutes
+            automation_hard_limit: Duration::from_secs(30 * 60), // 30 minutes
             progress_threshold: Duration::from_secs(progress_threshold_secs),
             memory_warn_pct,
             memory_soft_limit_pct,

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -341,7 +341,12 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     // and triggers runs when their schedules match. It ticks every 60 seconds
     // and respects operating mode (no runs in Stop mode).
 
-    let automation_scheduler = AutomationScheduler::new(server.clone(), Some(session_manager.clone()));
+    let automation_scheduler = AutomationScheduler::new(
+        server.clone(),
+        Some(session_manager.clone()),
+        config.automation_soft_limit,
+        config.automation_hard_limit,
+    );
     let automation_scheduler_handle = automation_scheduler.start();
     info!("automation scheduler started");
 
@@ -2013,6 +2018,8 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
             update_tx: update_tx.clone(),
             blocked_repos: config.blocked_repos.clone(),
             blocked_orgs: config.blocked_orgs.clone(),
+            automation_soft_limit: config.automation_soft_limit,
+            automation_hard_limit: config.automation_hard_limit,
         };
         let web_port = config.web_port;
 

--- a/crates/app/src/scheduler.rs
+++ b/crates/app/src/scheduler.rs
@@ -26,6 +26,10 @@ pub struct AutomationScheduler {
     next_runs: HashMap<String, DateTime<Utc>>,
     /// Track last run time for each automation to prevent double-runs.
     last_runs: HashMap<String, DateTime<Utc>>,
+    /// Automation session soft time limit.
+    automation_soft_limit: Duration,
+    /// Automation session hard time limit.
+    automation_hard_limit: Duration,
 }
 
 impl AutomationScheduler {
@@ -33,12 +37,16 @@ impl AutomationScheduler {
     pub fn new(
         server: Arc<Server>,
         session_manager: Option<Arc<SessionManager<AppleContainerRuntime>>>,
+        automation_soft_limit: Duration,
+        automation_hard_limit: Duration,
     ) -> Self {
         Self {
             server,
             session_manager,
             next_runs: HashMap::new(),
             last_runs: HashMap::new(),
+            automation_soft_limit,
+            automation_hard_limit,
         }
     }
 
@@ -208,9 +216,16 @@ impl AutomationScheduler {
                     let server = self.server.clone();
                     let run_id = run.id.clone();
                     let auto_id = automation_id.to_string();
+                    let soft_limit = self.automation_soft_limit;
+                    let hard_limit = self.automation_hard_limit;
                     tokio::spawn(async move {
                         crate::automation_runner::execute_automation_run(
-                            &sm, &server, &run_id, &auto_id,
+                            &sm,
+                            &server,
+                            &run_id,
+                            &auto_id,
+                            soft_limit,
+                            hard_limit,
                         )
                         .await;
                     });

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -45,6 +45,10 @@ pub struct ApiState {
     pub update_tx: tokio::sync::mpsc::Sender<()>,
     pub blocked_repos: Vec<String>,
     pub blocked_orgs: Vec<String>,
+    /// Automation session soft time limit.
+    pub automation_soft_limit: std::time::Duration,
+    /// Automation session hard time limit.
+    pub automation_hard_limit: std::time::Duration,
 }
 
 /// Build the API router.
@@ -1528,9 +1532,18 @@ async fn trigger_automation(
         let automation_id = automation.id.clone();
         let server = state.server.clone();
         let sm = session_manager.clone();
+        let soft_limit = state.automation_soft_limit;
+        let hard_limit = state.automation_hard_limit;
         tokio::spawn(async move {
-            crate::automation_runner::execute_automation_run(&sm, &server, &run_id, &automation_id)
-                .await;
+            crate::automation_runner::execute_automation_run(
+                &sm,
+                &server,
+                &run_id,
+                &automation_id,
+                soft_limit,
+                hard_limit,
+            )
+            .await;
         });
     } else if let Some(executor) = &state.automation_executor {
         // Fall back to direct LLM streaming execution

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -9,4 +9,4 @@ mod manager;
 
 pub use accounting::{TokenParser, TokenTracker, TokenUsage};
 pub use interpreter::{OutputInterpreter, OutputSignal, emit_signal_events};
-pub use manager::{ContainerInfo, SessionManager, SessionManagerError, SessionHandle};
+pub use manager::{ContainerInfo, SessionLimits, SessionManager, SessionManagerError, SessionHandle};

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -58,6 +58,18 @@ pub(crate) enum SessionCommand {
     Stop,
 }
 
+/// Per-session time limit overrides.
+///
+/// Used to customize time limits for specific session types (e.g., automation runs
+/// have shorter limits than regular task sessions).
+#[derive(Debug, Clone, Default)]
+pub struct SessionLimits {
+    /// Override for soft time limit. If `None`, uses manager's default.
+    pub soft_limit: Option<Duration>,
+    /// Override for hard time limit. If `None`, uses manager's default.
+    pub hard_limit: Option<Duration>,
+}
+
 /// Handle for a running session — tracks metadata and communication channel.
 pub struct SessionHandle {
     /// The task this session is executing.
@@ -376,6 +388,9 @@ impl<R: ContainerRuntime + Clone + Send + Sync + 'static> SessionManager<R> {
     ///
     /// The optional `progress_threshold` allows per-project customization
     /// (spec §13.1, §14.2). If not provided, uses the manager's default.
+    ///
+    /// The optional `time_limits` allows per-session time limit overrides
+    /// (e.g., automation sessions use shorter limits than regular tasks).
     pub async fn start_session(
         &self,
         task_id: String,
@@ -384,6 +399,33 @@ impl<R: ContainerRuntime + Clone + Send + Sync + 'static> SessionManager<R> {
         prompt: String,
         config: Option<ContainerConfig>,
         progress_threshold: Option<Duration>,
+    ) -> Result<(), SessionManagerError> {
+        self.start_session_with_limits(
+            task_id,
+            repo_url,
+            branch,
+            prompt,
+            config,
+            progress_threshold,
+            SessionLimits::default(),
+        )
+        .await
+    }
+
+    /// Start a new session with custom time limits.
+    ///
+    /// Like `start_session`, but accepts `SessionLimits` to override the
+    /// manager's default soft/hard time limits. Used for automation runs
+    /// which have shorter time limits than regular task sessions.
+    pub async fn start_session_with_limits(
+        &self,
+        task_id: String,
+        repo_url: String,
+        branch: String,
+        prompt: String,
+        config: Option<ContainerConfig>,
+        progress_threshold: Option<Duration>,
+        time_limits: SessionLimits,
     ) -> Result<(), SessionManagerError> {
         // Check if session already exists
         if self.sessions.read().await.contains_key(&task_id) {
@@ -408,6 +450,10 @@ impl<R: ContainerRuntime + Clone + Send + Sync + 'static> SessionManager<R> {
         // Use per-project progress threshold if provided, else manager's default (spec §14.2)
         let effective_progress_threshold = progress_threshold.unwrap_or(self.progress_threshold);
 
+        // Use per-session time limits if provided, else manager's defaults
+        let effective_soft_limit = time_limits.soft_limit.unwrap_or(self.soft_time_limit);
+        let effective_hard_limit = time_limits.hard_limit.unwrap_or(self.hard_time_limit);
+
         // Spawn the monitoring task
         let monitor = tokio::spawn(monitor_session(
             task_id.clone(),
@@ -417,8 +463,8 @@ impl<R: ContainerRuntime + Clone + Send + Sync + 'static> SessionManager<R> {
             self.sessions.clone(),
             self.runtime.clone(),
             container_id.clone(),
-            self.soft_time_limit,
-            self.hard_time_limit,
+            effective_soft_limit,
+            effective_hard_limit,
             effective_progress_threshold,
         ));
 


### PR DESCRIPTION
## Summary
- Add 30-minute hard limit (25-minute soft limit) for automation sessions to prevent stuck runs
- Add `SessionLimits` struct and `start_session_with_limits()` method to allow per-session time limit overrides
- Prepend `[TIME LIMIT]` notice to automation prompts so agents can plan accordingly
- Handle `TaskStateAwaitingMerge` as successful completion in automation event listener (previously only `TaskStateCompleted` was handled)

## Test plan
- [ ] Run an automation and verify it enforces the 30-minute hard limit
- [ ] Verify the time limit notice appears in the prompt
- [ ] Verify automation runs that create PRs (awaiting_merge state) are marked as completed
- [ ] Build and run: `cargo build && cargo run -- run --web`

Closes #442