### PR TITLE
Add orchestrator think() loop for periodic reasoning and narration

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -23,7 +23,7 @@ use tasks_github::poller::RepoPoller;
 
 use tasks_orchestrator::{
     ChatContext, ConflictContext, ConflictResolution, OperatingMode, Orchestrator,
-    OrchestratorChat,
+    OrchestratorAction, OrchestratorChat, SystemContext,
 };
 
 use crate::config::AppConfig;
@@ -125,6 +125,16 @@ impl AnyOrchestrator {
         match self {
             Self::Claude(o) => o.triage_conflict(context).await,
             Self::Mock(o) => o.triage_conflict(context).await,
+        }
+    }
+
+    async fn think(
+        &self,
+        context: &tasks_orchestrator::SystemContext,
+    ) -> Result<Vec<tasks_orchestrator::OrchestratorAction>, tasks_orchestrator::OrchestratorError> {
+        match self {
+            Self::Claude(o) => o.think(context).await,
+            Self::Mock(o) => o.think(context).await,
         }
     }
 }
@@ -1263,6 +1273,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
 
     let orch_server = server.clone();
     let orch = orchestrator.clone();
+    let think_orch = orchestrator.clone();
     let orch_event_bus = server.event_bus.clone();
     let orch_github_token = config.github_token.clone();
     let orch_rejected_cooldown = rejected_pr_cooldown.clone();
@@ -2173,6 +2184,122 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
         }
     });
 
+    // --- 8e. Spawn orchestrator think loop ---
+    //
+    // Periodic reasoning pass: the orchestrator surveys system state and
+    // recent events, identifies patterns, and emits narration (thoughts)
+    // plus state change requests. This runs on a fixed interval (~30s),
+    // independent of the evaluation loop.
+    //
+    // The think loop collects events between ticks and passes them to
+    // think() as recent_events so the orchestrator can see what happened.
+
+    let think_server = server.clone();
+    let think_event_bus = server.event_bus.clone();
+
+    let think_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        let mut event_rx = think_event_bus.subscribe();
+        let mut recent_events: Vec<Event> = Vec::new();
+        let mut last_think_at: Option<chrono::DateTime<chrono::Utc>> = None;
+
+        loop {
+            // Wait for next tick, collecting events in between
+            tokio::select! {
+                _ = interval.tick() => {}
+                result = event_rx.recv() => {
+                    match result {
+                        Ok(event) => {
+                            // Buffer events for the next think() pass.
+                            // Skip high-frequency noise (scheduler ticks, accounting, etc.)
+                            let dominated = event.event_type.matches("system:scheduler:*")
+                                || event.event_type.matches("system:accounting:*")
+                                || event.event_type.matches("automation:run:output");
+                            if !dominated {
+                                recent_events.push((*event).clone());
+                            }
+                            // Cap buffer to prevent unbounded growth
+                            if recent_events.len() > 200 {
+                                recent_events.drain(..100);
+                            }
+                            continue; // Keep collecting until the interval fires
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            warn!(skipped = n, "think loop lagged — {n} events dropped");
+                            continue;
+                        }
+                        Err(_) => break,
+                    }
+                }
+            }
+
+            // Skip think() in Stop mode
+            let mode = think_server.mode().await;
+            if mode == server::Mode::Stop {
+                recent_events.clear();
+                continue;
+            }
+
+            // Build SystemContext snapshot
+            let context = {
+                let state = think_server.state.read().await;
+                let orch_mode = match state.mode {
+                    server::Mode::Play => OperatingMode::Play,
+                    server::Mode::Pause => OperatingMode::Pause,
+                    server::Mode::Stop => OperatingMode::Stop,
+                };
+                SystemContext {
+                    mode: orch_mode,
+                    projects: state.projects.values().cloned().collect(),
+                    tasks: state.tasks.values().cloned().collect(),
+                    merge_queue: state.merge_queue.entries().to_vec(),
+                    human_present: think_server.presence.is_present(),
+                    recent_events: recent_events.clone(),
+                    last_think_at,
+                }
+            };
+
+            // Run the orchestrator's think pass
+            match think_orch.think(&context).await {
+                Ok(actions) => {
+                    for action in actions {
+                        match action {
+                            OrchestratorAction::EmitThought(message) => {
+                                let event = Event::new(
+                                    EventType::OrchestratorThought,
+                                    "",
+                                    Actor::Orchestrator,
+                                    serde_json::json!({ "message": message }),
+                                );
+                                if let Err(e) = think_server.event_bus.publish(event).await {
+                                    error!(error = %e, "failed to publish orchestrator thought");
+                                }
+                            }
+                            OrchestratorAction::UpdateTaskState { task_id, state } => {
+                                info!(task_id = %task_id, state = ?state, "orchestrator requested task state change");
+                                if let Err(e) = think_server
+                                    .set_task_state(&task_id, state, Actor::Orchestrator)
+                                    .await
+                                {
+                                    error!(task_id = %task_id, error = %e, "failed to update task state from think()");
+                                }
+                            }
+                            OrchestratorAction::PrioritizeTask { task_id, reason } => {
+                                info!(task_id = %task_id, reason = %reason, "orchestrator requested task prioritization (not yet implemented)");
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!(error = %e, "orchestrator think() failed");
+                }
+            }
+
+            last_think_at = Some(chrono::Utc::now());
+            recent_events.clear();
+        }
+    });
+
     // --- 9. Optionally spawn web server ---
 
     // Create update trigger channel (shared between API and auto-apply)
@@ -2324,6 +2451,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     dispatch_handle.abort();
     event_handler_handle.abort();
     orchestrator_handle.abort();
+    think_handle.abort();
     watchdog_handle.abort();
     cleanup_handle.abort();
     stop_mode_handle.abort();

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -77,6 +77,8 @@ pub enum EventType {
     OrchestratorMessage,
     /// Orchestrator chat response (LLM-generated reply to human message).
     OrchestratorResponse,
+    /// Orchestrator stream-of-consciousness narration of system events.
+    OrchestratorThought,
 
     // System events
     SystemStarted,
@@ -153,6 +155,7 @@ impl EventType {
             Self::OrchestratorDecision => "orchestrator:decision",
             Self::OrchestratorMessage => "orchestrator:message",
             Self::OrchestratorResponse => "orchestrator:response",
+            Self::OrchestratorThought => "orchestrator:thought",
             Self::SystemStarted => "system:started",
             Self::SystemModePlay => "system:mode:play",
             Self::SystemModePause => "system:mode:pause",
@@ -244,6 +247,7 @@ impl TryFrom<String> for EventType {
             "orchestrator:decision" => Ok(Self::OrchestratorDecision),
             "orchestrator:message" => Ok(Self::OrchestratorMessage),
             "orchestrator:response" => Ok(Self::OrchestratorResponse),
+            "orchestrator:thought" => Ok(Self::OrchestratorThought),
             "system:started" => Ok(Self::SystemStarted),
             "system:mode:play" => Ok(Self::SystemModePlay),
             "system:mode:pause" => Ok(Self::SystemModePause),

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+events = { path = "../events" }
 models = { path = "../models" }
 tasks-agent = { path = "../agent" }
 tasks-github = { path = "../github" }

--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -9,7 +9,11 @@ use tracing::{info, warn};
 use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
 use crate::prompt::{build_evaluation_prompt, build_deep_review_prompt, parse_pr_url, system_prompt};
-use crate::types::{default_triage, ConflictContext, ConflictTriage, EvaluationContext, QualityEvaluation};
+use crate::types::{
+    default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
+    QualityEvaluation, SystemContext,
+};
+use events::EventType;
 use models::task::{Task, TaskSource};
 use tasks_agent::{AnthropicProvider, CompletionConfig, CompletionRequest, Message, Provider};
 use tasks_github::GitHubClient;
@@ -331,6 +335,115 @@ impl Orchestrator for ClaudeOrchestrator {
         );
 
         Ok(triage)
+    }
+
+    async fn think(
+        &self,
+        context: &SystemContext,
+    ) -> Result<Vec<OrchestratorAction>, OrchestratorError> {
+        // Rule-based reasoning pass — no LLM calls.
+        // Survey system state and recent events, identify patterns, narrate.
+        let mut actions = Vec::new();
+
+        // Narrate recent events the human should know about
+        for event in &context.recent_events {
+            match &event.event_type {
+                EventType::TaskStateFailed => {
+                    let reason = event
+                        .data
+                        .get("reason")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown reason");
+                    actions.push(OrchestratorAction::EmitThought(format!(
+                        "Task {} failed: {}",
+                        event.task, reason
+                    )));
+                }
+                EventType::TaskStateCompleted => {
+                    actions.push(OrchestratorAction::EmitThought(format!(
+                        "Task {} completed.",
+                        event.task
+                    )));
+                }
+                EventType::MergeCompleted => {
+                    let task_id = event
+                        .data
+                        .get("task_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&event.task);
+                    actions.push(OrchestratorAction::EmitThought(format!(
+                        "Merged PR for task {}.",
+                        task_id
+                    )));
+                }
+                EventType::MergeConflict => {
+                    let task_id = event
+                        .data
+                        .get("task_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&event.task);
+                    actions.push(OrchestratorAction::EmitThought(format!(
+                        "Conflict detected on task {}.",
+                        task_id
+                    )));
+                }
+                EventType::SystemModePlay => {
+                    actions.push(OrchestratorAction::EmitThought(
+                        "Mode changed to Play — fully autonomous.".to_string(),
+                    ));
+                }
+                EventType::SystemModePause => {
+                    actions.push(OrchestratorAction::EmitThought(
+                        "Mode changed to Pause — holding approved merges.".to_string(),
+                    ));
+                }
+                EventType::SystemModeStop => {
+                    actions.push(OrchestratorAction::EmitThought(
+                        "Mode changed to Stop — idle.".to_string(),
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        // Pattern detection: multiple failures in the same area
+        let recent_failures: Vec<&events::Event> = context
+            .recent_events
+            .iter()
+            .filter(|e| e.event_type == EventType::TaskStateFailed)
+            .collect();
+        if recent_failures.len() >= 3 {
+            actions.push(OrchestratorAction::EmitThought(format!(
+                "{} tasks failed recently — possible systemic issue.",
+                recent_failures.len()
+            )));
+        }
+
+        // Surface long-running sessions
+        use models::task::TaskState;
+        let long_running: Vec<&Task> = context
+            .tasks
+            .iter()
+            .filter(|t| t.state == TaskState::Running)
+            .filter(|t| {
+                t.last_activity_at
+                    .map(|at| (chrono::Utc::now() - at).num_minutes() > 30)
+                    .unwrap_or(false)
+            })
+            .collect();
+        for task in &long_running {
+            let mins = task
+                .last_activity_at
+                .map(|at| (chrono::Utc::now() - at).num_minutes())
+                .unwrap_or(0);
+            actions.push(OrchestratorAction::EmitThought(format!(
+                "Task {} has been running with no activity for {}m.",
+                &task.id[..8.min(task.id.len())],
+                mins
+            )));
+        }
+
+        Ok(actions)
     }
 }
 

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -22,5 +22,5 @@ pub use orchestrator::Orchestrator;
 pub use prompt::parse_pr_url;
 pub use types::{
     ConflictContext, ConflictResolution, ConflictTriage, EvaluationContext, OperatingMode,
-    QualityEvaluation, QueueEntrySummary,
+    OrchestratorAction, QualityEvaluation, QueueEntrySummary, SystemContext,
 };

--- a/crates/orchestrator/src/mock.rs
+++ b/crates/orchestrator/src/mock.rs
@@ -5,7 +5,8 @@ use std::sync::Mutex;
 use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
 use crate::types::{
-    default_triage, ConflictContext, ConflictTriage, EvaluationContext, QualityEvaluation,
+    default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
+    QualityEvaluation, SystemContext,
 };
 use models::task::Task;
 
@@ -24,6 +25,8 @@ pub struct MockOrchestrator {
     pub feedback_count: Mutex<u32>,
     /// Count of triage_conflict calls (for assertions).
     pub triage_count: Mutex<u32>,
+    /// Count of process_event calls (for assertions).
+    pub think_count: Mutex<u32>,
 }
 
 impl MockOrchestrator {
@@ -39,6 +42,7 @@ impl MockOrchestrator {
             evaluate_count: Mutex::new(0),
             feedback_count: Mutex::new(0),
             triage_count: Mutex::new(0),
+            think_count: Mutex::new(0),
         }
     }
 
@@ -55,6 +59,7 @@ impl MockOrchestrator {
             evaluate_count: Mutex::new(0),
             feedback_count: Mutex::new(0),
             triage_count: Mutex::new(0),
+            think_count: Mutex::new(0),
         }
     }
 
@@ -97,6 +102,15 @@ impl Orchestrator for MockOrchestrator {
         Ok(override_triage.unwrap_or_else(|| {
             default_triage(&context.conflict_info, context.mode, context.human_present)
         }))
+    }
+
+    async fn think(
+        &self,
+        _context: &SystemContext,
+    ) -> Result<Vec<OrchestratorAction>, OrchestratorError> {
+        *self.think_count.lock().unwrap() += 1;
+        // Mock returns no actions — tests can verify call count.
+        Ok(Vec::new())
     }
 }
 

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -1,13 +1,18 @@
 //! Orchestrator trait — the core abstraction.
 //!
-//! Spec §4.2: The orchestrator evaluates work quality and provides feedback.
-//! Spec §7.4: The orchestrator triages conflicts with mode-aware resolution.
+//! Spec §4.2: The orchestrator is an AI agent that manages the project.
+//! It evaluates work quality, triages conflicts, and proactively manages
+//! project state through periodic reasoning passes.
 //!
-//! The trait is intentionally narrow — `evaluate` returns a verdict, and the
-//! caller (server run loop) decides whether to act on it based on mode.
+//! The orchestrator is an actor: it periodically surveys system state,
+//! identifies patterns, and returns actions. The event bus is a data
+//! source it can consult, not its driver.
 
 use crate::error::OrchestratorError;
-use crate::types::{ConflictContext, ConflictTriage, EvaluationContext, QualityEvaluation};
+use crate::types::{
+    ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction, QualityEvaluation,
+    SystemContext,
+};
 use models::task::Task;
 
 /// Trait for orchestrator implementations.
@@ -50,4 +55,18 @@ pub trait Orchestrator: Sync {
         &self,
         context: &ConflictContext,
     ) -> Result<ConflictTriage, OrchestratorError>;
+
+    /// Periodic reasoning pass — the orchestrator surveys system state and
+    /// decides what actions to take.
+    ///
+    /// Called on a regular interval (~30s) by the run loop. The orchestrator
+    /// receives a full snapshot of system state and recent events, identifies
+    /// patterns, and returns actions (narration, state changes, priorities).
+    ///
+    /// This is NOT reactive to individual events — the orchestrator stands
+    /// outside the event stream and sees the full picture.
+    async fn think(
+        &self,
+        context: &SystemContext,
+    ) -> Result<Vec<OrchestratorAction>, OrchestratorError>;
 }

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -3,11 +3,13 @@
 //! EvaluationContext: what the orchestrator receives.
 //! QualityEvaluation: what the orchestrator returns.
 //! ConflictTriage: conflict resolution decision (spec §7.4).
+//! SystemContext: snapshot of current system state for event processing.
+//! OrchestratorAction: actions the orchestrator can request.
 
 use chrono::{DateTime, Utc};
 use models::merge_queue::{ConflictInfo, ConflictType, MergeQueueEntry, MergeStatus};
 use models::project::Project;
-use models::task::Task;
+use models::task::{Task, TaskState};
 use serde::{Deserialize, Serialize};
 
 /// Summary of another merge queue entry for context during evaluation.
@@ -232,4 +234,50 @@ pub fn default_triage(conflict_info: &ConflictInfo, mode: OperatingMode, human_p
             }
         }
     }
+}
+
+/// Snapshot of current system state for the orchestrator's think() pass.
+///
+/// The orchestrator receives the full picture — tasks, merge queue, recent
+/// events — and can identify patterns across them. This is NOT per-event
+/// context; it's a periodic survey of the entire landscape.
+#[derive(Debug, Clone)]
+pub struct SystemContext {
+    /// Current operating mode.
+    pub mode: OperatingMode,
+    /// All projects.
+    pub projects: Vec<Project>,
+    /// All tasks with their current state.
+    pub tasks: Vec<Task>,
+    /// Merge queue entries.
+    pub merge_queue: Vec<MergeQueueEntry>,
+    /// Whether a human is currently connected.
+    pub human_present: bool,
+    /// Recent events since the last think() call (for pattern detection).
+    pub recent_events: Vec<events::Event>,
+    /// When the last think() pass ran (None if this is the first).
+    pub last_think_at: Option<DateTime<Utc>>,
+}
+
+/// Actions the orchestrator can request from its think() pass.
+///
+/// The run loop interprets these and executes them against the server.
+/// This keeps the orchestrator pure — it returns intentions, not side effects.
+#[derive(Debug, Clone)]
+pub enum OrchestratorAction {
+    /// Emit a thought to the orchestrator narration feed (stream of consciousness).
+    EmitThought(String),
+    /// Change a task's state.
+    UpdateTaskState {
+        task_id: String,
+        state: TaskState,
+    },
+    /// Request a task be dispatched with priority.
+    PrioritizeTask {
+        task_id: String,
+        reason: String,
+    },
+    // Future: DispatchAgent { task_id: String, config: DispatchConfig }
+    // Future: CreateIssue { repo: String, title: String, body: String }
+    // Future: CommentOnPr { pr_url: String, body: String }
 }


### PR DESCRIPTION
## Summary

Implements #539 (orchestrator trait expansion) and #536 (event-driven processing loop) together.

- **Orchestrator trait**: adds `think()` method that receives a `SystemContext` snapshot (mode, projects, tasks, merge queue, recent events) and returns `Vec<OrchestratorAction>` (thoughts, state changes, prioritization requests)
- **ClaudeOrchestrator**: rule-based narration of key events (task failures/completions, merges, conflicts, mode changes), pattern detection (multiple failures), and long-running session alerts. No LLM calls — pure rule-based reasoning
- **MockOrchestrator**: returns empty actions, tracks call count for test assertions
- **Run loop**: new think loop spawned alongside the existing eval loop. Buffers events between 30s ticks, builds `SystemContext`, calls `think()`, processes returned actions (publish `orchestrator:thought` events, call `set_task_state`, log prioritization)
- **Events**: new `OrchestratorThought` event type for stream-of-consciousness narration

### Design decisions

- `think()` is a required trait method (not default impl) because `trait_variant::make(Send)` does not support default async method bodies
- The think loop is independent of the eval loop — they run on different intervals and serve different purposes (eval = merge queue assessment, think = broad system awareness)
- Recent events are buffered between ticks and passed as `SystemContext.recent_events` so the orchestrator can detect patterns across events
- High-frequency noise (scheduler ticks, accounting, automation output) is filtered from the event buffer

Closes #539, closes #536.

## Test plan

- [x] `cargo check` passes for entire workspace
- [x] `cargo test --package tasks-orchestrator` — all 39 tests pass
- [x] `cargo test --package events` — all 36 tests pass
- [ ] Manual: run the server, verify `orchestrator:thought` events appear in SSE stream when tasks complete/fail