### PR TITLE
Fix merge queue rejection not persisted to SQLite

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -874,11 +874,11 @@ async fn reject_merge(
     State(state): State<ApiState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    let mut server_state = state.server.state.write().await;
-    server_state
-        .merge_queue
-        .reject(&id)
-        .map_err(|e| ApiError::MergeQueue(e.to_string()))?;
+    state
+        .server
+        .reject_merge_entry(&id, "Rejected via API", None)
+        .await
+        .map_err(ApiError::Server)?;
     Ok(StatusCode::OK)
 }
 

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1679,6 +1679,14 @@ impl Server {
                 .map_err(|e| ServerError::StoreError(e.to_string()))?;
             let entry = state.merge_queue.get(entry_id)
                 .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
+            // Persist rejected status to SQLite (issue #463)
+            if let Some(ref store) = self.store {
+                if let Ok(store) = store.lock() {
+                    if let Err(e) = store.save_merge_entry(entry) {
+                        tracing::error!(entry_id = %entry_id, error = %e, "failed to persist rejected merge queue entry");
+                    }
+                }
+            }
             entry.task_id.clone()
         };
 
@@ -1729,6 +1737,14 @@ impl Server {
                 .map_err(|e| ServerError::StoreError(e.to_string()))?;
             let entry = state.merge_queue.get(entry_id)
                 .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
+            // Persist rejected status to SQLite (issue #463)
+            if let Some(ref store) = self.store {
+                if let Ok(store) = store.lock() {
+                    if let Err(e) = store.save_merge_entry(entry) {
+                        tracing::error!(entry_id = %entry_id, error = %e, "failed to persist rejected merge queue entry");
+                    }
+                }
+            }
             entry.task_id.clone()
         };
 


### PR DESCRIPTION
## Summary

Closes #463

- Added `save_merge_entry()` calls to `reject_merge_entry()` and `reject_merge_entry_closed()` in `server.rs` so rejected merge queue status is persisted to SQLite and survives server restarts
- Updated the web API `reject_merge` handler to route through `Server::reject_merge_entry()` instead of directly mutating in-memory state, ensuring both persistence and event emission

## Test plan

- [x] Existing tests pass: `reject_merge_entry_transitions_task_to_waiting`, `reject_merge_entry_closed_marks_task_completed`
- [ ] Verify rejected entries reload correctly after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)