### PR TITLE
Orchestrator answers stuck agents' questions

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -23,7 +23,7 @@ use tasks_github::poller::RepoPoller;
 
 use tasks_orchestrator::{
     ChatContext, ConflictContext, ConflictResolution, OperatingMode, Orchestrator,
-    OrchestratorAction, OrchestratorChat, SystemContext,
+    OrchestratorAction, OrchestratorChat, QuestionContext, SystemContext,
 };
 
 use crate::config::AppConfig;
@@ -135,6 +135,16 @@ impl AnyOrchestrator {
         match self {
             Self::Claude(o) => o.think(context).await,
             Self::Mock(o) => o.think(context).await,
+        }
+    }
+
+    async fn answer_question(
+        &self,
+        context: &QuestionContext,
+    ) -> Result<String, tasks_orchestrator::OrchestratorError> {
+        match self {
+            Self::Claude(o) => o.answer_question(context).await,
+            Self::Mock(o) => o.answer_question(context).await,
         }
     }
 }
@@ -1277,6 +1287,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     let orch_event_bus = server.event_bus.clone();
     let orch_github_token = config.github_token.clone();
     let orch_rejected_cooldown = rejected_pr_cooldown.clone();
+    let orch_session_mgr = session_manager.clone();
 
     let orchestrator_eval_interval = config.orchestrator_eval_interval;
     let conflict_max_age = config.conflict_max_age;
@@ -1419,6 +1430,163 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                             lower_mode(&orch_server, &reason).await;
                         }
                     }
+                    // Handle stuck agents: when a task enters Question state, the
+                    // orchestrator answers the question to unblock the agent (issue #533).
+                    EventType::TaskStateQuestion => {
+                        let task_id = event.task.clone();
+                        let human_present = orch_server.is_human_present();
+
+                        // Extract the question text from event data, or look up
+                        // the most recent agent:question event for this task.
+                        let question = event.data.get("question")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string())
+                            .or_else(|| {
+                                event.data.get("message")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string())
+                            });
+
+                        // If the question text isn't in the event data, try to
+                        // find it from recent events for this task.
+                        let question = match question {
+                            Some(q) if !q.is_empty() => q,
+                            _ => {
+                                match orch_server.event_bus.read_task(&task_id).await {
+                                    Ok(events) => {
+                                        events.iter().rev()
+                                            .find(|e| e.event_type == EventType::AgentQuestion)
+                                            .and_then(|e| {
+                                                e.data.get("question")
+                                                    .or_else(|| e.data.get("message"))
+                                                    .and_then(|v| v.as_str())
+                                                    .map(|s| s.to_string())
+                                            })
+                                            .unwrap_or_else(|| "(no question text found)".to_string())
+                                    }
+                                    Err(e) => {
+                                        warn!(task_id = %task_id, error = %e, "failed to read task events for question text");
+                                        "(failed to retrieve question)".to_string()
+                                    }
+                                }
+                            }
+                        };
+
+                        // If human is present, surface the question as an escalation
+                        // instead of answering autonomously.
+                        if human_present {
+                            info!(
+                                task_id = %task_id,
+                                "agent stuck with question, human present — surfacing as escalation"
+                            );
+                            let escalation_event = Event::new(
+                                EventType::OrchestratorEscalation,
+                                &task_id,
+                                Actor::Orchestrator,
+                                serde_json::json!({
+                                    "action": "agent_question",
+                                    "message": format!("Agent is stuck and asking: {}", question),
+                                }),
+                            );
+                            if let Err(e) = orch_server.event_bus.publish(escalation_event).await {
+                                error!(error = %e, "failed to emit escalation for agent question");
+                            }
+                            continue;
+                        }
+
+                        // No human present — orchestrator answers autonomously.
+                        // Look up the task and project for context.
+                        let (task, project) = {
+                            let state = orch_server.state.read().await;
+                            let task = state.tasks.get(&task_id).cloned();
+                            let project = task.as_ref().and_then(|t| state.projects.get(&t.project).cloned());
+                            (task, project)
+                        };
+
+                        let (task, project) = match (task, project) {
+                            (Some(t), Some(p)) => (t, p),
+                            _ => {
+                                warn!(task_id = %task_id, "cannot answer question: task or project not found");
+                                continue;
+                            }
+                        };
+
+                        // Spawn LLM call to avoid blocking the event loop
+                        let orch_ref = orch.clone();
+                        let server_ref = orch_server.clone();
+                        let session_mgr_ref = orch_session_mgr.clone();
+                        let question_clone = question.clone();
+                        tokio::spawn(async move {
+                            let context = QuestionContext {
+                                task: task.clone(),
+                                project,
+                                question: question_clone,
+                                human_present: false,
+                            };
+
+                            match orch_ref.answer_question(&context).await {
+                                Ok(answer) => {
+                                    info!(
+                                        task_id = %task_id,
+                                        answer_len = answer.len(),
+                                        "orchestrator answered agent question"
+                                    );
+
+                                    // Emit HumanMessage event BEFORE sending to session.
+                                    // This triggers the dispatcher's pending_answers mechanism,
+                                    // which transitions the task from Question to Running on the
+                                    // next dispatch tick. Without this, the task stays in Question
+                                    // state indefinitely (issue #552 review comment).
+                                    let human_message_event = events::Event::new(
+                                        events::EventType::HumanMessage,
+                                        &task_id,
+                                        events::Actor::Orchestrator,
+                                        serde_json::json!({
+                                            "message": answer.clone(),
+                                            "source": "orchestrator_answer",
+                                        }),
+                                    );
+                                    if let Err(e) = server_ref.event_bus.publish(human_message_event).await {
+                                        error!(
+                                            task_id = %task_id,
+                                            error = %e,
+                                            "failed to emit HumanMessage event for orchestrator answer"
+                                        );
+                                    }
+
+                                    // Send the answer to the agent session
+                                    if let Err(e) = session_mgr_ref.send_chat(&task_id, answer.clone()).await {
+                                        warn!(
+                                            task_id = %task_id,
+                                            error = %e,
+                                            "failed to send orchestrator answer to session"
+                                        );
+                                    }
+
+                                    // Emit orchestrator:response event so humans can see what was answered
+                                    if let Err(e) = server_ref.emit_orchestrator_feedback(
+                                        &task_id,
+                                        &answer,
+                                        Some("question_answer"),
+                                    ).await {
+                                        error!(
+                                            task_id = %task_id,
+                                            error = %e,
+                                            "failed to emit orchestrator feedback event for question answer"
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    error!(
+                                        task_id = %task_id,
+                                        error = %e,
+                                        "orchestrator failed to answer agent question"
+                                    );
+                                }
+                            }
+                        });
+                        continue;
+                    }
                     // Handle orchestrator chat messages from humans (bypass queue)
                     EventType::OrchestratorMessage => {
                         let message = event
@@ -1445,7 +1613,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                         projects: state.projects.values().cloned().collect(),
                                         tasks: state.tasks.values().cloned().collect(),
                                         recent_events: Vec::new(),
-                                        human_present: orch_server.presence.is_present(),
+                                        human_present: orch_server.is_human_present(),
                                     }
                                 };
 
@@ -2253,7 +2421,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                     projects: state.projects.values().cloned().collect(),
                     tasks: state.tasks.values().cloned().collect(),
                     merge_queue: state.merge_queue.entries().to_vec(),
-                    human_present: think_server.presence.is_present(),
+                    human_present: think_server.is_human_present(),
                     recent_events: recent_events.clone(),
                     last_think_at,
                 }

--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -11,7 +11,7 @@ use crate::orchestrator::Orchestrator;
 use crate::prompt::{build_evaluation_prompt, build_deep_review_prompt, parse_pr_url, system_prompt};
 use crate::types::{
     default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
-    QualityEvaluation, SystemContext,
+    QualityEvaluation, QuestionContext, SystemContext,
 };
 use events::EventType;
 use models::task::{Task, TaskSource};
@@ -445,6 +445,91 @@ impl Orchestrator for ClaudeOrchestrator {
 
         Ok(actions)
     }
+
+    async fn answer_question(
+        &self,
+        context: &QuestionContext,
+    ) -> Result<String, OrchestratorError> {
+        info!(
+            task_id = %context.task.id,
+            question_len = context.question.len(),
+            "Answering stuck agent's question"
+        );
+
+        let system = build_question_answer_system_prompt();
+
+        let user_prompt = build_question_answer_prompt(
+            &context.task.title,
+            context.task.description.as_deref(),
+            &context.question,
+            &context.project.repo,
+        );
+
+        let config = CompletionConfig::new(&self.model).with_max_tokens(4096);
+        let request = CompletionRequest::new(config, vec![Message::user(user_prompt)])
+            .with_system(system);
+
+        let response = self
+            .provider
+            .complete(request)
+            .await
+            .map_err(OrchestratorError::Agent)?;
+
+        let answer = response.text().trim().to_string();
+
+        info!(
+            task_id = %context.task.id,
+            answer_len = answer.len(),
+            "Generated answer for stuck agent"
+        );
+
+        Ok(answer)
+    }
+}
+
+/// Build the system prompt for answering agent questions.
+fn build_question_answer_system_prompt() -> String {
+    r#"You are a project foreman helping an implementor who is stuck on a coding task.
+
+Your role:
+- Give concise, actionable guidance — the agent needs to move forward, not read an essay.
+- Be specific: point to files, functions, patterns, or approaches.
+- If the question reveals a misunderstanding, correct it directly.
+- If the question is about a design decision, make the call — don't equivocate.
+- Keep your answer under 500 words. Shorter is better.
+
+Do NOT:
+- Repeat the question back
+- Give vague advice like "consider the tradeoffs"
+- Suggest the agent ask someone else
+- Write code unless it directly answers the question"#.to_string()
+}
+
+/// Build the user prompt for answering an agent's question.
+fn build_question_answer_prompt(
+    task_title: &str,
+    task_description: Option<&str>,
+    question: &str,
+    repo: &str,
+) -> String {
+    let mut prompt = format!(
+        "## Task\n\
+         **Repository:** {repo}\n\
+         **Title:** {task_title}\n"
+    );
+
+    if let Some(desc) = task_description {
+        prompt.push_str(&format!("**Description:** {desc}\n"));
+    }
+
+    prompt.push_str(&format!(
+        "\n## Agent's Question\n\
+         {question}\n\
+         \n## Instructions\n\
+         Answer the agent's question with specific, actionable guidance so they can continue working."
+    ));
+
+    prompt
 }
 
 /// Extract JSON from a text response.

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -22,5 +22,5 @@ pub use orchestrator::Orchestrator;
 pub use prompt::parse_pr_url;
 pub use types::{
     ConflictContext, ConflictResolution, ConflictTriage, EvaluationContext, OperatingMode,
-    OrchestratorAction, QualityEvaluation, QueueEntrySummary, SystemContext,
+    OrchestratorAction, QualityEvaluation, QuestionContext, QueueEntrySummary, SystemContext,
 };

--- a/crates/orchestrator/src/mock.rs
+++ b/crates/orchestrator/src/mock.rs
@@ -6,7 +6,7 @@ use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
 use crate::types::{
     default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
-    QualityEvaluation, SystemContext,
+    QualityEvaluation, QuestionContext, SystemContext,
 };
 use models::task::Task;
 
@@ -25,8 +25,10 @@ pub struct MockOrchestrator {
     pub feedback_count: Mutex<u32>,
     /// Count of triage_conflict calls (for assertions).
     pub triage_count: Mutex<u32>,
-    /// Count of process_event calls (for assertions).
+    /// Count of think calls (for assertions).
     pub think_count: Mutex<u32>,
+    /// Count of answer_question calls (for assertions).
+    pub answer_question_count: Mutex<u32>,
 }
 
 impl MockOrchestrator {
@@ -43,6 +45,7 @@ impl MockOrchestrator {
             feedback_count: Mutex::new(0),
             triage_count: Mutex::new(0),
             think_count: Mutex::new(0),
+            answer_question_count: Mutex::new(0),
         }
     }
 
@@ -60,6 +63,7 @@ impl MockOrchestrator {
             feedback_count: Mutex::new(0),
             triage_count: Mutex::new(0),
             think_count: Mutex::new(0),
+            answer_question_count: Mutex::new(0),
         }
     }
 
@@ -111,6 +115,14 @@ impl Orchestrator for MockOrchestrator {
         *self.think_count.lock().unwrap() += 1;
         // Mock returns no actions — tests can verify call count.
         Ok(Vec::new())
+    }
+
+    async fn answer_question(
+        &self,
+        _context: &QuestionContext,
+    ) -> Result<String, OrchestratorError> {
+        *self.answer_question_count.lock().unwrap() += 1;
+        Ok("Mock: proceed with whatever approach you think is best.".to_string())
     }
 }
 
@@ -237,5 +249,19 @@ mod tests {
         // Should use the override, not the default (which would be Rebase)
         assert_eq!(result.resolution, ConflictResolution::SurfaceToHuman);
         assert_eq!(result.reasoning, "custom triage");
+    }
+
+    #[tokio::test]
+    async fn test_answer_question() {
+        let mock = MockOrchestrator::approving();
+        let ctx = QuestionContext {
+            task: Task::new("task-1", TaskSource::Internal, "Test task", "proj-1"),
+            project: Project::new("proj-1", "owner/repo"),
+            question: "How should I structure the database schema?".to_string(),
+            human_present: false,
+        };
+        let result = mock.answer_question(&ctx).await.unwrap();
+        assert!(!result.is_empty());
+        assert_eq!(*mock.answer_question_count.lock().unwrap(), 1);
     }
 }

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -11,7 +11,7 @@
 use crate::error::OrchestratorError;
 use crate::types::{
     ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction, QualityEvaluation,
-    SystemContext,
+    QuestionContext, SystemContext,
 };
 use models::task::Task;
 
@@ -69,4 +69,15 @@ pub trait Orchestrator: Sync {
         &self,
         context: &SystemContext,
     ) -> Result<Vec<OrchestratorAction>, OrchestratorError>;
+
+    /// Answer a stuck agent's question.
+    ///
+    /// When an agent session enters the Question state, the orchestrator
+    /// generates actionable guidance based on the task context and the
+    /// agent's question. The answer is sent back to the agent session
+    /// as a chat message.
+    async fn answer_question(
+        &self,
+        context: &QuestionContext,
+    ) -> Result<String, OrchestratorError>;
 }

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -154,6 +154,26 @@ impl ConflictResolution {
     }
 }
 
+/// Context for answering a stuck agent's question.
+///
+/// When an agent enters Question state, the orchestrator receives this context
+/// and generates actionable guidance to unblock the agent.
+pub struct QuestionContext {
+    /// The task the agent is working on.
+    pub task: Task,
+    /// The project this task belongs to.
+    pub project: Project,
+    /// The agent's question text (extracted from the most recent agent:question event).
+    pub question: String,
+    /// Whether a human is currently present (GUI connected).
+    ///
+    /// Note: The decision to answer vs escalate is made by the caller (run_loop)
+    /// before calling `answer_question()`. This field is passed for context and
+    /// potential future use in prompt customization, but is not currently read
+    /// by the answer generation logic.
+    pub human_present: bool,
+}
+
 /// Default triage logic for conflicts — spec §7.4.
 ///
 /// This function implements the mode-aware conflict resolution strategy:


### PR DESCRIPTION
## Summary

Closes #533

When an agent session enters the Question state (stuck and needs guidance), the orchestrator now automatically detects it and generates actionable guidance via an LLM call to unblock the agent. If a human is present (GUI connected), the question is surfaced as an escalation event instead of being answered autonomously.

- **Orchestrator trait**: Added `answer_question(context: &QuestionContext) -> Result<String>` method
- **QuestionContext**: New type containing task, project, question text, and human_present flag
- **ClaudeOrchestrator**: LLM-backed implementation using claude-opus-4-6 with a project-foreman system prompt that produces concise, actionable guidance
- **Run loop wiring**: `TaskStateQuestion` events in the orchestrator loop trigger the flow — extracts question text from event data or recent `agent:question` events, spawns async LLM call, sends answer via `SessionManager::send_chat`, emits `orchestrator:feedback` event for audit trail
- **Human-present guard**: When a human is connected, emits `orchestrator:escalation` instead of answering, letting the human decide
- **MockOrchestrator**: Returns a stub answer, tracks call count for test assertions

## Test plan

- [x] `cargo check` passes (full workspace)
- [x] `cargo test --package tasks-orchestrator` passes (40 tests including new `test_answer_question`)
- [ ] Manual: verify agent in Question state gets unblocked when orchestrator is running
- [ ] Manual: verify escalation event is emitted when human is present