### PR TITLE
Add UNIQUE constraint on merge_queue.pr_url

### DIFF
--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -233,7 +233,8 @@ impl Store {
             .to_string();
         let queued_at = entry.queued_at.to_rfc3339();
         self.conn.execute(
-            "INSERT OR REPLACE INTO merge_queue (id, task_id, pr_url, status, queued_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT INTO merge_queue (id, task_id, pr_url, status, queued_at) VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(id) DO UPDATE SET task_id=excluded.task_id, pr_url=excluded.pr_url, status=excluded.status, queued_at=excluded.queued_at",
             params![entry.id, entry.task_id, entry.pr_url, status, queued_at],
         )?;
         Ok(())
@@ -1190,15 +1191,15 @@ mod tests {
     fn merge_status_roundtrip() {
         let store = Store::open_memory().unwrap();
 
-        for (id, status) in [
-            ("m1", MergeStatus::Pending),
-            ("m2", MergeStatus::Approved),
-            ("m3", MergeStatus::Merging),
-            ("m4", MergeStatus::Rejected),
-            ("m5", MergeStatus::Merged),
-            ("m6", MergeStatus::Conflict),
+        for (id, pr_num, status) in [
+            ("m1", 1, MergeStatus::Pending),
+            ("m2", 2, MergeStatus::Approved),
+            ("m3", 3, MergeStatus::Merging),
+            ("m4", 4, MergeStatus::Rejected),
+            ("m5", 5, MergeStatus::Merged),
+            ("m6", 6, MergeStatus::Conflict),
         ] {
-            let mut entry = MergeQueueEntry::new(id, "t1", "https://github.com/test/repo/pull/1");
+            let mut entry = MergeQueueEntry::new(id, "t1", &format!("https://github.com/test/repo/pull/{pr_num}"));
             entry.status = status;
             store.save_merge_entry(&entry).unwrap();
 
@@ -1215,6 +1216,36 @@ mod tests {
 
         let loaded = store.get_merge_entry("m1").unwrap().unwrap();
         assert_eq!(loaded.pr_url, "https://github.com/owner/repo/pull/1");
+    }
+
+    #[test]
+    fn merge_entry_duplicate_pr_url_rejected() {
+        let store = Store::open_memory().unwrap();
+        let entry1 = MergeQueueEntry::new("m1", "t1", "https://github.com/owner/repo/pull/1");
+        store.save_merge_entry(&entry1).unwrap();
+
+        // Different id, same pr_url — should fail with UNIQUE constraint violation
+        let entry2 = MergeQueueEntry::new("m2", "t2", "https://github.com/owner/repo/pull/1");
+        assert!(store.save_merge_entry(&entry2).is_err());
+
+        // Only one entry should exist
+        let entries = store.list_merge_entries().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "m1");
+    }
+
+    #[test]
+    fn merge_entry_same_id_update_allowed() {
+        let store = Store::open_memory().unwrap();
+        let mut entry = MergeQueueEntry::new("m1", "t1", "https://github.com/owner/repo/pull/1");
+        store.save_merge_entry(&entry).unwrap();
+
+        // Same id, updated status — should succeed (upsert)
+        entry.status = MergeStatus::Approved;
+        store.save_merge_entry(&entry).unwrap();
+
+        let loaded = store.get_merge_entry("m1").unwrap().unwrap();
+        assert_eq!(loaded.status, MergeStatus::Approved);
     }
 
     // ── Task tests ───────────────────────────────────────────────

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -54,7 +54,7 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
         CREATE TABLE IF NOT EXISTS merge_queue (
             id TEXT PRIMARY KEY,
             task_id TEXT NOT NULL,
-            pr_url TEXT,
+            pr_url TEXT UNIQUE,
             status TEXT NOT NULL DEFAULT 'pending',
             queued_at TEXT NOT NULL
         );
@@ -100,8 +100,7 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
         CREATE INDEX IF NOT EXISTS idx_tasks_state ON tasks(state);
         CREATE INDEX IF NOT EXISTS idx_tasks_source ON tasks(source_json);
 
-        -- merge_queue: dedup by pr_url, lookup by task_id
-        CREATE INDEX IF NOT EXISTS idx_merge_queue_pr_url ON merge_queue(pr_url);
+        -- merge_queue: lookup by task_id (pr_url already has a UNIQUE index)
         CREATE INDEX IF NOT EXISTS idx_merge_queue_task_id ON merge_queue(task_id);
 
         -- automations: lookup by project
@@ -219,6 +218,23 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
         Err(e) => {
             tracing::error!(error = %e, "failed to add rejection_feedback column");
             return Err(e);
+        }
+    }
+
+    // Migration: add UNIQUE constraint on merge_queue.pr_url (issue #464)
+    // SQLite cannot add constraints to existing columns, so we create the unique index
+    // if it doesn't already exist. The column-level UNIQUE in CREATE TABLE handles new DBs;
+    // this handles existing DBs that already have the table.
+    match conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_merge_queue_pr_url_unique ON merge_queue(pr_url)",
+        [],
+    ) {
+        Ok(_) => {
+            // Also drop the old non-unique index if it exists
+            let _ = conn.execute("DROP INDEX IF EXISTS idx_merge_queue_pr_url", []);
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "could not create unique index on merge_queue.pr_url (duplicates may exist)");
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a `UNIQUE` constraint on `merge_queue.pr_url` to prevent duplicate entries at the database level, fixing a race condition where two concurrent requests could both pass the in-memory dedup check and insert duplicates.
- Changes `INSERT OR REPLACE` to `INSERT ... ON CONFLICT(id) DO UPDATE` to avoid unintended row deletion when a pr_url uniqueness conflict occurs.
- Includes a migration for existing databases and new tests verifying the constraint.

## Test plan
- [x] All 43 store tests pass (`cargo test --package tasks-store`)
- [x] Full workspace compiles (`cargo check`)
- [x] New test `merge_entry_duplicate_pr_url_rejected` verifies constraint prevents duplicates
- [x] New test `merge_entry_same_id_update_allowed` verifies upsert still works

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)