### PR TITLE
Log malformed JSON lines in transport reader loop

### DIFF
--- a/crates/runtime/src/protocol/codec.rs
+++ b/crates/runtime/src/protocol/codec.rs
@@ -11,13 +11,16 @@ pub fn encode<T: Serialize>(msg: &T) -> String {
     s
 }
 
-/// Parse a single JSON line. Returns None on empty or invalid input.
-pub fn decode_line<T: DeserializeOwned>(line: &str) -> Option<T> {
+/// Parse a single JSON line.
+///
+/// Returns `Ok(None)` for empty/whitespace-only lines, `Ok(Some(T))` on
+/// successful decode, or `Err` when the line contains invalid JSON.
+pub fn decode_line<T: DeserializeOwned>(line: &str) -> Result<Option<T>, serde_json::Error> {
     let trimmed = line.trim();
     if trimmed.is_empty() {
-        return None;
+        return Ok(None);
     }
-    serde_json::from_str(trimmed).ok()
+    serde_json::from_str(trimmed).map(Some)
 }
 
 /// Line-buffered reader that yields complete messages.
@@ -50,8 +53,12 @@ where
             let line = self.buffer[..newline_pos].to_string();
             self.buffer = self.buffer[newline_pos + 1..].to_string();
 
-            if let Some(msg) = decode_line(&line) {
-                (self.callback)(msg);
+            match decode_line(&line) {
+                Ok(Some(msg)) => (self.callback)(msg),
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, line = %line, "malformed JSON line, discarding");
+                }
             }
         }
     }
@@ -59,8 +66,12 @@ where
     /// Flush any remaining data in the buffer.
     pub fn flush(&mut self) {
         if !self.buffer.trim().is_empty() {
-            if let Some(msg) = decode_line(&self.buffer) {
-                (self.callback)(msg);
+            match decode_line(&self.buffer) {
+                Ok(Some(msg)) => (self.callback)(msg),
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, line = %self.buffer, "malformed JSON in buffer on flush, discarding");
+                }
             }
         }
         self.buffer.clear();
@@ -83,15 +94,21 @@ mod tests {
     #[test]
     fn decode_event() {
         let line = r#"{"ev":"system:ready"}"#;
-        let event: Option<Event> = decode_line(line);
-        assert!(event.is_some());
-        assert!(event.unwrap().is_ready());
+        let event: Result<Option<Event>, _> = decode_line(line);
+        let event = event.expect("should parse").expect("should not be empty");
+        assert!(event.is_ready());
     }
 
     #[test]
     fn decode_empty() {
-        let event: Option<Event> = decode_line("");
-        assert!(event.is_none());
+        let result: Result<Option<Event>, _> = decode_line("");
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[test]
+    fn decode_malformed() {
+        let result: Result<Option<Event>, _> = decode_line("{bad json}");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/runtime/src/transport.rs
+++ b/crates/runtime/src/transport.rs
@@ -55,13 +55,17 @@ impl StdioTransport {
         let reader = BufReader::new(stdout);
         for line in reader.lines() {
             match line {
-                Ok(line) => {
-                    if let Some(event) = decode_line(&line) {
+                Ok(line) => match decode_line(&line) {
+                    Ok(Some(event)) => {
                         if event_tx.send(event).is_err() {
                             break;
                         }
                     }
-                }
+                    Ok(None) => {}
+                    Err(e) => {
+                        tracing::warn!(error = %e, line = %line, "malformed JSON from supervisor, discarding");
+                    }
+                },
                 Err(_) => break,
             }
         }

--- a/crates/runtime/src/transport.rs
+++ b/crates/runtime/src/transport.rs
@@ -66,7 +66,10 @@ impl StdioTransport {
                         tracing::warn!(error = %e, line = %line, "malformed JSON from supervisor, discarding");
                     }
                 },
-                Err(_) => break,
+                Err(e) => {
+                    tracing::warn!(error = %e, "IO error reading from supervisor stdout");
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Change `decode_line()` return type from `Option<T>` to `Result<Option<T>, serde_json::Error>` to distinguish empty lines from parse failures
- Log malformed JSON at `warn` level with raw content in all three call sites: transport reader loop, `LineReader::push`, and `LineReader::flush`
- Add `decode_malformed` test to verify parse errors are properly surfaced

## Test plan

- [x] All 14 existing runtime tests pass
- [x] New `decode_malformed` test verifies `Err` is returned for invalid JSON
- [ ] Manual: send malformed JSON to supervisor transport and verify warn log appears

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)