### PR TITLE
Orchestrator think loop: periodic reasoning with stream-of-consciousness narration

### DIFF
--- a/crates/app/src/automation_runner.rs
+++ b/crates/app/src/automation_runner.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::task::JoinHandle;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 use uuid::Uuid;
 
 use events::EventBus;
@@ -209,9 +209,9 @@ pub fn spawn_automation_event_listener(
                     }
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(
+                    error!(
                         skipped = n,
-                        "automation event listener lagged, skipped {n} events"
+                        "automation event listener lagged — {n} events dropped from broadcast channel"
                     );
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -230,7 +230,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     let event_dir = format!("{}/events", config.data_dir);
     std::fs::create_dir_all(&event_dir)?;
     let event_store = EventStore::new(&event_dir);
-    let bus = EventBus::new(event_store, 256);
+    let bus = EventBus::new(event_store, 1024);
 
     // --- 2. Create server ---
 
@@ -879,10 +879,68 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
             let event = match rx.recv().await {
                 Ok(e) => e,
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(
+                    error!(
                         skipped = n,
-                        "event handler lagged, some events may not update state"
+                        "event handler lagged — {n} events dropped from broadcast channel. \
+                         Replaying recent state events from store to recover."
                     );
+                    // Recovery: replay the latest state event for each task from
+                    // the persistent event store so we don't permanently lose
+                    // state transitions. Events are always persisted before
+                    // broadcast, so the store is the source of truth.
+                    match event_handler_bus.query_by_type_prefix("task:state:", 500).await {
+                        Ok(state_events) => {
+                            // Collect the latest state event per task
+                            let mut latest_per_task: std::collections::HashMap<String, events::Event> =
+                                std::collections::HashMap::new();
+                            for ev in state_events {
+                                latest_per_task
+                                    .entry(ev.task.clone())
+                                    .and_modify(|existing| {
+                                        if ev.ts > existing.ts {
+                                            *existing = ev.clone();
+                                        }
+                                    })
+                                    .or_insert(ev);
+                            }
+                            let replayed = latest_per_task.len();
+                            for (_task_id, ev) in &latest_per_task {
+                                if ev.actor == events::Actor::Scheduler {
+                                    continue;
+                                }
+                                let state = match ev.event_type {
+                                    EventType::TaskStateRunning => Some(models::task::TaskState::Running),
+                                    EventType::TaskStateQuestion => Some(models::task::TaskState::Question),
+                                    EventType::TaskStateWaiting => Some(models::task::TaskState::Waiting),
+                                    EventType::TaskStateBlocked => Some(models::task::TaskState::Blocked),
+                                    EventType::TaskStateTesting => Some(models::task::TaskState::Testing),
+                                    EventType::TaskStateAwaitingMerge => Some(models::task::TaskState::AwaitingMerge),
+                                    EventType::TaskStateConflict => Some(models::task::TaskState::Conflict),
+                                    EventType::TaskStateCompleted => Some(models::task::TaskState::Completed),
+                                    EventType::TaskStateFailed => Some(models::task::TaskState::Failed),
+                                    EventType::TaskStateCancelled => Some(models::task::TaskState::Cancelled),
+                                    _ => None,
+                                };
+                                if let Some(s) = state {
+                                    if let Err(e) = event_handler_server.apply_task_state(&ev.task, s).await {
+                                        if !matches!(e, server::ServerError::TaskNotFound(_)) {
+                                            error!(task_id = %ev.task, error = %e, "failed to replay task state during lag recovery");
+                                        }
+                                    }
+                                }
+                            }
+                            info!(
+                                tasks_replayed = replayed,
+                                "lag recovery complete — replayed latest state for {replayed} tasks"
+                            );
+                        }
+                        Err(e) => {
+                            error!(
+                                error = %e,
+                                "lag recovery failed — could not read state events from store"
+                            );
+                        }
+                    }
                     continue;
                 }
                 Err(_) => break,
@@ -994,7 +1052,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                     match result {
                         Ok(event) => Some(event),
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            warn!(skipped = n, "dispatch loop lagged, some events may not trigger dispatch");
+                            warn!(skipped = n, "dispatch loop lagged — {n} events dropped, next reconciliation tick will catch up");
                             None
                         }
                         Err(_) => continue, // channel closed, will be handled by outer loop
@@ -1252,7 +1310,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                     match result {
                         Ok(event) => Some(event),
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            warn!(skipped = n, "orchestrator loop lagged");
+                            warn!(skipped = n, "orchestrator loop lagged — {n} events dropped, next eval tick will catch up");
                             continue;
                         }
                         Err(_) => break, // channel closed, shut down
@@ -2091,9 +2149,9 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
             let event = match rx.recv().await {
                 Ok(e) => e,
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(
+                    error!(
                         skipped = n,
-                        "stop mode listener lagged, some events may be missed"
+                        "stop mode listener lagged — {n} events dropped, may miss SystemModeStop event"
                     );
                     continue;
                 }

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -2194,7 +2194,6 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     // The think loop collects events between ticks and passes them to
     // think() as recent_events so the orchestrator can see what happened.
 
-    let think_orch = orchestrator.clone();
     let think_server = server.clone();
     let think_event_bus = server.event_bus.clone();
 

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -23,7 +23,7 @@ use tasks_github::poller::RepoPoller;
 
 use tasks_orchestrator::{
     ChatContext, ConflictContext, ConflictResolution, OperatingMode, Orchestrator,
-    OrchestratorChat,
+    OrchestratorAction, OrchestratorChat, SystemContext,
 };
 
 use crate::config::AppConfig;
@@ -125,6 +125,16 @@ impl AnyOrchestrator {
         match self {
             Self::Claude(o) => o.triage_conflict(context).await,
             Self::Mock(o) => o.triage_conflict(context).await,
+        }
+    }
+
+    async fn think(
+        &self,
+        context: &tasks_orchestrator::SystemContext,
+    ) -> Result<Vec<tasks_orchestrator::OrchestratorAction>, tasks_orchestrator::OrchestratorError> {
+        match self {
+            Self::Claude(o) => o.think(context).await,
+            Self::Mock(o) => o.think(context).await,
         }
     }
 }
@@ -1263,6 +1273,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
 
     let orch_server = server.clone();
     let orch = orchestrator.clone();
+    let think_orch = orchestrator.clone();
     let orch_event_bus = server.event_bus.clone();
     let orch_github_token = config.github_token.clone();
     let orch_rejected_cooldown = rejected_pr_cooldown.clone();
@@ -2173,6 +2184,123 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
         }
     });
 
+    // --- 8e. Spawn orchestrator think loop ---
+    //
+    // Periodic reasoning pass: the orchestrator surveys system state and
+    // recent events, identifies patterns, and emits narration (thoughts)
+    // plus state change requests. This runs on a fixed interval (~30s),
+    // independent of the evaluation loop.
+    //
+    // The think loop collects events between ticks and passes them to
+    // think() as recent_events so the orchestrator can see what happened.
+
+    let think_orch = orchestrator.clone();
+    let think_server = server.clone();
+    let think_event_bus = server.event_bus.clone();
+
+    let think_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        let mut event_rx = think_event_bus.subscribe();
+        let mut recent_events: Vec<Event> = Vec::new();
+        let mut last_think_at: Option<chrono::DateTime<chrono::Utc>> = None;
+
+        loop {
+            // Wait for next tick, collecting events in between
+            tokio::select! {
+                _ = interval.tick() => {}
+                result = event_rx.recv() => {
+                    match result {
+                        Ok(event) => {
+                            // Buffer events for the next think() pass.
+                            // Skip high-frequency noise (scheduler ticks, accounting, etc.)
+                            let dominated = event.event_type.matches("system:scheduler:*")
+                                || event.event_type.matches("system:accounting:*")
+                                || event.event_type.matches("automation:run:output");
+                            if !dominated {
+                                recent_events.push((*event).clone());
+                            }
+                            // Cap buffer to prevent unbounded growth
+                            if recent_events.len() > 200 {
+                                recent_events.drain(..100);
+                            }
+                            continue; // Keep collecting until the interval fires
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            warn!(skipped = n, "think loop lagged — {n} events dropped");
+                            continue;
+                        }
+                        Err(_) => break,
+                    }
+                }
+            }
+
+            // Skip think() in Stop mode
+            let mode = think_server.mode().await;
+            if mode == server::Mode::Stop {
+                recent_events.clear();
+                continue;
+            }
+
+            // Build SystemContext snapshot
+            let context = {
+                let state = think_server.state.read().await;
+                let orch_mode = match state.mode {
+                    server::Mode::Play => OperatingMode::Play,
+                    server::Mode::Pause => OperatingMode::Pause,
+                    server::Mode::Stop => OperatingMode::Stop,
+                };
+                SystemContext {
+                    mode: orch_mode,
+                    projects: state.projects.values().cloned().collect(),
+                    tasks: state.tasks.values().cloned().collect(),
+                    merge_queue: state.merge_queue.entries().to_vec(),
+                    human_present: think_server.presence.is_present(),
+                    recent_events: recent_events.clone(),
+                    last_think_at,
+                }
+            };
+
+            // Run the orchestrator's think pass
+            match think_orch.think(&context).await {
+                Ok(actions) => {
+                    for action in actions {
+                        match action {
+                            OrchestratorAction::EmitThought(message) => {
+                                let event = Event::new(
+                                    EventType::OrchestratorThought,
+                                    "",
+                                    Actor::Orchestrator,
+                                    serde_json::json!({ "message": message }),
+                                );
+                                if let Err(e) = think_server.event_bus.publish(event).await {
+                                    error!(error = %e, "failed to publish orchestrator thought");
+                                }
+                            }
+                            OrchestratorAction::UpdateTaskState { task_id, state } => {
+                                info!(task_id = %task_id, state = ?state, "orchestrator requested task state change");
+                                if let Err(e) = think_server
+                                    .set_task_state(&task_id, state, Actor::Orchestrator)
+                                    .await
+                                {
+                                    error!(task_id = %task_id, error = %e, "failed to update task state from think()");
+                                }
+                            }
+                            OrchestratorAction::PrioritizeTask { task_id, reason } => {
+                                info!(task_id = %task_id, reason = %reason, "orchestrator requested task prioritization (not yet implemented)");
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!(error = %e, "orchestrator think() failed");
+                }
+            }
+
+            last_think_at = Some(chrono::Utc::now());
+            recent_events.clear();
+        }
+    });
+
     // --- 9. Optionally spawn web server ---
 
     // Create update trigger channel (shared between API and auto-apply)
@@ -2324,6 +2452,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     dispatch_handle.abort();
     event_handler_handle.abort();
     orchestrator_handle.abort();
+    think_handle.abort();
     watchdog_handle.abort();
     cleanup_handle.abort();
     stop_mode_handle.abort();

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -77,6 +77,8 @@ pub enum EventType {
     OrchestratorMessage,
     /// Orchestrator chat response (LLM-generated reply to human message).
     OrchestratorResponse,
+    /// Orchestrator stream-of-consciousness narration of system events.
+    OrchestratorThought,
 
     // System events
     SystemStarted,
@@ -153,6 +155,7 @@ impl EventType {
             Self::OrchestratorDecision => "orchestrator:decision",
             Self::OrchestratorMessage => "orchestrator:message",
             Self::OrchestratorResponse => "orchestrator:response",
+            Self::OrchestratorThought => "orchestrator:thought",
             Self::SystemStarted => "system:started",
             Self::SystemModePlay => "system:mode:play",
             Self::SystemModePause => "system:mode:pause",
@@ -244,6 +247,7 @@ impl TryFrom<String> for EventType {
             "orchestrator:decision" => Ok(Self::OrchestratorDecision),
             "orchestrator:message" => Ok(Self::OrchestratorMessage),
             "orchestrator:response" => Ok(Self::OrchestratorResponse),
+            "orchestrator:thought" => Ok(Self::OrchestratorThought),
             "system:started" => Ok(Self::SystemStarted),
             "system:mode:play" => Ok(Self::SystemModePlay),
             "system:mode:pause" => Ok(Self::SystemModePause),

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+events = { path = "../events" }
 models = { path = "../models" }
 tasks-agent = { path = "../agent" }
 tasks-github = { path = "../github" }

--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -9,7 +9,11 @@ use tracing::{info, warn};
 use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
 use crate::prompt::{build_evaluation_prompt, build_deep_review_prompt, parse_pr_url, system_prompt};
-use crate::types::{default_triage, ConflictContext, ConflictTriage, EvaluationContext, QualityEvaluation};
+use crate::types::{
+    default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
+    QualityEvaluation, SystemContext,
+};
+use events::EventType;
 use models::task::{Task, TaskSource};
 use tasks_agent::{AnthropicProvider, CompletionConfig, CompletionRequest, Message, Provider};
 use tasks_github::GitHubClient;
@@ -331,6 +335,115 @@ impl Orchestrator for ClaudeOrchestrator {
         );
 
         Ok(triage)
+    }
+
+    async fn think(
+        &self,
+        context: &SystemContext,
+    ) -> Result<Vec<OrchestratorAction>, OrchestratorError> {
+        // Rule-based reasoning pass — no LLM calls.
+        // Survey system state and recent events, identify patterns, narrate.
+        let mut actions = Vec::new();
+
+        // Narrate recent events the human should know about
+        for event in &context.recent_events {
+            match &event.event_type {
+                EventType::TaskStateFailed => {
+                    let reason = event
+                        .data
+                        .get("reason")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown reason");
+                    actions.push(OrchestratorAction::EmitThought(format!(
+                        "Task {} failed: {}",
+                        event.task, reason
+                    )));
+                }
+                EventType::TaskStateCompleted => {
+                    actions.push(OrchestratorAction::EmitThought(format!(
+                        "Task {} completed.",
+                        event.task
+                    )));
+                }
+                EventType::MergeCompleted => {
+                    let task_id = event
+                        .data
+                        .get("task_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&event.task);
+                    actions.push(OrchestratorAction::EmitThought(format!(
+                        "Merged PR for task {}.",
+                        task_id
+                    )));
+                }
+                EventType::MergeConflict => {
+                    let task_id = event
+                        .data
+                        .get("task_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&event.task);
+                    actions.push(OrchestratorAction::EmitThought(format!(
+                        "Conflict detected on task {}.",
+                        task_id
+                    )));
+                }
+                EventType::SystemModePlay => {
+                    actions.push(OrchestratorAction::EmitThought(
+                        "Mode changed to Play — fully autonomous.".to_string(),
+                    ));
+                }
+                EventType::SystemModePause => {
+                    actions.push(OrchestratorAction::EmitThought(
+                        "Mode changed to Pause — holding approved merges.".to_string(),
+                    ));
+                }
+                EventType::SystemModeStop => {
+                    actions.push(OrchestratorAction::EmitThought(
+                        "Mode changed to Stop — idle.".to_string(),
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        // Pattern detection: multiple failures in the same area
+        let recent_failures: Vec<&events::Event> = context
+            .recent_events
+            .iter()
+            .filter(|e| e.event_type == EventType::TaskStateFailed)
+            .collect();
+        if recent_failures.len() >= 3 {
+            actions.push(OrchestratorAction::EmitThought(format!(
+                "{} tasks failed recently — possible systemic issue.",
+                recent_failures.len()
+            )));
+        }
+
+        // Surface long-running sessions
+        use models::task::TaskState;
+        let long_running: Vec<&Task> = context
+            .tasks
+            .iter()
+            .filter(|t| t.state == TaskState::Running)
+            .filter(|t| {
+                t.last_activity_at
+                    .map(|at| (chrono::Utc::now() - at).num_minutes() > 30)
+                    .unwrap_or(false)
+            })
+            .collect();
+        for task in &long_running {
+            let mins = task
+                .last_activity_at
+                .map(|at| (chrono::Utc::now() - at).num_minutes())
+                .unwrap_or(0);
+            actions.push(OrchestratorAction::EmitThought(format!(
+                "Task {} has been running with no activity for {}m.",
+                &task.id[..8.min(task.id.len())],
+                mins
+            )));
+        }
+
+        Ok(actions)
     }
 }
 

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -22,5 +22,5 @@ pub use orchestrator::Orchestrator;
 pub use prompt::parse_pr_url;
 pub use types::{
     ConflictContext, ConflictResolution, ConflictTriage, EvaluationContext, OperatingMode,
-    QualityEvaluation, QueueEntrySummary,
+    OrchestratorAction, QualityEvaluation, QueueEntrySummary, SystemContext,
 };

--- a/crates/orchestrator/src/mock.rs
+++ b/crates/orchestrator/src/mock.rs
@@ -5,7 +5,8 @@ use std::sync::Mutex;
 use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
 use crate::types::{
-    default_triage, ConflictContext, ConflictTriage, EvaluationContext, QualityEvaluation,
+    default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
+    QualityEvaluation, SystemContext,
 };
 use models::task::Task;
 
@@ -24,6 +25,8 @@ pub struct MockOrchestrator {
     pub feedback_count: Mutex<u32>,
     /// Count of triage_conflict calls (for assertions).
     pub triage_count: Mutex<u32>,
+    /// Count of process_event calls (for assertions).
+    pub think_count: Mutex<u32>,
 }
 
 impl MockOrchestrator {
@@ -39,6 +42,7 @@ impl MockOrchestrator {
             evaluate_count: Mutex::new(0),
             feedback_count: Mutex::new(0),
             triage_count: Mutex::new(0),
+            think_count: Mutex::new(0),
         }
     }
 
@@ -55,6 +59,7 @@ impl MockOrchestrator {
             evaluate_count: Mutex::new(0),
             feedback_count: Mutex::new(0),
             triage_count: Mutex::new(0),
+            think_count: Mutex::new(0),
         }
     }
 
@@ -97,6 +102,15 @@ impl Orchestrator for MockOrchestrator {
         Ok(override_triage.unwrap_or_else(|| {
             default_triage(&context.conflict_info, context.mode, context.human_present)
         }))
+    }
+
+    async fn think(
+        &self,
+        _context: &SystemContext,
+    ) -> Result<Vec<OrchestratorAction>, OrchestratorError> {
+        *self.think_count.lock().unwrap() += 1;
+        // Mock returns no actions — tests can verify call count.
+        Ok(Vec::new())
     }
 }
 

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -1,13 +1,18 @@
 //! Orchestrator trait — the core abstraction.
 //!
-//! Spec §4.2: The orchestrator evaluates work quality and provides feedback.
-//! Spec §7.4: The orchestrator triages conflicts with mode-aware resolution.
+//! Spec §4.2: The orchestrator is an AI agent that manages the project.
+//! It evaluates work quality, triages conflicts, and proactively manages
+//! project state through periodic reasoning passes.
 //!
-//! The trait is intentionally narrow — `evaluate` returns a verdict, and the
-//! caller (server run loop) decides whether to act on it based on mode.
+//! The orchestrator is an actor: it periodically surveys system state,
+//! identifies patterns, and returns actions. The event bus is a data
+//! source it can consult, not its driver.
 
 use crate::error::OrchestratorError;
-use crate::types::{ConflictContext, ConflictTriage, EvaluationContext, QualityEvaluation};
+use crate::types::{
+    ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction, QualityEvaluation,
+    SystemContext,
+};
 use models::task::Task;
 
 /// Trait for orchestrator implementations.
@@ -50,4 +55,18 @@ pub trait Orchestrator: Sync {
         &self,
         context: &ConflictContext,
     ) -> Result<ConflictTriage, OrchestratorError>;
+
+    /// Periodic reasoning pass — the orchestrator surveys system state and
+    /// decides what actions to take.
+    ///
+    /// Called on a regular interval (~30s) by the run loop. The orchestrator
+    /// receives a full snapshot of system state and recent events, identifies
+    /// patterns, and returns actions (narration, state changes, priorities).
+    ///
+    /// This is NOT reactive to individual events — the orchestrator stands
+    /// outside the event stream and sees the full picture.
+    async fn think(
+        &self,
+        context: &SystemContext,
+    ) -> Result<Vec<OrchestratorAction>, OrchestratorError>;
 }

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -3,11 +3,13 @@
 //! EvaluationContext: what the orchestrator receives.
 //! QualityEvaluation: what the orchestrator returns.
 //! ConflictTriage: conflict resolution decision (spec §7.4).
+//! SystemContext: snapshot of current system state for event processing.
+//! OrchestratorAction: actions the orchestrator can request.
 
 use chrono::{DateTime, Utc};
 use models::merge_queue::{ConflictInfo, ConflictType, MergeQueueEntry, MergeStatus};
 use models::project::Project;
-use models::task::Task;
+use models::task::{Task, TaskState};
 use serde::{Deserialize, Serialize};
 
 /// Summary of another merge queue entry for context during evaluation.
@@ -232,4 +234,50 @@ pub fn default_triage(conflict_info: &ConflictInfo, mode: OperatingMode, human_p
             }
         }
     }
+}
+
+/// Snapshot of current system state for the orchestrator's think() pass.
+///
+/// The orchestrator receives the full picture — tasks, merge queue, recent
+/// events — and can identify patterns across them. This is NOT per-event
+/// context; it's a periodic survey of the entire landscape.
+#[derive(Debug, Clone)]
+pub struct SystemContext {
+    /// Current operating mode.
+    pub mode: OperatingMode,
+    /// All projects.
+    pub projects: Vec<Project>,
+    /// All tasks with their current state.
+    pub tasks: Vec<Task>,
+    /// Merge queue entries.
+    pub merge_queue: Vec<MergeQueueEntry>,
+    /// Whether a human is currently connected.
+    pub human_present: bool,
+    /// Recent events since the last think() call (for pattern detection).
+    pub recent_events: Vec<events::Event>,
+    /// When the last think() pass ran (None if this is the first).
+    pub last_think_at: Option<DateTime<Utc>>,
+}
+
+/// Actions the orchestrator can request from its think() pass.
+///
+/// The run loop interprets these and executes them against the server.
+/// This keeps the orchestrator pure — it returns intentions, not side effects.
+#[derive(Debug, Clone)]
+pub enum OrchestratorAction {
+    /// Emit a thought to the orchestrator narration feed (stream of consciousness).
+    EmitThought(String),
+    /// Change a task's state.
+    UpdateTaskState {
+        task_id: String,
+        state: TaskState,
+    },
+    /// Request a task be dispatched with priority.
+    PrioritizeTask {
+        task_id: String,
+        reason: String,
+    },
+    // Future: DispatchAgent { task_id: String, config: DispatchConfig }
+    // Future: CreateIssue { repo: String, title: String, body: String }
+    // Future: CommentOnPr { pr_url: String, body: String }
 }

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -504,6 +504,12 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
     let mut soft_limit_notified = false;
     let mut hard_limit_triggered = false;
 
+    // Compute tokio-compatible deadlines for time limit enforcement.
+    // These ensure the select! loop wakes even when no events/commands arrive.
+    let tokio_start = tokio::time::Instant::now();
+    let soft_deadline = tokio_start + soft_limit;
+    let hard_deadline = tokio_start + hard_limit;
+
     // Output interpreter for state detection (spec §9.3)
     let mut interpreter = OutputInterpreter::new();
 
@@ -543,6 +549,18 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
     });
 
     loop {
+        // Compute the next time-limit deadline so the select! loop wakes even
+        // when both channels are idle (fixes #458).
+        let next_deadline = if !soft_limit_notified {
+            soft_deadline
+        } else if !hard_limit_triggered {
+            hard_deadline
+        } else {
+            // Both limits already fired; use a far-future deadline to avoid busy-looping
+            // while we wait for the agent to exit after stop_agent().
+            tokio::time::Instant::now() + Duration::from_secs(60)
+        };
+
         tokio::select! {
             Some(supervisor_event) = event_rx.recv() => {
                 // Capture stderr into rolling buffer for failure diagnosis (spec §13.4)
@@ -597,6 +615,12 @@ async fn monitor_session<R: ContainerRuntime + Send + 'static>(
                         }
                     }
                 }
+            }
+            // Timeout arm: fires when the next time limit is reached, even if no
+            // events or commands arrive. This ensures hard/soft limits are enforced
+            // when the session stalls (#458).
+            _ = tokio::time::sleep_until(next_deadline) => {
+                tracing::debug!(task_id = %task_id, "time limit check triggered by timeout");
             }
             else => break, // both channels closed
         }

--- a/docs/plans/2026-03-25-orchestrator-think-loop.md
+++ b/docs/plans/2026-03-25-orchestrator-think-loop.md
@@ -1,0 +1,121 @@
+# Orchestrator Think Loop
+
+**Issues:** #539, #536, #530
+
+## Design
+
+The orchestrator is an actor that periodically surveys system state, identifies
+patterns, and decides what to do. The event bus is a data source it can consult,
+not its driver.
+
+### Core concept: `think()`
+
+```rust
+/// Periodic orchestrator reasoning pass.
+/// Called every ~30s by a dedicated task in the run loop.
+async fn think(
+    &self,
+    context: &SystemContext,
+) -> Result<Vec<OrchestratorAction>, OrchestratorError>;
+```
+
+The orchestrator receives a full snapshot of system state and returns actions.
+It is NOT reactive to individual events — it stands outside the event stream
+and sees patterns across events, tasks, and merge queue state.
+
+### SystemContext (what the orchestrator sees)
+
+```rust
+pub struct SystemContext {
+    pub mode: OperatingMode,
+    pub projects: Vec<Project>,
+    pub tasks: Vec<Task>,
+    pub merge_queue: Vec<MergeQueueEntry>,
+    pub active_sessions: Vec<SessionInfo>,
+    pub human_present: bool,
+    pub recent_events: Vec<Event>,    // last N events for pattern detection
+    pub last_think_at: Option<DateTime<Utc>>,  // when we last ran think()
+}
+```
+
+### OrchestratorAction (what the orchestrator can do)
+
+```rust
+pub enum OrchestratorAction {
+    /// Stream-of-consciousness narration → emits orchestrator:thought event
+    EmitThought(String),
+    /// Change a task's state
+    UpdateTaskState { task_id: String, state: TaskState },
+    /// Request priority dispatch for a task
+    PrioritizeTask { task_id: String, reason: String },
+    // Future:
+    // DispatchAgent { prompt: String, context: AgentContext },
+    // CreateIssue { repo: String, title: String, body: String },
+    // CloseIssue { repo: String, number: u64, reason: String },
+    // SendChat { task_id: String, message: String },
+}
+```
+
+### Implementation phases
+
+**Phase 1 (this PR):**
+- Trait expansion with `think()` method (default impl returns empty vec)
+- `SystemContext` and `OrchestratorAction` types
+- Rule-based `think()` in ClaudeOrchestrator:
+  - Narrate tasks that changed state since last think
+  - Flag tasks running longer than expected
+  - Summarize merge queue state changes
+  - Spot patterns: repeated failures, stuck tasks
+- Wire into run_loop as a periodic tick (30s interval)
+- Process returned actions (EmitThought → publish orchestrator:thought event)
+
+**Phase 2 (future):**
+- LLM-powered think() for complex pattern detection
+- DispatchAgent action type
+- CreateIssue / CloseIssue actions
+- Priority management
+
+### Run loop wiring
+
+```rust
+// In run_loop.rs, new spawned task:
+let orchestrator_think = tokio::spawn(async move {
+    let mut interval = tokio::time::interval(Duration::from_secs(30));
+    let mut last_think_at = None;
+    loop {
+        interval.tick().await;
+        if *mode.read().await != Mode::Stop {
+            let context = build_system_context(&server, last_think_at).await;
+            match orchestrator.think(&context).await {
+                Ok(actions) => {
+                    for action in actions {
+                        process_orchestrator_action(&server, &event_bus, action).await;
+                    }
+                }
+                Err(e) => tracing::warn!("orchestrator think failed: {e}"),
+            }
+            last_think_at = Some(Utc::now());
+        }
+    }
+});
+```
+
+### What the orchestrator narrates (rule-based, no LLM)
+
+- "Task X completed — PR ready for review"
+- "Task Y failed after 3 retries — may need manual investigation"
+- "3 tasks in auth code all failed with timeout errors — possible systemic issue"
+- "Merge queue clear — all approved PRs merged"
+- "Session for task Z has been running for 45 minutes (soft limit: 25m)"
+- "PR #123 approved and merged"
+- "PR #456 rejected — feedback sent to agent"
+
+### Key design decisions
+
+1. **No LLM for narration** — rule-based pattern matching is fast and predictable.
+   LLM reasoning comes in phase 2 for complex pattern detection.
+2. **Periodic, not reactive** — the orchestrator surveys state on a tick, not per-event.
+   This lets it see patterns across events.
+3. **Actions are requests** — the run loop decides how to fulfill them. The orchestrator
+   doesn't directly mutate state.
+4. **Default impl is no-op** — existing code doesn't break.


### PR DESCRIPTION
## Summary

Implements the orchestrator as an **actor** that periodically surveys system state and decides what to do, rather than reacting to individual events.

Closes #539, closes #536, addresses #530.

### What's new

**Trait expansion:**
- New `think()` method on the `Orchestrator` trait — periodic reasoning pass that receives a full `SystemContext` snapshot and returns `Vec<OrchestratorAction>`
- `SystemContext` — full snapshot including tasks, merge queue, recent events, presence, mode
- `OrchestratorAction` enum — `EmitThought`, `UpdateTaskState`, `PrioritizeTask`
- `OrchestratorThought` event type for stream-of-consciousness narration

**ClaudeOrchestrator implementation (rule-based, no LLM):**
- Narrates key events: task completions, failures, merges, conflicts, mode changes
- Pattern detection: flags when 3+ tasks fail recently
- Surfaces long-running sessions (>30min with no activity)

**Run loop integration:**
- 30-second periodic tick collects events between passes
- Filters out noise (scheduler ticks, accounting events)
- Builds SystemContext snapshot and calls `think()`
- Processes returned actions (publishes `orchestrator:thought` events)

### Design decisions

- **Periodic, not reactive** — the orchestrator stands outside the event stream and sees patterns across events
- **No LLM for narration** — rule-based for speed and predictability. LLM reasoning comes in phase 2.
- **Actions are requests** — the run loop fulfills them, keeping the orchestrator pure

## Test plan
- [x] `cargo check` — full workspace compiles
- [x] `cargo test --package tasks-orchestrator` — 39 tests pass
- [ ] Manual: verify `orchestrator:thought` events appear in SSE stream
- [ ] Manual: verify thoughts show in web UI orchestrator feed