### PR TITLE
Wire up orchestrator question-answering and eval feedback to web UI

### DIFF
--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -107,6 +107,11 @@ function MergeQueueRow({
             {prRepo(entry.pr_url)}#{num}
           </a>
         )}
+        {entry.changes_requested_feedback && (
+          <p className="text-xs text-muted-foreground truncate mt-0.5" title={entry.changes_requested_feedback}>
+            {entry.changes_requested_feedback}
+          </p>
+        )}
       </TextCell>
 
       {/* Project */}

--- a/web/src/pages/orchestrator/page.tsx
+++ b/web/src/pages/orchestrator/page.tsx
@@ -8,6 +8,7 @@ import {
   AlertTriangle,
   Brain,
   Sparkles,
+  HelpCircle,
 } from "lucide-react";
 import { useAppState } from "@/hooks/use-app-state";
 import { sendOrchestratorChat } from "@/lib/api";
@@ -62,7 +63,7 @@ function getTaskInfo(taskId: string | undefined, tasks: Task[], projects: Projec
 // ---------------------------------------------------------------------------
 
 interface OrchestratorBlock {
-  kind: "decision" | "feedback" | "escalation" | "message" | "thought" | "system";
+  kind: "decision" | "feedback" | "escalation" | "message" | "thought" | "question_answer" | "system";
   id: string;
   timestamp: string;
   approved?: boolean;
@@ -75,7 +76,7 @@ interface OrchestratorBlock {
   /** Resolved task info for richer display */
   taskInfo?: TaskInfo;
   /** Escalation-specific fields */
-  escalationAction?: "conflict_needs_human" | "mode_lowered" | string;
+  escalationAction?: "conflict_needs_human" | "mode_lowered" | "agent_question" | string;
   prUrl?: string;
   fromMode?: string;
   toMode?: string;
@@ -102,14 +103,16 @@ function parseOrchestratorEvents(
       });
     } else if (event.type === "orchestrator:feedback") {
       const taskId = typeof event.data?.task_id === "string" ? event.data.task_id : event.task;
+      const context = typeof event.data?.context === "string" ? event.data.context : undefined;
+      // Distinguish question answers from regular feedback
       blocks.push({
-        kind: "feedback",
+        kind: context === "question_answer" ? "question_answer" : "feedback",
         id: event.id,
         timestamp: event.ts,
         feedback: typeof event.data?.feedback === "string" ? event.data.feedback : undefined,
         taskId,
         taskInfo: getTaskInfo(taskId, tasks, projects) ?? undefined,
-        content: typeof event.data?.context === "string" ? event.data.context : undefined,
+        content: context,
       });
     } else if (event.type === "orchestrator:escalation") {
       const action = typeof event.data?.action === "string" ? event.data.action : undefined;
@@ -119,12 +122,14 @@ function parseOrchestratorEvents(
         typeof event.data?.reason === "string" ? event.data.reason :
         undefined;
       const taskId = event.task;
+      // For agent_question escalations, the message field contains the question
+      const message = typeof event.data?.message === "string" ? event.data.message : undefined;
 
       blocks.push({
         kind: "escalation",
         id: event.id,
         timestamp: event.ts,
-        content: reasoning,
+        content: action === "agent_question" ? message : reasoning,
         taskId,
         taskInfo: getTaskInfo(taskId, tasks, projects) ?? undefined,
         entryId: typeof event.data?.entry_id === "string" ? event.data.entry_id : undefined,
@@ -282,6 +287,14 @@ function EscalationBlock({ block }: { block: OrchestratorBlock }) {
     } else {
       actionHint = "Review recent activity and raise the mode when ready to continue.";
     }
+  } else if (block.escalationAction === "agent_question") {
+    // Agent is stuck with a question, human is present
+    if (info) {
+      headerText = `Agent working on "${info.title}" (${info.number}) in ${info.repoName} is stuck and needs your input.`;
+    } else {
+      headerText = "An agent is stuck and needs your input.";
+    }
+    actionHint = "Check the task detail view to respond to the agent.";
   } else if (block.escalationAction === "conflict_needs_human") {
     // Conflict needs human review
     if (info) {
@@ -325,7 +338,7 @@ function EscalationBlock({ block }: { block: OrchestratorBlock }) {
           {actionHint && (
             <p className="mt-1 text-sm text-muted-foreground leading-relaxed">{actionHint}</p>
           )}
-          {block.content && block.escalationAction !== "mode_lowered" && (
+          {block.content && block.escalationAction !== "mode_lowered" && block.escalationAction !== "agent_question" && (
             <>
               <button
                 onClick={() => setCollapsed(!collapsed)}
@@ -392,6 +405,47 @@ function ThoughtBlock({ block }: { block: OrchestratorBlock }) {
   );
 }
 
+function QuestionAnswerBlock({ block }: { block: OrchestratorBlock }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const info = block.taskInfo;
+
+  const headerText = info
+    ? `Answered a question from "${info.title}" (${info.number}) in ${info.repoName}.`
+    : "Answered an agent's question.";
+
+  return (
+    <div className="rounded-md border border-violet-500/30 bg-violet-500/5 p-4">
+      <div className="flex items-start gap-3">
+        <div className="rounded-full p-1.5 bg-violet-500/20 shrink-0">
+          <HelpCircle className="h-4 w-4 text-violet-500" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs text-muted-foreground">{formatRelativeTime(block.timestamp)}</span>
+          </div>
+          <p className="mt-1 text-sm leading-relaxed">{headerText}</p>
+          {block.feedback && (
+            <>
+              <button
+                onClick={() => setCollapsed(!collapsed)}
+                className="mt-2 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+              >
+                <ChevronDown className={cn("h-3 w-3 transition-transform", collapsed && "-rotate-90")} />
+                {collapsed ? "Show" : "Hide"} answer
+              </button>
+              {!collapsed && (
+                <p className="mt-2 text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
+                  {block.feedback}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function BlockView({ block }: { block: OrchestratorBlock }) {
   switch (block.kind) {
     case "decision": return <DecisionBlock block={block} />;
@@ -399,6 +453,7 @@ function BlockView({ block }: { block: OrchestratorBlock }) {
     case "escalation": return <EscalationBlock block={block} />;
     case "message": return <MessageBlock block={block} />;
     case "thought": return <ThoughtBlock block={block} />;
+    case "question_answer": return <QuestionAnswerBlock block={block} />;
     default: return null;
   }
 }

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -14,6 +14,8 @@ import {
   Clock,
   Activity,
   MessageSquare,
+  HelpCircle,
+  Brain,
 } from "lucide-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -100,7 +102,7 @@ function sourceDisplay(task: Task) {
 // ---------------------------------------------------------------------------
 
 interface ParsedBlock {
-  kind: "text" | "thinking" | "tool_use" | "tool_result" | "error" | "system" | "lifecycle" | "human_message" | "session_boundary";
+  kind: "text" | "thinking" | "tool_use" | "tool_result" | "error" | "system" | "lifecycle" | "human_message" | "agent_question" | "orchestrator_answer" | "session_boundary";
   content: string;
   toolName?: string;
   filePath?: string;
@@ -145,10 +147,24 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
       continue;
     }
 
+    if (event.type === "agent:question") {
+      const question = (event.data?.question ?? event.data?.message ?? event.data?.text) as string | undefined;
+      if (question) {
+        blocks.push({ kind: "agent_question", content: question, timestamp: event.ts });
+      }
+      continue;
+    }
+
     if (event.type === "human:message") {
       const message = event.data?.message as string | undefined;
+      const source = event.data?.source as string | undefined;
       if (message) {
-        blocks.push({ kind: "human_message", content: message, timestamp: event.ts });
+        // Orchestrator answers come as human:message with source "orchestrator_answer"
+        blocks.push({
+          kind: source === "orchestrator_answer" ? "orchestrator_answer" : "human_message",
+          content: message,
+          timestamp: event.ts,
+        });
       }
       continue;
     }
@@ -291,6 +307,32 @@ function BlockView({ block }: { block: ParsedBlock }) {
     );
   }
 
+  if (block.kind === "agent_question") {
+    return (
+      <div className="rounded-md border border-violet-500/30 bg-violet-500/10 px-3 py-2">
+        <div className="flex items-center gap-2 text-xs text-violet-400 mb-1">
+          <HelpCircle className="h-3 w-3" />
+          <span className="font-medium">Agent is asking a question</span>
+          {timestamp && <span className="text-muted-foreground ml-auto">{timestamp}</span>}
+        </div>
+        <p className="text-sm text-violet-300">{block.content}</p>
+      </div>
+    );
+  }
+
+  if (block.kind === "orchestrator_answer") {
+    return (
+      <div className="rounded-md border border-orange-500/30 bg-orange-500/10 px-3 py-2">
+        <div className="flex items-center gap-2 text-xs text-orange-400 mb-1">
+          <Brain className="h-3 w-3" />
+          <span className="font-medium">Orchestrator answered</span>
+          {timestamp && <span className="text-muted-foreground ml-auto">{timestamp}</span>}
+        </div>
+        <p className="text-sm text-orange-300/90 whitespace-pre-wrap">{block.content}</p>
+      </div>
+    );
+  }
+
   if (block.kind === "session_boundary") {
     return (
       <div className="flex items-center gap-2 py-3 text-sm text-yellow-500">
@@ -370,6 +412,7 @@ function SessionView({ taskId, chatEnabled }: { taskId: string; chatEnabled: boo
       e.type === "agent:question" ||
       e.type === "agent:error" ||
       e.type === "human:message" ||
+      e.type === "orchestrator:feedback" ||
       e.type.startsWith("task:");
 
     fetchTaskEvents(taskId).then((events) => {


### PR DESCRIPTION
## Summary
- **Orchestrator page**: New `QuestionAnswerBlock` (violet) for when the orchestrator autonomously answers an agent's question. Also handles `agent_question` escalation type for human-present mode with a clear "needs your input" message.
- **Task detail**: `agent:question` events now render distinctly (violet box with question text). Orchestrator answers (via `human:message` with `source: "orchestrator_answer"`) display differently from human messages (orange, labeled "Orchestrator answered").
- **Merge queue**: Shows `changes_requested_feedback` as a truncated subtitle under the entry title, with full text on hover.

## Related issues
Closes #559, closes #561

## Test plan
- [ ] Verify orchestrator page renders `question_answer` blocks with violet styling
- [ ] Verify `agent_question` escalation shows "needs your input" messaging
- [ ] Verify task detail shows agent questions and orchestrator answers distinctly
- [ ] Verify merge queue shows feedback subtitle on rejected/changes_requested entries
- [ ] `bun run build` succeeds