### PR TITLE
Make automation run state transitions idempotent

### DIFF
--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -481,6 +481,16 @@ impl Server {
                 .ok_or_else(|| ServerError::StoreError(format!("run not found: {}", run_id)))?
         };
 
+        // If already in a terminal state, skip to avoid overwriting
+        if run.status.is_terminal() {
+            tracing::debug!(
+                run_id = %run_id,
+                status = ?run.status,
+                "automation run already terminal, skipping duplicate complete"
+            );
+            return Ok(run);
+        }
+
         run.complete(output.clone());
 
         // Save to store
@@ -522,6 +532,17 @@ impl Server {
                 .map_err(|e| ServerError::StoreError(e.to_string()))?
                 .ok_or_else(|| ServerError::StoreError(format!("run not found: {}", run_id)))?
         };
+
+        // If already in a terminal state, skip to avoid duplicate events
+        // (e.g. hard time limit emits TaskStateFailed, then handle_exit emits another)
+        if run.status.is_terminal() {
+            tracing::debug!(
+                run_id = %run_id,
+                status = ?run.status,
+                "automation run already terminal, skipping duplicate fail"
+            );
+            return Ok(run);
+        }
 
         run.fail(&error_str);
 


### PR DESCRIPTION
## Summary

- Adds terminal state guards to `fail_automation_run()` and `complete_automation_run()` so they return early if the run is already in a terminal state (Failed/Completed/Cancelled)
- When a session's hard time limit fires, two `TaskStateFailed` events are emitted — one from the session monitor and one from `handle_exit()`. The automation event listener catches both and previously called `fail_automation_run()` twice, causing duplicate `AutomationRunFailed` events with overwritten `error` and `completed_at` fields
- This matches the existing guard pattern already used in `cancel_automation_run()`

## Test plan

- [ ] Verify that when hard time limit fires, only one `AutomationRunFailed` event is published
- [ ] Verify that a run already in `Failed` state is not overwritten by a subsequent fail/complete call
- [ ] Verify normal (non-duplicate) fail and complete paths still work correctly

Fixes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)