### PR TITLE
Fix stale sessions persisting after monitor task crash

### DIFF
--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -428,8 +428,24 @@ impl<R: ContainerRuntime + Clone + Send + Sync + 'static> SessionManager<R> {
         time_limits: SessionLimits,
     ) -> Result<(), SessionManagerError> {
         // Check if session already exists
-        if self.sessions.read().await.contains_key(&task_id) {
-            return Err(SessionManagerError::AlreadyExists(task_id));
+        {
+            let sessions = self.sessions.read().await;
+            if let Some(handle) = sessions.get(&task_id) {
+                if !handle.monitor_handle.is_finished() {
+                    return Err(SessionManagerError::AlreadyExists(task_id));
+                }
+                // Monitor task has finished (panic, OOM-kill, or missed cleanup).
+                // Drop the read lock, remove the stale entry, then proceed.
+                drop(sessions);
+                let removed = self.sessions.write().await.remove(&task_id);
+                if let Some(removed) = removed {
+                    tracing::warn!(
+                        task_id = %task_id,
+                        container_id = %removed.container_id,
+                        "removed stale session entry (monitor task already finished)"
+                    );
+                }
+            }
         }
 
         // Create and start the runtime session


### PR DESCRIPTION
## Summary

- Detects stale session entries whose monitor task has already finished (due to panic, OOM-kill, or missed cleanup) by checking `JoinHandle::is_finished()` before returning `AlreadyExists`
- Removes the stale entry and logs a warning, allowing a new session to start for the task
- Prevents tasks from being permanently blocked when the monitor crashes before reaching its cleanup code

Closes #459

## Test plan

- [ ] Verify that normal session lifecycle (start, run, stop) is unaffected
- [ ] Simulate a monitor task panic and confirm the stale entry is cleaned up on next `start_session` call
- [ ] Confirm the warning log is emitted when a stale entry is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)