### PR TITLE
Add database indexes to SQLite schema

### DIFF
--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -77,6 +77,22 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
             output TEXT,
             error TEXT
         );
+
+        -- Indexes for common query patterns (issue #465)
+        -- tasks: lookup by project, filter by state, find by source
+        CREATE INDEX IF NOT EXISTS idx_tasks_project ON tasks(project);
+        CREATE INDEX IF NOT EXISTS idx_tasks_state ON tasks(state);
+        CREATE INDEX IF NOT EXISTS idx_tasks_source ON tasks(source_json);
+
+        -- merge_queue: dedup by pr_url, lookup by task_id
+        CREATE INDEX IF NOT EXISTS idx_merge_queue_pr_url ON merge_queue(pr_url);
+        CREATE INDEX IF NOT EXISTS idx_merge_queue_task_id ON merge_queue(task_id);
+
+        -- automations: lookup by project
+        CREATE INDEX IF NOT EXISTS idx_automations_project_id ON automations(project_id);
+
+        -- automation_runs: lookup by automation_id
+        CREATE INDEX IF NOT EXISTS idx_automation_runs_automation_id ON automation_runs(automation_id);
         ",
     )?;
 


### PR DESCRIPTION
## Summary

- Adds 7 `CREATE INDEX IF NOT EXISTS` statements to the SQLite schema for common query patterns that were previously doing full table scans
- Indexes cover: `tasks.project`, `tasks.state`, `tasks.source_json`, `merge_queue.pr_url`, `merge_queue.task_id`, `automations.project_id`, `automation_runs.automation_id`
- Uses `IF NOT EXISTS` so they are safe to re-run on existing databases — no migration needed

Closes #465

## Test plan

- [x] `cargo check --package tasks-store` passes
- [x] All 36 `cargo test --package tasks-store` tests pass
- [ ] Verify indexes are created on an existing database by checking `sqlite3 ~/.local/state/tasks/tasks.db ".indexes"`