### PR TITLE
Wire up orchestrator feedback delivery to agent sessions

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -1045,7 +1045,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                 &comments,
                             );
 
-                            if let Err(e) = dispatch_session_mgr
+                            match dispatch_session_mgr
                                 .start_session(
                                     task_id.clone(),
                                     repo_url,
@@ -1056,14 +1056,26 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                 )
                                 .await
                             {
-                                error!(task_id = %task_id, error = %e, "failed to start session");
-                                // Treat as a failure with no progress so backoff kicks in.
-                                // This prevents tight retry loops when containers can't start.
-                                if let Err(e2) = dispatch_server
-                                    .handle_task_failure(task_id, false, max_retries, None)
-                                    .await
-                                {
-                                    warn!(task_id = %task_id, error = %e2, "failed to handle session start failure");
+                                Ok(_) => {
+                                    // Clear rejection feedback after successful dispatch (issue #423).
+                                    // This prevents stale feedback from being repeated if the task
+                                    // is rejected and re-dispatched again.
+                                    if task.rejection_feedback.is_some() {
+                                        if let Err(e) = dispatch_server.clear_task_rejection_feedback(task_id).await {
+                                            warn!(task_id = %task_id, error = %e, "failed to clear rejection feedback after dispatch");
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    error!(task_id = %task_id, error = %e, "failed to start session");
+                                    // Treat as a failure with no progress so backoff kicks in.
+                                    // This prevents tight retry loops when containers can't start.
+                                    if let Err(e2) = dispatch_server
+                                        .handle_task_failure(task_id, false, max_retries, None)
+                                        .await
+                                    {
+                                        warn!(task_id = %task_id, error = %e2, "failed to handle session start failure");
+                                    }
                                 }
                             }
                         }
@@ -1849,9 +1861,8 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                 error!(error = %e, "failed to emit orchestrator feedback event");
                             }
                         }
-                        // TODO: The feedback event is now recorded in the audit trail.
-                        // Delivering feedback to the re-dispatched session's prompt
-                        // context still needs dispatch loop changes.
+                        // Feedback is now stored on the task (issue #423) and will be
+                        // delivered to the agent via the prompt when re-dispatched.
                     }
                 }
             } // end single-entry evaluation block

--- a/crates/models/src/task.rs
+++ b/crates/models/src/task.rs
@@ -137,6 +137,10 @@ pub struct Task {
     pub last_activity_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Feedback from orchestrator after PR rejection (issue #423).
+    /// Delivered to the agent when the task is re-dispatched.
+    /// Cleared after dispatch so stale feedback isn't repeated.
+    pub rejection_feedback: Option<String>,
 }
 
 impl Task {
@@ -169,6 +173,7 @@ impl Task {
             last_activity_at: None,
             created_at: now,
             updated_at: now,
+            rejection_feedback: None,
         }
     }
 

--- a/crates/server/src/prompt.rs
+++ b/crates/server/src/prompt.rs
@@ -38,6 +38,10 @@ pub struct PromptParams<'a> {
     pub related_tasks: &'a [RelatedTaskInfo],
     /// Retry context if this is a retry.
     pub retry: Option<&'a RetryContext>,
+    /// Orchestrator feedback from a previous PR rejection (issue #423).
+    /// This is separate from retry context because it comes from orchestrator
+    /// review, not from a session failure.
+    pub rejection_feedback: Option<&'a str>,
 }
 
 /// A single comment on an issue or PR.
@@ -179,21 +183,27 @@ pub fn build_prompt(params: &PromptParams) -> String {
         writeln!(out, "{system_prompt}\n").unwrap();
     }
 
-    // 2. Retry context (spec §15.2) — prepended before task section
+    // 2. Rejection feedback (issue #423) — prepended before retry/task
+    // This is feedback from the orchestrator about why a previous PR was rejected.
+    if let Some(feedback) = params.rejection_feedback {
+        render_rejection_feedback(&mut out, feedback);
+    }
+
+    // 3. Retry context (spec §15.2) — prepended before task section
     if let Some(retry) = params.retry {
         render_retry(&mut out, retry);
     }
 
-    // 3. Task description — spec §15.1 layer 2
+    // 4. Task description — spec §15.1 layer 2
     render_task(&mut out, params);
 
-    // 4. Comments
+    // 5. Comments
     render_comments(&mut out, params.comments, params.number);
 
-    // 5. Context — spec §15.1 layer 3
+    // 6. Context — spec §15.1 layer 3
     render_context(&mut out, params);
 
-    // 6. Behavioral instructions — spec §15.1 layer 4
+    // 7. Behavioral instructions — spec §15.1 layer 4
     render_instructions(&mut out, params.branch, params.number);
 
     out
@@ -266,6 +276,7 @@ pub fn build_prompt_for_task(
         parent: None,
         related_tasks: &[],
         retry: retry.as_ref(),
+        rejection_feedback: task.rejection_feedback.as_deref(),
     };
 
     build_prompt(&params)
@@ -274,6 +285,21 @@ pub fn build_prompt_for_task(
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
+
+fn render_rejection_feedback(out: &mut String, feedback: &str) {
+    writeln!(out, "# Previous PR Rejection\n").unwrap();
+    writeln!(
+        out,
+        "Your previous pull request was rejected by the orchestrator. Please address the following feedback:\n"
+    )
+    .unwrap();
+    writeln!(out, "{feedback}\n").unwrap();
+    writeln!(
+        out,
+        "Review this feedback carefully before starting work. The branch has been reset, so you are starting fresh.\n"
+    )
+    .unwrap();
+}
 
 fn render_retry(out: &mut String, retry: &RetryContext) {
     writeln!(out, "# Retry Information\n").unwrap();
@@ -536,6 +562,7 @@ mod tests {
             parent: None,
             related_tasks: &[],
             retry: None,
+            rejection_feedback: None,
         }
     }
 
@@ -712,6 +739,54 @@ mod tests {
     }
 
     #[test]
+    fn rejection_feedback_prepended() {
+        let feedback = "The PR lacks test coverage for the new endpoint. Please add unit tests for the error cases.";
+        let params = PromptParams {
+            rejection_feedback: Some(feedback),
+            ..minimal_params()
+        };
+        let prompt = build_prompt(&params);
+
+        assert!(prompt.contains("# Previous PR Rejection"));
+        assert!(prompt.contains("rejected by the orchestrator"));
+        assert!(prompt.contains(feedback));
+        assert!(prompt.contains("branch has been reset"));
+
+        // Rejection feedback appears before the task section.
+        let rejection_pos = prompt.find("# Previous PR Rejection").unwrap();
+        let task_pos = prompt.find("# Task").unwrap();
+        assert!(rejection_pos < task_pos);
+    }
+
+    #[test]
+    fn rejection_feedback_with_retry_context() {
+        let feedback = "Missing error handling for edge cases.";
+        let retry = RetryContext {
+            attempt: 2,
+            previous_failure: "Session timeout".to_string(),
+            has_prior_commits: false,
+            failure_details: None,
+        };
+        let params = PromptParams {
+            rejection_feedback: Some(feedback),
+            retry: Some(&retry),
+            ..minimal_params()
+        };
+        let prompt = build_prompt(&params);
+
+        // Both sections should be present.
+        assert!(prompt.contains("# Previous PR Rejection"));
+        assert!(prompt.contains("# Retry Information"));
+
+        // Rejection feedback comes before retry context.
+        let rejection_pos = prompt.find("# Previous PR Rejection").unwrap();
+        let retry_pos = prompt.find("# Retry Information").unwrap();
+        let task_pos = prompt.find("# Task").unwrap();
+        assert!(rejection_pos < retry_pos);
+        assert!(retry_pos < task_pos);
+    }
+
+    #[test]
     fn empty_optionals_omitted() {
         let params = PromptParams {
             system_prompt: None,
@@ -727,6 +802,8 @@ mod tests {
 
         // No system prompt section.
         assert!(!prompt.contains("# Project Context"));
+        // No rejection feedback section.
+        assert!(!prompt.contains("# Previous PR Rejection"));
         // No parent line.
         assert!(!prompt.contains("Parent task"));
         // No related tasks line.

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -818,6 +818,48 @@ impl Server {
         Ok(())
     }
 
+    /// Set rejection feedback on a task (issue #423).
+    ///
+    /// Called when the orchestrator rejects a PR to store feedback that will be
+    /// delivered to the agent when the task is re-dispatched. This feedback helps
+    /// the agent understand what went wrong and what to fix.
+    pub async fn set_task_rejection_feedback(
+        &self,
+        task_id: &str,
+        feedback: Option<String>,
+    ) -> Result<(), ServerError> {
+        let mut state = self.state.write().await;
+        let task = state
+            .tasks
+            .get_mut(task_id)
+            .ok_or_else(|| ServerError::TaskNotFound(task_id.to_string()))?;
+
+        task.rejection_feedback = feedback;
+        task.updated_at = chrono::Utc::now();
+
+        // Write-through to store
+        if let Some(ref store) = self.store {
+            if let Ok(store) = store.lock() {
+                if let Err(e) = store.save_task(task) {
+                    tracing::error!(task_id = %task_id, error = %e, "failed to persist rejection feedback to store");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Clear rejection feedback from a task after dispatch (issue #423).
+    ///
+    /// Called after successfully dispatching a task to prevent stale feedback
+    /// from being repeated on subsequent re-dispatches.
+    pub async fn clear_task_rejection_feedback(
+        &self,
+        task_id: &str,
+    ) -> Result<(), ServerError> {
+        self.set_task_rejection_feedback(task_id, None).await
+    }
+
     /// Reorder tasks by updating their priorities.
     ///
     /// Takes a list of task IDs in the desired order and assigns sequential
@@ -1549,6 +1591,8 @@ impl Server {
     ///
     /// The task transitions back to Waiting so the dispatch loop picks
     /// it up and starts a fresh session with the feedback as context.
+    /// The feedback is stored on the task (issue #423) so it survives
+    /// restarts and is delivered to the agent via the prompt.
     pub async fn reject_merge_entry(
         &self,
         entry_id: &str,
@@ -1565,6 +1609,11 @@ impl Server {
                 .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
             entry.task_id.clone()
         };
+
+        // Store rejection feedback on the task for delivery to agent (issue #423)
+        if let Some(fb) = feedback {
+            self.set_task_rejection_feedback(&task_id, Some(fb.to_string())).await?;
+        }
 
         // Emit rejection event
         let event = Event::new(
@@ -2621,6 +2670,43 @@ mod tests {
         // Task should be back to Waiting for re-dispatch
         let task = server.get_task("task-1").await.unwrap();
         assert_eq!(task.state, TaskState::Waiting);
+
+        // Feedback should be set on the task (issue #423)
+        assert_eq!(
+            task.rejection_feedback.as_deref(),
+            Some("add unit tests for the new endpoint")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejection_feedback_cleared_after_set() {
+        let server = test_server().await;
+
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+
+        let task = Task::new("task-1", TaskSource::Internal, "Test task", "proj-1");
+        server.add_task(task).await.unwrap();
+
+        // Set rejection feedback
+        server
+            .set_task_rejection_feedback("task-1", Some("Fix the error handling".to_string()))
+            .await
+            .unwrap();
+
+        // Verify feedback is set
+        let task = server.get_task("task-1").await.unwrap();
+        assert_eq!(
+            task.rejection_feedback.as_deref(),
+            Some("Fix the error handling")
+        );
+
+        // Clear feedback
+        server.clear_task_rejection_feedback("task-1").await.unwrap();
+
+        // Verify feedback is cleared
+        let task = server.get_task("task-1").await.unwrap();
+        assert!(task.rejection_feedback.is_none());
     }
 
     // --- Progress detection tests (spec §13.1, §13.2) ---

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -291,12 +291,14 @@ impl Store {
                 id, source_json, title, description, state,
                 parent_id, blocked_by_json, project, labels_json, priority,
                 session_id, workspace_id, retry_count, last_failure_at,
-                last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at
+                last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at,
+                rejection_feedback
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5,
                 ?6, ?7, ?8, ?9, ?10,
                 ?11, ?12, ?13, ?14,
-                ?15, ?16, ?17, ?18, ?19, ?20
+                ?15, ?16, ?17, ?18, ?19, ?20,
+                ?21
             )",
             params![
                 task.id,
@@ -319,6 +321,7 @@ impl Store {
                 last_activity_at,
                 created_at,
                 updated_at,
+                task.rejection_feedback,
             ],
         )?;
         Ok(())
@@ -330,7 +333,8 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at
+                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at,
+                    rejection_feedback
              FROM tasks WHERE id = ?1",
         )?;
         let mut rows = stmt.query_map(params![id], row_to_task)?;
@@ -349,7 +353,8 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at
+                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at,
+                    rejection_feedback
              FROM tasks",
         )?;
         let rows = stmt.query_map([], row_to_task)?;
@@ -366,7 +371,8 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at
+                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at,
+                    rejection_feedback
              FROM tasks WHERE project = ?1",
         )?;
         let rows = stmt.query_map(params![project], row_to_task)?;
@@ -384,7 +390,8 @@ impl Store {
             "SELECT id, source_json, title, description, state,
                     parent_id, blocked_by_json, project, labels_json, priority,
                     session_id, workspace_id, retry_count, last_failure_at,
-                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at
+                    last_failure_json, source_created_at, source_number, last_activity_at, created_at, updated_at,
+                    rejection_feedback
              FROM tasks WHERE state = ?1",
         )?;
         let rows = stmt.query_map(params![state_json], row_to_task)?;
@@ -775,6 +782,7 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
     let last_activity_at_str: Option<String> = row.get(17)?;
     let created_at_str: String = row.get(18)?;
     let updated_at_str: String = row.get(19)?;
+    let rejection_feedback: Option<String> = row.get(20)?;
 
     let source: TaskSource = serde_json::from_str(&source_json).map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Text, Box::new(e))
@@ -879,6 +887,7 @@ fn row_to_task(row: &rusqlite::Row) -> Result<Task, rusqlite::Error> {
         last_activity_at,
         created_at,
         updated_at,
+        rejection_feedback,
     })
 }
 

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -168,5 +168,27 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
         }
     }
 
+    // Migration: add rejection_feedback column if it doesn't exist (issue #423)
+    // This stores orchestrator feedback from PR rejections for delivery to re-dispatched agents.
+    match conn.execute(
+        "ALTER TABLE tasks ADD COLUMN rejection_feedback TEXT",
+        [],
+    ) {
+        Ok(_) => {
+            tracing::info!("added rejection_feedback column to tasks table");
+        }
+        Err(rusqlite::Error::SqliteFailure(e, Some(ref msg)))
+            if e.extended_code == rusqlite::ffi::SQLITE_ERROR
+                && msg.contains("duplicate column name") =>
+        {
+            // Column already exists — this is expected for existing databases
+            tracing::debug!("rejection_feedback column already exists");
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "failed to add rejection_feedback column");
+            return Err(e);
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

When the orchestrator rejects a PR, the feedback was being generated but never delivered to the agent when the task was re-dispatched. This PR fixes that by:

- Adding a `rejection_feedback` field to the Task model, persisted to the database
- Storing the feedback when `reject_merge_entry` is called
- Including the feedback in the agent's prompt via a new "Previous PR Rejection" section
- Clearing the feedback after successful dispatch to prevent stale feedback from being repeated

## Test plan

- [x] Build passes (`cargo build`)
- [x] All existing tests pass (`cargo test`)
- [x] New tests added for:
  - Rejection feedback being set on task when rejecting merge entry
  - Rejection feedback being cleared after set
  - Prompt rendering with rejection feedback
  - Prompt ordering (rejection feedback before retry context before task)

Closes #423