### PR TITLE
Add GitHub write operations for orchestrator/agent interaction

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -611,7 +611,7 @@ async fn bootstrap_project(
     );
 
     let created_issue = client
-        .create_issue(owner, repo, &issue_title, Some(&issue_body), None)
+        .create_issue(owner, repo, &issue_title, Some(&issue_body), None, None)
         .await
         .map_err(ApiError::GitHubApi)?;
 
@@ -722,7 +722,7 @@ async fn create_issue(
     };
 
     let created = client
-        .create_issue(&owner, &repo, &req.title, req.body.as_deref(), labels)
+        .create_issue(&owner, &repo, &req.title, req.body.as_deref(), labels, None)
         .await
         .map_err(ApiError::GitHubApi)?;
 

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -358,7 +358,7 @@ impl GitHubClient {
     }
 
     // -----------------------------------------------------------------------
-    // Issue write operations (spec github.md §4 — write ops)
+    // Issue write operations
     // -----------------------------------------------------------------------
 
     /// Post a comment on an issue or pull request.
@@ -431,6 +431,8 @@ impl GitHubClient {
     ///
     /// Uses the GitHub REST API to update issue fields. All fields are optional;
     /// only provided fields will be updated. Pass `None` to leave a field unchanged.
+    ///
+    /// `state` — if provided, must be `"open"` or `"closed"` (lowercase).
     pub async fn update_issue(
         &self,
         owner: &str,
@@ -511,9 +513,9 @@ impl GitHubClient {
 
     /// Add labels to an issue or pull request.
     ///
-    /// Uses the GitHub REST API to add labels. Labels that don't exist in the
-    /// repository will be created automatically by GitHub. Existing labels on
-    /// the issue are preserved — this only adds new ones.
+    /// Uses the GitHub REST API to add one or more labels to an issue. Labels
+    /// must already exist in the repository — unknown label names cause a 422.
+    /// Existing labels on the issue are preserved; this only adds new ones.
     pub async fn add_labels(
         &self,
         owner: &str,

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -30,6 +30,32 @@ pub struct CreatedIssue {
     pub state: String,
 }
 
+/// Response from GitHub REST API when posting a comment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreatedComment {
+    /// Comment ID.
+    pub id: u64,
+    /// Comment body (markdown).
+    pub body: String,
+    /// Comment URL (HTML).
+    pub html_url: String,
+}
+
+/// Response from GitHub REST API when updating an issue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdatedIssue {
+    /// Issue number.
+    pub number: u64,
+    /// Issue title.
+    pub title: String,
+    /// Issue body (markdown).
+    pub body: Option<String>,
+    /// Issue URL (HTML).
+    pub html_url: String,
+    /// Issue state.
+    pub state: String,
+}
+
 /// Response from GitHub REST API when creating a repository.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreatedRepository {
@@ -265,6 +291,7 @@ impl GitHubClient {
         title: &str,
         body: Option<&str>,
         labels: Option<&[String]>,
+        assignees: Option<&[String]>,
     ) -> Result<CreatedIssue, GitHubError> {
         self.wait_for_rate_limit().await;
 
@@ -280,6 +307,10 @@ impl GitHubClient {
 
         if let Some(l) = labels {
             request_body["labels"] = json!(l);
+        }
+
+        if let Some(a) = assignees {
+            request_body["assignees"] = json!(a);
         }
 
         let response = self.http.post(&url).json(&request_body).send().await?;
@@ -323,6 +354,222 @@ impl GitHubClient {
         let text = response.text().await.unwrap_or_default();
         Err(GitHubError::Decode(format!(
             "unexpected create issue status {status}: {text}"
+        )))
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue write operations (spec github.md §4 — write ops)
+    // -----------------------------------------------------------------------
+
+    /// Post a comment on an issue or pull request.
+    ///
+    /// Uses the GitHub REST API to create a comment. Works for both issues
+    /// and pull requests (they share the issues comments endpoint).
+    pub async fn post_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        body: &str,
+    ) -> Result<CreatedComment, GitHubError> {
+        self.wait_for_rate_limit().await;
+
+        let url = format!(
+            "{}/repos/{}/{}/issues/{}/comments",
+            self.base_url, owner, repo, issue_number
+        );
+
+        let request_body = json!({ "body": body });
+
+        let response = self.http.post(&url).json(&request_body).send().await?;
+        self.update_rate_limit(&response);
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::CREATED {
+            let created: CreatedComment = response.json().await.map_err(|e| {
+                GitHubError::Decode(format!("failed to parse created comment: {e}"))
+            })?;
+            return Ok(created);
+        }
+
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(GitHubError::NotFound(format!(
+                "{owner}/{repo}#{issue_number}"
+            )));
+        }
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::FORBIDDEN {
+            if let Some(rl) = self.rate_limit() {
+                if rl.remaining == 0 {
+                    return Err(GitHubError::RateLimited {
+                        reset_at: rl.reset_at,
+                    });
+                }
+            }
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::UNPROCESSABLE_ENTITY {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Validation(text));
+        }
+
+        let text = response.text().await.unwrap_or_default();
+        Err(GitHubError::Decode(format!(
+            "unexpected post comment status {status}: {text}"
+        )))
+    }
+
+    /// Update an existing issue or pull request.
+    ///
+    /// Uses the GitHub REST API to update issue fields. All fields are optional;
+    /// only provided fields will be updated. Pass `None` to leave a field unchanged.
+    pub async fn update_issue(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        title: Option<&str>,
+        body: Option<&str>,
+        state: Option<&str>,
+        labels: Option<&[String]>,
+    ) -> Result<UpdatedIssue, GitHubError> {
+        self.wait_for_rate_limit().await;
+
+        let url = format!(
+            "{}/repos/{}/{}/issues/{}",
+            self.base_url, owner, repo, issue_number
+        );
+
+        let mut request_body = json!({});
+
+        if let Some(t) = title {
+            request_body["title"] = json!(t);
+        }
+        if let Some(b) = body {
+            request_body["body"] = json!(b);
+        }
+        if let Some(s) = state {
+            request_body["state"] = json!(s);
+        }
+        if let Some(l) = labels {
+            request_body["labels"] = json!(l);
+        }
+
+        let response = self.http.patch(&url).json(&request_body).send().await?;
+        self.update_rate_limit(&response);
+
+        let status = response.status();
+
+        if status.is_success() {
+            let updated: UpdatedIssue = response.json().await.map_err(|e| {
+                GitHubError::Decode(format!("failed to parse updated issue: {e}"))
+            })?;
+            return Ok(updated);
+        }
+
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(GitHubError::NotFound(format!(
+                "{owner}/{repo}#{issue_number}"
+            )));
+        }
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::FORBIDDEN {
+            if let Some(rl) = self.rate_limit() {
+                if rl.remaining == 0 {
+                    return Err(GitHubError::RateLimited {
+                        reset_at: rl.reset_at,
+                    });
+                }
+            }
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::UNPROCESSABLE_ENTITY {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Validation(text));
+        }
+
+        let text = response.text().await.unwrap_or_default();
+        Err(GitHubError::Decode(format!(
+            "unexpected update issue status {status}: {text}"
+        )))
+    }
+
+    /// Add labels to an issue or pull request.
+    ///
+    /// Uses the GitHub REST API to add labels. Labels that don't exist in the
+    /// repository will be created automatically by GitHub. Existing labels on
+    /// the issue are preserved — this only adds new ones.
+    pub async fn add_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        issue_number: u64,
+        labels: &[String],
+    ) -> Result<(), GitHubError> {
+        self.wait_for_rate_limit().await;
+
+        let url = format!(
+            "{}/repos/{}/{}/issues/{}/labels",
+            self.base_url, owner, repo, issue_number
+        );
+
+        let request_body = json!({ "labels": labels });
+
+        let response = self.http.post(&url).json(&request_body).send().await?;
+        self.update_rate_limit(&response);
+
+        let status = response.status();
+
+        if status.is_success() {
+            return Ok(());
+        }
+
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(GitHubError::NotFound(format!(
+                "{owner}/{repo}#{issue_number}"
+            )));
+        }
+
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::FORBIDDEN {
+            if let Some(rl) = self.rate_limit() {
+                if rl.remaining == 0 {
+                    return Err(GitHubError::RateLimited {
+                        reset_at: rl.reset_at,
+                    });
+                }
+            }
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Auth(text));
+        }
+
+        if status == reqwest::StatusCode::UNPROCESSABLE_ENTITY {
+            let text = response.text().await.unwrap_or_default();
+            return Err(GitHubError::Validation(text));
+        }
+
+        let text = response.text().await.unwrap_or_default();
+        Err(GitHubError::Decode(format!(
+            "unexpected add labels status {status}: {text}"
         )))
     }
 

--- a/crates/github/src/lib.rs
+++ b/crates/github/src/lib.rs
@@ -14,6 +14,6 @@ pub mod poller;
 mod queries;
 mod response;
 
-pub use client::{CreatedIssue, GitHubClient};
+pub use client::{CreatedComment, CreatedIssue, GitHubClient, UpdatedIssue};
 pub use error::GitHubError;
 pub use poller::{PollResult, RepoPoller};

--- a/crates/github/tests/client_tests.rs
+++ b/crates/github/tests/client_tests.rs
@@ -930,3 +930,327 @@ async fn get_pr_diff_truncates_large_diffs() {
     assert!(diff.len() < 150_000);
     assert!(diff.contains("[diff truncated"));
 }
+
+// ---------------------------------------------------------------------------
+// Post issue comment tests (#478 — write operations)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn post_issue_comment_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/42/comments"))
+        .and(body_string_contains("\"body\":\"Hello from the orchestrator\""))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "id": 100,
+            "body": "Hello from the orchestrator",
+            "html_url": "https://github.com/owner/repo/issues/42#issuecomment-100"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let comment = client
+        .post_issue_comment("owner", "repo", 42, "Hello from the orchestrator")
+        .await
+        .unwrap();
+
+    assert_eq!(comment.id, 100);
+    assert_eq!(comment.body, "Hello from the orchestrator");
+    assert!(comment.html_url.contains("issuecomment-100"));
+}
+
+#[tokio::test]
+async fn post_issue_comment_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/999/comments"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let result = client
+        .post_issue_comment("owner", "repo", 999, "test")
+        .await;
+
+    assert!(matches!(result, Err(GitHubError::NotFound(_))));
+}
+
+#[tokio::test]
+async fn post_issue_comment_auth_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/42/comments"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Bad credentials"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let result = client
+        .post_issue_comment("owner", "repo", 42, "test")
+        .await;
+
+    assert!(matches!(result, Err(GitHubError::Auth(_))));
+}
+
+#[tokio::test]
+async fn post_issue_comment_validation_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/42/comments"))
+        .respond_with(
+            ResponseTemplate::new(422).set_body_string("Validation Failed: body is too long"),
+        )
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let result = client
+        .post_issue_comment("owner", "repo", 42, "test")
+        .await;
+
+    assert!(matches!(result, Err(GitHubError::Validation(_))));
+}
+
+// ---------------------------------------------------------------------------
+// Update issue tests (#478 — write operations)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn update_issue_all_fields() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/repos/owner/repo/issues/42"))
+        .and(body_string_contains("\"title\":\"Updated title\""))
+        .and(body_string_contains("\"state\":\"closed\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "number": 42,
+            "title": "Updated title",
+            "body": "Updated body",
+            "html_url": "https://github.com/owner/repo/issues/42",
+            "state": "closed"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let labels = vec!["bug".to_string(), "urgent".to_string()];
+    let updated = client
+        .update_issue(
+            "owner",
+            "repo",
+            42,
+            Some("Updated title"),
+            Some("Updated body"),
+            Some("closed"),
+            Some(&labels),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(updated.number, 42);
+    assert_eq!(updated.title, "Updated title");
+    assert_eq!(updated.state, "closed");
+}
+
+#[tokio::test]
+async fn update_issue_partial_fields() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/repos/owner/repo/issues/42"))
+        .and(body_string_contains("\"state\":\"closed\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "number": 42,
+            "title": "Original title",
+            "body": null,
+            "html_url": "https://github.com/owner/repo/issues/42",
+            "state": "closed"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let updated = client
+        .update_issue("owner", "repo", 42, None, None, Some("closed"), None)
+        .await
+        .unwrap();
+
+    assert_eq!(updated.number, 42);
+    assert_eq!(updated.state, "closed");
+}
+
+#[tokio::test]
+async fn update_issue_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/repos/owner/repo/issues/999"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let result = client
+        .update_issue("owner", "repo", 999, Some("title"), None, None, None)
+        .await;
+
+    assert!(matches!(result, Err(GitHubError::NotFound(_))));
+}
+
+#[tokio::test]
+async fn update_issue_auth_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/repos/owner/repo/issues/42"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Bad credentials"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let result = client
+        .update_issue("owner", "repo", 42, Some("title"), None, None, None)
+        .await;
+
+    assert!(matches!(result, Err(GitHubError::Auth(_))));
+}
+
+#[tokio::test]
+async fn update_issue_validation_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/repos/owner/repo/issues/42"))
+        .respond_with(
+            ResponseTemplate::new(422).set_body_string("Validation Failed"),
+        )
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let result = client
+        .update_issue("owner", "repo", 42, Some(""), None, None, None)
+        .await;
+
+    assert!(matches!(result, Err(GitHubError::Validation(_))));
+}
+
+// ---------------------------------------------------------------------------
+// Add labels tests (#478 — write operations)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn add_labels_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/42/labels"))
+        .and(body_string_contains("\"labels\""))
+        .and(body_string_contains("\"bug\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "name": "bug", "color": "d73a4a" },
+            { "name": "enhancement", "color": "a2eeef" }
+        ])))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let labels = vec!["bug".to_string(), "enhancement".to_string()];
+    let result = client.add_labels("owner", "repo", 42, &labels).await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn add_labels_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/999/labels"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let labels = vec!["bug".to_string()];
+    let result = client.add_labels("owner", "repo", 999, &labels).await;
+
+    assert!(matches!(result, Err(GitHubError::NotFound(_))));
+}
+
+#[tokio::test]
+async fn add_labels_auth_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/42/labels"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Bad credentials"))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let labels = vec!["bug".to_string()];
+    let result = client.add_labels("owner", "repo", 42, &labels).await;
+
+    assert!(matches!(result, Err(GitHubError::Auth(_))));
+}
+
+#[tokio::test]
+async fn add_labels_validation_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/42/labels"))
+        .respond_with(
+            ResponseTemplate::new(422).set_body_string("Validation Failed"),
+        )
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let labels = vec!["bug".to_string()];
+    let result = client.add_labels("owner", "repo", 42, &labels).await;
+
+    assert!(matches!(result, Err(GitHubError::Validation(_))));
+}
+
+// ---------------------------------------------------------------------------
+// Create issue with assignees tests (#478 — write operations)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn create_issue_with_assignees() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues"))
+        .and(body_string_contains("\"assignees\""))
+        .and(body_string_contains("\"alice\""))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "number": 99,
+            "title": "New issue",
+            "body": "Issue body",
+            "html_url": "https://github.com/owner/repo/issues/99",
+            "state": "open"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = mock_client(&server.uri());
+    let labels = vec!["bug".to_string()];
+    let assignees = vec!["alice".to_string()];
+    let created = client
+        .create_issue("owner", "repo", "New issue", Some("Issue body"), Some(&labels), Some(&assignees))
+        .await
+        .unwrap();
+
+    assert_eq!(created.number, 99);
+    assert_eq!(created.title, "New issue");
+}

--- a/spec/github.md
+++ b/spec/github.md
@@ -8,13 +8,14 @@ Integration, §3.2 Scheduler).
 
 ## 1. Overview
 
-The GitHub crate is the platform's read interface to GitHub. It fetches issues, pull requests, and
+The GitHub crate is the platform's interface to GitHub. It fetches issues, pull requests, and
 their associated metadata from GitHub's GraphQL API, normalizes them into a stable internal model,
 and provides a polling mechanism for discovering new and changed work.
 
-The crate does not write to GitHub. All GitHub mutations (comments, labels, state changes, PR
-creation) are performed by agents working inside their sessions, using the `gh` CLI with
-credentials injected into the container environment (session-runtime.md §3.1).
+The crate also provides write operations for the orchestrator and server to interact with GitHub
+directly (posting comments, updating issues, adding labels, merging PRs, managing branches). Agents
+working inside sessions may also use the `gh` CLI with credentials injected into the container
+environment (session-runtime.md §3.1).
 
 ```
 Server


### PR DESCRIPTION
## Summary

Closes #478

- Added `post_issue_comment(owner, repo, issue_number, body)` -- POST comments on issues/PRs via REST API
- Added `update_issue(owner, repo, issue_number, title, body, state, labels)` -- PATCH issue fields (all optional except owner/repo/number)
- Added `add_labels(owner, repo, issue_number, labels)` -- POST labels to issues/PRs
- Extended existing `create_issue` with optional `assignees` parameter
- Added `CreatedComment` and `UpdatedIssue` response types, exported from `lib.rs`
- Updated call sites in `crates/app/src/web.rs` for the new `create_issue` signature

All methods follow the same patterns as existing REST methods (rate limit checking, consistent error handling for 401/403/404/422).

## Test plan

- [x] 14 new wiremock tests covering success + error cases for all new methods
- [x] `cargo check --package tasks-github` passes
- [x] `cargo test --package tasks-github` passes (42 client tests total)
- [x] `cargo check --package tasks-app` passes (call site updates verified)