### PR TITLE
Fix blocking Mutex in async session management

### DIFF
--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -535,21 +535,35 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
     // Rolling stderr buffer for failure diagnosis (spec §13.4)
     let mut stderr_buffer: VecDeque<String> = VecDeque::with_capacity(MAX_STDERR_LINES);
 
-    // Wrap session for shared access between blocking recv thread and async command handler
-    let session = Arc::new(std::sync::Mutex::new(session));
-    let session_recv = session.clone();
-    let session_cmd = session.clone();
-
     let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
+    let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<SessionCommand>();
 
-    // Blocking reader thread — reads from the sync transport
+    // Clone task_id for use in the blocking reader thread
+    let task_id_for_reader = task_id.clone();
+
+    // Blocking reader thread — owns the session exclusively.
+    // Reads events from the sync transport and processes commands from async tasks,
+    // avoiding any cross-boundary Mutex contention.
     let reader = tokio::task::spawn_blocking(move || {
+        let mut session = session;
         loop {
-            let result = {
-                let mut sess = session_recv.lock().unwrap();
-                sess.recv_timeout(Duration::from_secs(1))
-            }; // lock released here
-            match result {
+            // Drain any pending commands before reading
+            while let Ok(cmd) = cmd_rx.try_recv() {
+                match cmd {
+                    SessionCommand::Chat(text) => {
+                        if let Err(e) = session.send_chat(text) {
+                            tracing::error!(task_id = %task_id_for_reader, error = %e, "failed to send chat to session");
+                        }
+                    }
+                    SessionCommand::Stop => {
+                        if let Err(e) = session.stop_agent() {
+                            tracing::error!(task_id = %task_id_for_reader, error = %e, "failed to stop agent");
+                        }
+                    }
+                }
+            }
+
+            match session.recv_timeout(Duration::from_secs(1)) {
                 Ok(event) => {
                     if event_tx.blocking_send(event).is_err() {
                         break;
@@ -617,18 +631,8 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
                 }
             }
             Some(cmd) = command_rx.recv() => {
-                let mut sess = session_cmd.lock().unwrap();
-                match cmd {
-                    SessionCommand::Chat(text) => {
-                        if let Err(e) = sess.send_chat(text) {
-                            tracing::error!(task_id = %task_id, error = %e, "failed to send chat to session");
-                        }
-                    }
-                    SessionCommand::Stop => {
-                        if let Err(e) = sess.stop_agent() {
-                            tracing::error!(task_id = %task_id, error = %e, "failed to stop agent");
-                        }
-                    }
+                if cmd_tx.send(cmd).is_err() {
+                    tracing::error!(task_id = %task_id, "session reader thread gone, cannot forward command");
                 }
             }
             // Timeout arm: fires when the next time limit is reached, even if no
@@ -677,9 +681,8 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
             }
 
             // Stop the agent
-            let mut sess = session_cmd.lock().unwrap();
-            if let Err(e) = sess.stop_agent() {
-                tracing::error!(task_id = %task_id, error = %e, "failed to stop agent at hard time limit");
+            if cmd_tx.send(SessionCommand::Stop).is_err() {
+                tracing::error!(task_id = %task_id, "session reader thread gone, cannot send stop at hard time limit");
             }
         } else if elapsed >= soft_limit && !soft_limit_notified {
             soft_limit_notified = true;


### PR DESCRIPTION
## Summary

- Eliminates `std::sync::Mutex` around the session object that was shared between a `spawn_blocking` reader thread and async command handlers
- Moves session ownership entirely into the blocking reader thread, which now processes commands via a `std::sync::mpsc` channel
- Commands (chat, stop) from async tasks are forwarded through the channel and drained on each loop iteration before `recv_timeout`

**Before:** The blocking reader held the Mutex during `recv_timeout(1s)`, causing async command handlers to block for up to 1 second per attempt. Under concurrent chat + stop commands, this could deadlock or starve the async runtime.

**After:** No Mutex contention — the session is single-owned by the reader thread. Commands are delivered via a lock-free channel with ~nanosecond send latency.

## Test plan

- [ ] Verify compilation with `cargo check -p tasks-session`
- [ ] Run existing session tests
- [ ] Manual test: concurrent chat + stop commands under load should no longer cause delays or deadlocks

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)