### PR TITLE
Rebuild desktop client with gpuikit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "str
 bytes = "1.11"
 futures = "0.3"
 sysinfo = "0.33"
-gpui = { git = "https://github.com/zed-industries/zed", rev = "v0.175.5", package = "gpui" }
+gpui = { git = "https://github.com/zed-industries/zed", package = "gpui" }
+gpui_platform = { git = "https://github.com/zed-industries/zed", package = "gpui_platform", features = ["font-kit"] }
+gpuikit = { path = "../gpuikit" }
 smol = "2.0"

--- a/crates/desktop/Cargo.toml
+++ b/crates/desktop/Cargo.toml
@@ -10,19 +10,18 @@ name = "tasks-desktop"
 path = "src/main.rs"
 
 [dependencies]
-# GPUI from Zed
 gpui.workspace = true
-
-# Workspace dependencies
-serde.workspace = true
-serde_json.workspace = true
-chrono.workspace = true
+gpui_platform.workspace = true
+gpuikit.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-futures.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 reqwest.workspace = true
 smol.workspace = true
+futures.workspace = true
+tokio.workspace = true
 
 # Internal crates
 events = { path = "../events" }

--- a/crates/desktop/src/api.rs
+++ b/crates/desktop/src/api.rs
@@ -120,6 +120,7 @@ pub struct ApiClient {
 impl ApiClient {
     /// Create a new API client with the given base URL.
     pub fn new(base_url: impl Into<String>) -> Self {
+        let _guard = crate::tokio_runtime().enter();
         Self {
             client: reqwest::Client::new(),
             base_url: base_url.into(),

--- a/crates/desktop/src/lib.rs
+++ b/crates/desktop/src/lib.rs
@@ -1,67 +1,34 @@
-//! Tasks Desktop — GPUI-based desktop application.
-//!
-//! This crate provides a native desktop UI for the Tasks platform,
-//! built with GPUI (Zed's GPU-accelerated UI framework).
-//!
-//! # Modules
-//!
-//! - [`api`] - HTTP API client for the Tasks server
-//! - [`components`] - Reusable UI primitive components (Button, Badge, Card, Input)
-//! - [`sse`] - Server-Sent Events client for real-time updates
-//! - [`state`] - Application state management (GPUI Model-based)
-//! - [`theme`] - Theming and styling system
-
-use gpui::{Context, SharedString, Window, div, prelude::*, rgb};
+//! Tasks Desktop — GPUI + gpuikit native client.
 
 pub mod api;
-pub mod components;
 pub(crate) mod sse;
 pub mod state;
-pub mod theme;
-pub mod views;
 
-pub use sse::{SseClient, SseClientEvent, SseConnectionState, SseFilters};
-pub use theme::{ComponentTheme, Theme, colors, radius, spacing, style_helpers, typography};
-
-// Re-export state management types
 pub use api::{ApiClient, ApiError};
+pub use sse::{SseClient, SseClientEvent, SseConnectionState, SseFilters};
 pub use state::{AppState, AppStateEvent, ConnectionStatus, create_app_state};
 
-/// Root view for the Tasks desktop application.
-pub struct RootView {
-    title: SharedString,
+use std::sync::OnceLock;
+
+/// Background tokio runtime for reqwest.
+///
+/// GPUI runs on smol, but reqwest needs a tokio reactor. This runtime
+/// stays alive for the process lifetime. Call `install_tokio()` at startup
+/// to enter its context on the main thread; smol worker threads inherit it.
+static TOKIO_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+pub(crate) fn tokio_runtime() -> &'static tokio::runtime::Runtime {
+    TOKIO_RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("failed to create tokio runtime")
+    })
 }
 
-impl RootView {
-    pub fn new(title: impl Into<SharedString>) -> Self {
-        Self {
-            title: title.into(),
-        }
-    }
-}
-
-impl Render for RootView {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        div()
-            .flex()
-            .flex_col()
-            .size_full()
-            .bg(rgb(0x1e1e2e))
-            .justify_center()
-            .items_center()
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap_4()
-                    .items_center()
-                    .child(
-                        div()
-                            .text_3xl()
-                            .text_color(rgb(0xcdd6f4))
-                            .child(self.title.clone()),
-                    )
-                    .child(div().text_color(rgb(0xa6adc8)).child("GPUI Desktop Shell")),
-            )
-    }
+/// Enter the tokio runtime context. Call once at startup before any HTTP calls.
+/// Returns a guard that must be held for the lifetime of the application.
+pub fn install_tokio() -> tokio::runtime::EnterGuard<'static> {
+    tokio_runtime().enter()
 }

--- a/crates/desktop/src/main.rs
+++ b/crates/desktop/src/main.rs
@@ -1,175 +1,308 @@
-//! Tasks Desktop — Main entry point.
-//!
-//! A GPUI-based native desktop application for the Tasks platform.
+//! Tasks Desktop — GPUI + gpuikit native client.
+
+use std::collections::BTreeMap;
 
 use gpui::{
-    App, AppContext as _, Application, Context, Entity, IntoElement, ParentElement, Render, Styled,
-    Window, WindowOptions, actions, px,
+    actions, div, point, prelude::FluentBuilder, px, size, App, AppContext as _, Application,
+    Bounds, Context, Entity, FocusHandle, Focusable, FontWeight, InteractiveElement, IntoElement,
+    KeyBinding, ParentElement, Render, SharedString, Styled, Window, WindowBounds,
+    WindowControlArea, WindowOptions,
 };
-use std::sync::Arc;
-use tasks_desktop::{
-    SseClient, SseClientEvent, SseConnectionState, SseFilters, colors, spacing,
-    style_helpers::{StyledExt, container, heading, muted_text, status_dot},
-    typography,
-};
-use tracing_subscriber::EnvFilter;
+use gpuikit::elements::icon_button::icon_button;
+use gpuikit::elements::input::input;
+use gpuikit::elements::scroll_area::scroll_area;
+use gpuikit::icons::Icons;
+use gpuikit::input::InputState;
+use gpuikit::layout::{h_stack, v_stack};
+use gpuikit::theme::{ActiveTheme, Themeable};
+use models::project::Project;
+use tasks_desktop::state::{AppState, create_app_state};
 
-actions!(desktop, [Quit]);
+actions!(tasks_desktop, [Quit]);
 
-/// Default server URL.
-const DEFAULT_SERVER_URL: &str = "http://localhost:4800";
+const TRAFFIC_LIGHT_PADDING: f32 = 71.;
+const TOOLBAR_HEIGHT: f32 = 46.;
+const SIDEBAR_WIDTH: f32 = 220.;
+const LIST_WIDTH: f32 = 280.;
 
 fn main() {
-    // Initialize logging
+    // Install tokio reactor so reqwest works inside GPUI's smol executor.
+    let _tokio_guard = tasks_desktop::install_tokio();
+
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
         .init();
 
-    Application::new().run(|cx: &mut App| {
-        // Register quit action
-        cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
-        cx.bind_keys([gpui::KeyBinding::new("cmd-q", Quit, None)]);
+    Application::with_platform(gpui_platform::current_platform(false))
+        .with_assets(gpuikit::assets())
+        .run(|cx: &mut App| {
+            gpuikit::init(cx);
 
-        cx.open_window(
-            WindowOptions {
-                window_bounds: Some(gpui::WindowBounds::Windowed(gpui::Bounds {
-                    origin: gpui::Point::default(),
-                    size: gpui::Size {
-                        width: px(800.),
-                        height: px(600.),
-                    },
-                })),
-                ..Default::default()
-            },
-            |_window, cx| {
-                let view = cx.new(|cx| TasksApp::new(cx));
-                view
-            },
-        )
-        .unwrap();
+            cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
+            cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
 
-        cx.activate(true);
-    });
+            let bounds = Bounds::centered(None, size(px(1200.), px(800.)), cx);
+            cx.open_window(
+                WindowOptions {
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
+                    titlebar: Some(gpui::TitlebarOptions {
+                        title: Some(SharedString::from("Tasks")),
+                        appears_transparent: true,
+                        traffic_light_position: Some(point(px(9.), px(9.))),
+                    }),
+                    ..Default::default()
+                },
+                |window, cx| {
+                    let view = cx.new(|cx| TasksApp::new(window, cx));
+                    let focus_handle = view.read(cx).focus_handle.clone();
+                    window.focus(&focus_handle, cx);
+                    view
+                },
+            )
+            .unwrap();
+
+            cx.activate(true);
+        });
 }
 
-/// Main application view.
+/// Group projects by owner (the part before `/` in the repo string).
+fn group_projects_by_owner(projects: &[Project]) -> BTreeMap<String, Vec<&Project>> {
+    let mut groups: BTreeMap<String, Vec<&Project>> = BTreeMap::new();
+    for project in projects {
+        let owner = project
+            .repo
+            .split('/')
+            .next()
+            .unwrap_or("Unknown")
+            .to_string();
+        groups.entry(owner).or_default().push(project);
+    }
+    groups
+}
+
 struct TasksApp {
-    #[allow(dead_code)] // Kept for future disconnect functionality
-    sse_client: Entity<SseClient>,
-    connection_state: SseConnectionState,
-    event_count: usize,
-    last_event: Option<Arc<events::Event>>,
+    focus_handle: FocusHandle,
+    app_state: Entity<AppState>,
+    search_input: Entity<InputState>,
 }
 
 impl TasksApp {
-    fn new(cx: &mut Context<Self>) -> Self {
-        // Get server URL from environment or use default
-        let server_url =
-            std::env::var("TASKS_SERVER_URL").unwrap_or_else(|_| DEFAULT_SERVER_URL.to_string());
+    fn new(_window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let app_state = cx.new(|cx| create_app_state(cx));
+        let search_input = cx.new(|cx| InputState::new_singleline(cx));
 
-        // Create SSE client
-        let filters = SseFilters::new();
-        let sse_client = cx.new(|_| SseClient::new(&server_url, filters));
-
-        // Subscribe to SSE events
-        cx.subscribe(
-            &sse_client,
-            |this: &mut Self, _entity, event: &SseClientEvent, cx| match event {
-                SseClientEvent::StateChanged(state) => {
-                    this.connection_state = *state;
-                    cx.notify();
-                }
-                SseClientEvent::EventReceived(event) => {
-                    this.event_count += 1;
-                    this.last_event = Some(event.clone());
-                    cx.notify();
-                }
-                SseClientEvent::Error(err) => {
-                    tracing::error!(error = %err, "SSE error");
-                    cx.notify();
-                }
-            },
-        )
+        // Re-render when app state changes
+        cx.subscribe(&app_state, |_this, _state, _event, cx| {
+            cx.notify();
+        })
         .detach();
 
-        // Start connection
-        sse_client.update(cx, |client: &mut SseClient, cx| {
-            client.connect(cx);
-        });
-
         Self {
-            sse_client,
-            connection_state: SseConnectionState::Connecting,
-            event_count: 0,
-            last_event: None,
+            focus_handle: cx.focus_handle(),
+            app_state,
+            search_input,
         }
+    }
+
+    fn render_sidebar(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let state = self.app_state.read(cx);
+        let projects = state.projects();
+        let selected_id = state.selected_project().map(|s| s.to_string());
+        let grouped = group_projects_by_owner(projects);
+
+        v_stack()
+            .id("sidebar")
+            .w(px(SIDEBAR_WIDTH))
+            .h_full()
+            .flex_shrink_0()
+            .bg(theme.surface())
+            .border_r_1()
+            .border_color(theme.border())
+            // Toolbar: traffic lights left, + button right
+            .child(
+                h_stack()
+                    .id("sidebar-toolbar")
+                    .window_control_area(WindowControlArea::Drag)
+                    .h(px(TOOLBAR_HEIGHT))
+                    .w_full()
+                    .flex_shrink_0()
+                    .pl(px(TRAFFIC_LIGHT_PADDING))
+                    .pr_2()
+                    .items_center()
+                    .justify_end()
+                    .child(
+                        icon_button("add-project", Icons::plus()).on_click(
+                            cx.listener(|_this, _event, _window, _cx| {
+                                // TODO: open add project dialog
+                            }),
+                        ),
+                    ),
+            )
+            // Search input
+            .child(
+                div()
+                    .px_2()
+                    .pb_1()
+                    .child(input(&self.search_input, cx).placeholder("Search...")),
+            )
+            // Scrollable project list grouped by owner
+            .child(
+                scroll_area("project-list")
+                    .vertical()
+                    .full_width(true)
+                    .full_height(true)
+                    .child(v_stack().w_full().pb_2().children(
+                        grouped.into_iter().map({
+                            let theme = theme.clone();
+                            let selected_id = selected_id.clone();
+                            move |(owner, projects)| {
+                                let theme = theme.clone();
+                                let selected_id = selected_id.clone();
+                                v_stack()
+                                    .w_full()
+                                    .child(
+                                        div()
+                                            .px_3()
+                                            .pt_3()
+                                            .pb_1()
+                                            .text_xs()
+                                            .font_weight(FontWeight::SEMIBOLD)
+                                            .text_color(theme.fg_muted())
+                                            .child(owner),
+                                    )
+                                    .children(projects.into_iter().map({
+                                        let theme = theme.clone();
+                                        let selected_id = selected_id.clone();
+                                        move |project| {
+                                            let repo_name = project
+                                                .repo
+                                                .split('/')
+                                                .nth(1)
+                                                .unwrap_or(&project.repo);
+                                            let is_selected =
+                                                selected_id.as_deref() == Some(&project.id);
+
+                                            div()
+                                                .id(SharedString::from(format!(
+                                                    "project-{}",
+                                                    project.id
+                                                )))
+                                                .mx_2()
+                                                .px_2()
+                                                .py_1()
+                                                .rounded_md()
+                                                .text_sm()
+                                                .cursor_pointer()
+                                                .when(is_selected, |el| {
+                                                    el.bg(theme.selection())
+                                                        .text_color(theme.fg())
+                                                })
+                                                .when(!is_selected, |el| {
+                                                    el.text_color(theme.fg()).hover(|style| {
+                                                        style.bg(theme.border_subtle())
+                                                    })
+                                                })
+                                                .child(repo_name.to_string())
+                                        }
+                                    }))
+                            }
+                        }),
+                    )),
+            )
+    }
+
+    fn render_list(&self, cx: &Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+
+        v_stack()
+            .id("list")
+            .w(px(LIST_WIDTH))
+            .h_full()
+            .flex_shrink_0()
+            .bg(theme.bg())
+            .border_r_1()
+            .border_color(theme.border())
+            .child(
+                h_stack()
+                    .id("list-toolbar")
+                    .window_control_area(WindowControlArea::Drag)
+                    .h(px(TOOLBAR_HEIGHT))
+                    .w_full()
+                    .flex_shrink_0()
+                    .px_3()
+                    .items_center()
+                    .border_b_1()
+                    .border_color(theme.border()),
+            )
+            .child(
+                v_stack().flex_1().p_2().child(
+                    div()
+                        .text_xs()
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(theme.fg_muted())
+                        .child("TASKS"),
+                ),
+            )
+    }
+
+    fn render_detail(&self, cx: &Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+
+        v_stack()
+            .id("detail")
+            .flex_1()
+            .h_full()
+            .bg(theme.bg())
+            .child(
+                h_stack()
+                    .id("detail-toolbar")
+                    .window_control_area(WindowControlArea::Drag)
+                    .h(px(TOOLBAR_HEIGHT))
+                    .w_full()
+                    .flex_shrink_0()
+                    .px_3()
+                    .items_center()
+                    .border_b_1()
+                    .border_color(theme.border()),
+            )
+            .child(
+                v_stack()
+                    .flex_1()
+                    .p_4()
+                    .justify_center()
+                    .items_center()
+                    .child(
+                        div()
+                            .text_color(theme.fg_muted())
+                            .child("Select a task"),
+                    ),
+            )
+    }
+}
+
+impl Focusable for TasksApp {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
     }
 }
 
 impl Render for TasksApp {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        let status_text = match self.connection_state {
-            SseConnectionState::Disconnected => "Disconnected",
-            SseConnectionState::Connecting => "Connecting...",
-            SseConnectionState::Connected => "Connected",
-            SseConnectionState::Reconnecting => "Reconnecting...",
-            SseConnectionState::Failed => "Connection Failed",
-        };
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
 
-        let status_color = match self.connection_state {
-            SseConnectionState::Connected => colors::STATE_COMPLETED,
-            SseConnectionState::Connecting | SseConnectionState::Reconnecting => {
-                colors::STATE_QUESTION
-            }
-            SseConnectionState::Disconnected | SseConnectionState::Failed => colors::STATE_FAILED,
-        };
-
-        let last_event_text = self
-            .last_event
-            .as_ref()
-            .map(|e| format!("{}: {}", e.event_type.as_str(), e.task))
-            .unwrap_or_else(|| "No events yet".to_string());
-
-        container()
-            .p(spacing::SPACE_4)
-            .gap(spacing::SPACE_4)
-            .child(
-                gpui::div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::SPACE_2)
-                    .child(
-                        heading(typography::TEXT_XL)
-                            .font_weight(typography::WEIGHT_BOLD)
-                            .child("Tasks Desktop"),
-                    )
-                    .child(muted_text().child("GPUI-based desktop client for the Tasks platform")),
-            )
-            .child(
-                gpui::div()
-                    .flex()
-                    .items_center()
-                    .gap(spacing::SPACE_2)
-                    .child(status_dot(status_color))
-                    .child(
-                        gpui::div()
-                            .text_primary()
-                            .child(format!("Status: {}", status_text)),
-                    ),
-            )
-            .child(
-                gpui::div()
-                    .flex()
-                    .flex_col()
-                    .gap(spacing::SPACE_1)
-                    .child(
-                        gpui::div()
-                            .text_primary()
-                            .child(format!("Events received: {}", self.event_count)),
-                    )
-                    .child(muted_text().child(format!("Last event: {}", last_event_text))),
-            )
+        h_stack()
+            .id("tasks-app")
+            .key_context("TasksApp")
+            .track_focus(&self.focus_handle)
+            .size_full()
+            .bg(theme.bg())
+            .text_color(theme.fg())
+            .child(self.render_sidebar(cx))
+            .child(self.render_list(cx))
+            .child(self.render_detail(cx))
     }
 }

--- a/crates/desktop/src/sse.rs
+++ b/crates/desktop/src/sse.rs
@@ -162,7 +162,7 @@ impl SseClient {
 
         let url = self.filters.build_url(&self.base_url);
 
-        cx.spawn(|this, cx| async move {
+        cx.spawn(async move |this, cx| {
             run_sse_loop(url, stop_flag, this, cx).await;
         })
         .detach();
@@ -212,7 +212,7 @@ async fn run_sse_loop(
     url: String,
     stop_flag: Arc<AtomicBool>,
     entity: WeakEntity<SseClient>,
-    mut cx: AsyncApp,
+    cx: &mut AsyncApp,
 ) {
     let mut reconnect_delay = Duration::from_millis(RECONNECT_DELAY_MS);
     let mut consecutive_failures = 0u32;
@@ -227,7 +227,7 @@ async fn run_sse_loop(
         info!(url = %url, "SSE connecting...");
 
         let (was_connected, result) =
-            connect_and_stream(&url, &stop_flag, &entity, &mut cx).await;
+            connect_and_stream(&url, &stop_flag, &entity, cx).await;
 
         // Reset failure counter if we had a successful connection
         if was_connected {
@@ -251,7 +251,7 @@ async fn run_sse_loop(
 
                 // Update state based on failure count
                 let error_msg = e.to_string();
-                if let Err(update_err) = entity.update(&mut cx, |client: &mut SseClient, cx| {
+                if let Err(update_err) = entity.update(cx, |client: &mut SseClient, cx| {
                     if consecutive_failures == 1 {
                         // First failure: enter reconnecting state (grace period)
                         client.set_state(SseConnectionState::Reconnecting, cx);
@@ -279,7 +279,7 @@ async fn run_sse_loop(
                 while elapsed < delay {
                     if stop_flag.load(Ordering::SeqCst) {
                         info!(url = %url, "SSE client stopped during reconnect");
-                        if let Err(e) = entity.update(&mut cx, |client: &mut SseClient, cx| {
+                        if let Err(e) = entity.update(cx, |client: &mut SseClient, cx| {
                             client.stop_flag = None;
                             client.set_state(SseConnectionState::Disconnected, cx);
                         }) {
@@ -298,7 +298,7 @@ async fn run_sse_loop(
         }
     }
 
-    if let Err(e) = entity.update(&mut cx, |client: &mut SseClient, cx| {
+    if let Err(e) = entity.update(cx, |client: &mut SseClient, cx| {
         client.stop_flag = None;
         client.set_state(SseConnectionState::Disconnected, cx);
     }) {

--- a/crates/desktop/src/state.rs
+++ b/crates/desktop/src/state.rs
@@ -341,11 +341,11 @@ impl AppState {
         let api_client = self.api_client.clone();
         let fetch_in_flight = self.fetch_in_flight.clone();
 
-        cx.spawn(|this, mut cx| async move {
+        cx.spawn(async move |this, cx| {
             let result = api_client.fetch_snapshot().await;
             fetch_in_flight.store(false, Ordering::SeqCst);
 
-            if let Err(e) = this.update(&mut cx, |state, cx| {
+            if let Err(e) = this.update(cx, |state, cx| {
                 state.update_snapshot(result, cx);
             }) {
                 warn!(error = %e, "Failed to update snapshot state");
@@ -408,7 +408,7 @@ impl AppState {
         let stop_flag = Arc::new(AtomicBool::new(false));
         self.stop_polling = Some(stop_flag.clone());
 
-        cx.spawn(|this, cx| async move {
+        cx.spawn(async move |this, cx| {
             run_polling_loop(stop_flag, this, cx).await;
         })
         .detach();
@@ -473,7 +473,7 @@ impl Drop for AppState {
 async fn run_polling_loop(
     stop_flag: Arc<AtomicBool>,
     entity: WeakEntity<AppState>,
-    mut cx: AsyncApp,
+    cx: &mut AsyncApp,
 ) {
     let interval = Duration::from_millis(POLL_INTERVAL_MS);
 
@@ -488,7 +488,7 @@ async fn run_polling_loop(
         }
 
         // Trigger a snapshot refresh
-        if let Err(e) = entity.update(&mut cx, |state, cx| {
+        if let Err(e) = entity.update(cx, |state, cx| {
             state.refresh_snapshot(cx);
         }) {
             warn!(error = %e, "Failed to trigger snapshot refresh from polling loop");


### PR DESCRIPTION
## Summary

- Replaces custom components/theme system with [gpuikit](https://github.com/iamnbutler/gpuikit) (local path dep at `../gpuikit`)
- Upgrades gpui to latest zed nightly to match gpuikit's dependency (includes `gpui_platform` split)
- 3-column Apple Notes-style layout: sidebar (projects grouped by org), task list, detail pane
- Custom transparent titlebar with macOS traffic lights embedded in the sidebar column
- Sidebar wired to real `AppState`/`ApiClient` — projects fetched from server, grouped by owner, with selection + search input
- Adds background tokio runtime bridge (`install_tokio()`) so reqwest works inside GPUI's smol executor
- Fixes gpui API breaking changes: `async move` spawn closures, `&mut AsyncApp` borrows

## What's not done yet

- Task list and detail columns are placeholder (wiring to real task data is next)
- Project selection click handler (sets `selected_project` on AppState)
- Add project dialog (gpuikit `dialog` component is ready)
- Search filtering (input is wired but not connected to filter logic)
- gpuikit `list` component for virtualized rendering (in progress upstream)

## Test plan

- [ ] `cargo check` — full workspace builds clean
- [ ] `cargo run --package tasks-desktop` — window opens with 3-column layout
- [ ] With server running (`cargo run -- run --web`), sidebar populates with real projects grouped by org