### PR TITLE
Prompt to clear local data on version change

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -24,11 +24,60 @@ fn data_dir() -> String {
     })
 }
 
+fn db_path() -> String {
+    format!("{}/db.sqlite", data_dir())
+}
+
 fn open_store() -> Result<Store, String> {
     let dir = data_dir();
     std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create data dir: {e}"))?;
-    let db_path = format!("{dir}/db.sqlite");
-    Store::open(&db_path).map_err(|e| format!("Failed to open store: {e}"))
+    Store::open(db_path()).map_err(|e| format!("Failed to open store: {e}"))
+}
+
+/// Check whether the stored data version matches the expected version.
+/// If there is a mismatch, prompt the user to clear and rebuild local data.
+/// Returns the opened store on success.
+fn open_store_with_version_check() -> Result<Store, String> {
+    let dir = data_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create data dir: {e}"))?;
+    let db = db_path();
+
+    // Only check version if the database file already exists
+    if std::path::Path::new(&db).exists() {
+        if let Some((stored, expected)) = Store::check_version(&db)
+            .map_err(|e| format!("Failed to check data version: {e}"))?
+        {
+            eprintln!(
+                "Local data version mismatch: stored v{stored}, expected v{expected}."
+            );
+            eprintln!(
+                "The data format has changed and local data needs to be cleared."
+            );
+            eprintln!(
+                "This will remove cached tasks, merge queue entries, and event logs."
+            );
+            eprintln!("Projects will be re-imported from GitHub on the next poll cycle.");
+            eprintln!();
+
+            if std::env::var("TASKS_CLEAR_DATA").as_deref() == Ok("1") {
+                eprintln!("TASKS_CLEAR_DATA=1 detected — clearing automatically.");
+            } else {
+                eprint!("Clear local data and continue? [y/N] ");
+                let mut input = String::new();
+                std::io::stdin()
+                    .read_line(&mut input)
+                    .map_err(|e| format!("Failed to read input: {e}"))?;
+                if !matches!(input.trim(), "y" | "Y" | "yes" | "Yes" | "YES") {
+                    return Err("Aborted. Local data was not modified.".to_string());
+                }
+            }
+
+            return Store::clear_and_reopen(&db, &dir)
+                .map_err(|e| format!("Failed to clear and reopen store: {e}"));
+        }
+    }
+
+    Store::open(&db).map_err(|e| format!("Failed to open store: {e}"))
 }
 
 fn cmd_add_project(repo: &str) -> Result<(), String> {
@@ -326,6 +375,12 @@ async fn main() {
             };
             if args.iter().any(|a| a == "--web") {
                 config.web = true;
+            }
+            // Check data version before starting the run loop (issue #452).
+            // This prompts the user if a version mismatch is detected.
+            if let Err(e) = open_store_with_version_check() {
+                eprintln!("{e}");
+                std::process::exit(1);
             }
             match run_loop::run(config).await {
                 Ok(run_loop::RunResult::Normal) => Ok(()),

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -13,3 +13,6 @@ serde_json.workspace = true
 chrono.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -8,6 +8,7 @@ mod accounting;
 mod schema;
 
 pub use accounting::{AccountingSummary, TaskAccounting};
+pub use schema::DATA_VERSION;
 
 use std::path::Path;
 
@@ -25,6 +26,8 @@ pub enum StoreError {
     Sqlite(#[from] rusqlite::Error),
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("data version mismatch: stored={stored}, expected={expected}")]
+    VersionMismatch { stored: u32, expected: u32 },
 }
 
 /// Persistent storage backed by SQLite (spec §3.5).
@@ -36,6 +39,44 @@ pub struct Store {
 }
 
 impl Store {
+    /// Check the stored data version without fully initializing the schema.
+    ///
+    /// Returns `Ok(None)` if the database is new (version 0).
+    /// Returns `Ok(Some((stored, expected)))` if there is a mismatch.
+    /// Returns `Ok(None)` if versions match.
+    pub fn check_version(path: impl AsRef<Path>) -> Result<Option<(u32, u32)>, StoreError> {
+        let conn = Connection::open(path)?;
+        let stored = schema::read_version(&conn)?;
+        if stored == 0 || stored == schema::DATA_VERSION {
+            Ok(None)
+        } else {
+            Ok(Some((stored, schema::DATA_VERSION)))
+        }
+    }
+
+    /// Delete the database file and event log directory, then open a fresh store.
+    pub fn clear_and_reopen(db_path: impl AsRef<Path>, data_dir: impl AsRef<Path>) -> Result<Self, StoreError> {
+        let db = db_path.as_ref();
+        let data = data_dir.as_ref();
+
+        // Remove the SQLite database and its WAL/SHM files
+        for ext in &["", "-wal", "-shm"] {
+            let mut p = db.as_os_str().to_owned();
+            p.push(ext);
+            let _ = std::fs::remove_file(&p);
+        }
+
+        // Remove the event log directory
+        let events_dir = data.join("events");
+        if events_dir.exists() {
+            let _ = std::fs::remove_dir_all(&events_dir);
+        }
+
+        tracing::info!("cleared local data for version upgrade");
+
+        Self::open(db)
+    }
+
     /// Open or create a store at the given path.
     pub fn open(path: impl AsRef<Path>) -> Result<Self, StoreError> {
         let conn = Connection::open(path)?;
@@ -1628,5 +1669,73 @@ mod tests {
         let updated = store.get_automation_run("r1").unwrap().unwrap();
         assert_eq!(updated.status, RunStatus::Completed);
         assert_eq!(updated.output, Some("Output text".to_string()));
+    }
+
+    #[test]
+    fn test_data_version_stamped_on_init() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        // Before init, version is 0
+        assert_eq!(schema::read_version(&conn).unwrap(), 0);
+        schema::initialize(&conn).unwrap();
+        // After init, version matches DATA_VERSION
+        assert_eq!(schema::read_version(&conn).unwrap(), schema::DATA_VERSION);
+    }
+
+    #[test]
+    fn test_check_version_fresh_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("test.sqlite");
+        // Fresh DB (doesn't exist yet) — no mismatch
+        assert!(Store::check_version(&db).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_check_version_matching() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("test.sqlite");
+        // Create and initialize
+        Store::open(&db).unwrap();
+        // Version should match
+        assert!(Store::check_version(&db).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_check_version_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("test.sqlite");
+        // Create DB with a different version
+        {
+            let conn = Connection::open(&db).unwrap();
+            conn.pragma_update(None, "user_version", 999u32).unwrap();
+        }
+        let result = Store::check_version(&db).unwrap();
+        assert_eq!(result, Some((999, schema::DATA_VERSION)));
+    }
+
+    #[test]
+    fn test_clear_and_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("test.sqlite");
+
+        // Create a store with some data
+        {
+            let store = Store::open(&db).unwrap();
+            let project = models::project::Project::new("test/repo", "test/repo");
+            store.save_project(&project).unwrap();
+            assert_eq!(store.list_projects().unwrap().len(), 1);
+        }
+
+        // Create events dir to verify it gets cleaned up
+        let events = dir.path().join("events");
+        std::fs::create_dir_all(&events).unwrap();
+        std::fs::write(events.join("dummy.jsonl"), "{}").unwrap();
+
+        // Clear and reopen
+        let store = Store::clear_and_reopen(&db, dir.path()).unwrap();
+        // Data should be gone
+        assert_eq!(store.list_projects().unwrap().len(), 0);
+        // Events dir should be gone
+        assert!(!events.exists());
     }
 }

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -26,8 +26,8 @@ pub enum StoreError {
     Sqlite(#[from] rusqlite::Error),
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),
-    #[error("data version mismatch: stored={stored}, expected={expected}")]
-    VersionMismatch { stored: u32, expected: u32 },
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 /// Persistent storage backed by SQLite (spec §3.5).
@@ -55,21 +55,36 @@ impl Store {
     }
 
     /// Delete the database file and event log directory, then open a fresh store.
+    ///
+    /// Returns an error if the primary database file cannot be removed.
+    /// WAL/SHM files and the events directory are removed on a best-effort basis.
     pub fn clear_and_reopen(db_path: impl AsRef<Path>, data_dir: impl AsRef<Path>) -> Result<Self, StoreError> {
         let db = db_path.as_ref();
         let data = data_dir.as_ref();
 
-        // Remove the SQLite database and its WAL/SHM files
-        for ext in &["", "-wal", "-shm"] {
-            let mut p = db.as_os_str().to_owned();
-            p.push(ext);
-            let _ = std::fs::remove_file(&p);
+        // Remove the primary SQLite database file (propagate errors)
+        if db.exists() {
+            std::fs::remove_file(db)?;
         }
 
-        // Remove the event log directory
+        // Remove WAL/SHM files on best-effort basis (auxiliary files)
+        for ext in &["-wal", "-shm"] {
+            let mut p = db.as_os_str().to_owned();
+            p.push(ext);
+            let path = std::path::Path::new(&p);
+            if path.exists() {
+                if let Err(e) = std::fs::remove_file(path) {
+                    tracing::warn!(path = ?path, error = %e, "failed to remove auxiliary db file");
+                }
+            }
+        }
+
+        // Remove the event log directory on best-effort basis
         let events_dir = data.join("events");
         if events_dir.exists() {
-            let _ = std::fs::remove_dir_all(&events_dir);
+            if let Err(e) = std::fs::remove_dir_all(&events_dir) {
+                tracing::warn!(path = ?events_dir, error = %e, "failed to remove events directory");
+            }
         }
 
         tracing::info!("cleared local data for version upgrade");

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -2,6 +2,22 @@
 
 use rusqlite::Connection;
 
+/// Current data schema version. Bump this when making incompatible schema changes
+/// that require a full data reset rather than an incremental migration.
+pub const DATA_VERSION: u32 = 1;
+
+/// Read the stored data version from SQLite's `user_version` pragma.
+/// Returns 0 if no version has been set (fresh database).
+pub fn read_version(conn: &Connection) -> Result<u32, rusqlite::Error> {
+    conn.pragma_query_value(None, "user_version", |row| row.get(0))
+}
+
+/// Write the data version to SQLite's `user_version` pragma.
+pub fn write_version(conn: &Connection, version: u32) -> Result<(), rusqlite::Error> {
+    conn.pragma_update(None, "user_version", version)?;
+    Ok(())
+}
+
 /// Create tables if they don't exist.
 pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute_batch(
@@ -205,6 +221,9 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
             return Err(e);
         }
     }
+
+    // Stamp the current data version so future runs can detect mismatches.
+    write_version(conn, DATA_VERSION)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Adds data versioning to the SQLite store using SQLite's `user_version` pragma
- On startup (`run` command), detects if stored data version doesn't match expected version
- Prompts user interactively before clearing data — never auto-deletes
- Supports `TASKS_CLEAR_DATA=1` environment variable for non-interactive/CI use
- Clears SQLite database files and event log directory, then re-initializes fresh

## How it works

1. `schema::DATA_VERSION` (currently `1`) is stamped via `PRAGMA user_version` after every schema init
2. `Store::check_version()` reads the pragma without initializing — detects mismatches
3. `open_store_with_version_check()` in the app prompts the user if mismatch found
4. `Store::clear_and_reopen()` removes db files + events dir, then opens fresh

## Test plan

- [x] `test_data_version_stamped_on_init` — version set after schema init
- [x] `test_check_version_fresh_db` — no mismatch on new DB
- [x] `test_check_version_matching` — no mismatch when versions match
- [x] `test_check_version_mismatch` — detects version difference
- [x] `test_clear_and_reopen` — data + events cleared, fresh store returned

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)