### PR TITLE
Add retry queue for failed merge operations

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -774,6 +774,57 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                             _ => {} // No changes
                         }
 
+                        // --- Retry approved merges (issue #467) ---
+                        //
+                        // In Play mode, pick up any Approved entries that haven't
+                        // transitioned to Merging/Merged yet. This handles the case
+                        // where a merge was reverted to Approved after a transient
+                        // GitHub API failure.
+                        if poll_server.mode().await == server::Mode::Play {
+                            let approved_entries: Vec<(String, String)> = {
+                                let state = poll_server.state.read().await;
+                                state.merge_queue.approved().iter().map(|e| {
+                                    (e.id.clone(), e.pr_url.clone())
+                                }).collect()
+                            };
+
+                            if !approved_entries.is_empty() {
+                                let retry_token = std::env::var("GITHUB_TOKEN").unwrap_or_default();
+                                if !retry_token.is_empty() {
+                                    let retry_client = GitHubClient::new(&retry_token);
+                                    for (entry_id, pr_url) in &approved_entries {
+                                        if let Some((owner, repo, number)) = tasks_orchestrator::parse_pr_url(pr_url) {
+                                            info!(entry_id = %entry_id, pr_url = %pr_url, "retrying merge for approved entry");
+                                            if let Err(e) = poll_server.mark_entry_merging(entry_id, pr_url).await {
+                                                error!(entry_id = %entry_id, error = %e, "failed to mark entry as merging for retry");
+                                                continue;
+                                            }
+                                            match retry_client.merge_pull_request(&owner, &repo, number).await {
+                                                Ok(true) => {
+                                                    info!(entry_id = %entry_id, pr_url = %pr_url, "PR merged on retry");
+                                                    if let Err(e) = poll_server.mark_entry_merged(entry_id, pr_url).await {
+                                                        error!(entry_id = %entry_id, error = %e, "failed to mark entry merged on retry");
+                                                    }
+                                                }
+                                                Ok(false) => {
+                                                    warn!(entry_id = %entry_id, pr_url = %pr_url, "PR not mergeable on retry");
+                                                    if let Err(e) = poll_server.mark_entry_conflict(entry_id, pr_url, None).await {
+                                                        error!(entry_id = %entry_id, error = %e, "failed to mark entry conflict on retry");
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    error!(entry_id = %entry_id, pr_url = %pr_url, error = %e, "merge retry failed, will retry next poll cycle");
+                                                    if let Err(e) = poll_server.revert_entry_to_approved(entry_id, pr_url).await {
+                                                        error!(entry_id = %entry_id, error = %e, "failed to revert entry to Approved on retry failure");
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
                         // --- PR closure: transition linked tasks (spec §11.3) ---
                         //
                         // When a PR is merged/closed externally, transition the linked
@@ -2131,7 +2182,10 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                     }
                                 }
                                 Err(e) => {
-                                    error!(entry_id = %entry_id, pr_url = %pr_url, error = %e, "failed to merge PR on GitHub");
+                                    error!(entry_id = %entry_id, pr_url = %pr_url, error = %e, "failed to merge PR on GitHub, reverting to Approved for retry");
+                                    if let Err(e) = orch_server.revert_entry_to_approved(&entry_id, &pr_url).await {
+                                        error!(entry_id = %entry_id, error = %e, "failed to revert entry to Approved");
+                                    }
                                 }
                             }
                         } else {

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -791,7 +791,10 @@ async fn flush_merge_queue(State(state): State<ApiState>) -> Result<Json<Vec<Str
                     }
                 }
                 Err(e) => {
-                    tracing::error!(entry_id = %entry_id, pr_url = %pr_url, error = %e, "failed to merge PR during flush");
+                    tracing::error!(entry_id = %entry_id, pr_url = %pr_url, error = %e, "failed to merge PR during flush, reverting to Approved for retry");
+                    if let Err(e) = state.server.revert_entry_to_approved(entry_id, pr_url).await {
+                        tracing::error!(entry_id = %entry_id, error = %e, "failed to revert entry to Approved after flush failure");
+                    }
                 }
             }
         }
@@ -857,7 +860,10 @@ async fn approve_merge(
                         }
                     }
                     Err(e) => {
-                        tracing::error!(entry_id = %id, pr_url = %pr_url, error = %e, "failed to merge PR after approval");
+                        tracing::error!(entry_id = %id, pr_url = %pr_url, error = %e, "failed to merge PR after approval, reverting to Approved for retry");
+                        if let Err(e) = state.server.revert_entry_to_approved(&id, &pr_url).await {
+                            tracing::error!(entry_id = %id, error = %e, "failed to revert entry to Approved");
+                        }
                     }
                 }
             }

--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -135,6 +135,15 @@ impl MergeQueue {
         Ok(())
     }
 
+    /// Revert a Merging entry back to Approved (for retry after transient failures).
+    pub fn revert_to_approved(&mut self, id: &str) -> Result<(), MergeQueueError> {
+        let entry = self
+            .get_mut(id)
+            .ok_or_else(|| MergeQueueError::NotFound(id.to_string()))?;
+        entry.status = MergeStatus::Approved;
+        Ok(())
+    }
+
     /// Reject an entry (spec Section 7.1 step 5).
     pub fn reject(&mut self, id: &str) -> Result<(), MergeQueueError> {
         let entry = self
@@ -391,6 +400,26 @@ mod tests {
         assert!(q.collect_approved_for_flush(Mode::Stop).is_err());
         assert!(q.collect_approved_for_flush(Mode::Play).is_err());
         assert!(q.collect_approved_for_flush(Mode::Pause).is_ok());
+    }
+
+    #[test]
+    fn revert_merging_to_approved() {
+        let mut q = MergeQueue::new();
+        q.enqueue(entry("m1", "t1"));
+        q.approve("m1").unwrap();
+        q.mark_merging("m1").unwrap();
+        assert_eq!(q.get("m1").unwrap().status, MergeStatus::Merging);
+
+        // Revert to Approved after transient failure
+        q.revert_to_approved("m1").unwrap();
+        assert_eq!(q.get("m1").unwrap().status, MergeStatus::Approved);
+        assert_eq!(q.approved().len(), 1);
+    }
+
+    #[test]
+    fn revert_not_found() {
+        let mut q = MergeQueue::new();
+        assert!(q.revert_to_approved("nonexistent").is_err());
     }
 
     #[test]

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1524,6 +1524,55 @@ impl Server {
         Ok(())
     }
 
+    /// Revert a merge queue entry from Merging back to Approved after a transient
+    /// GitHub API failure. This preserves the approval intent so the reconciliation
+    /// loop or next eval tick can retry the merge.
+    pub async fn revert_entry_to_approved(
+        &self,
+        entry_id: &str,
+        pr_url: &str,
+    ) -> Result<(), ServerError> {
+        let task_id = {
+            let mut state = self.state.write().await;
+            state
+                .merge_queue
+                .revert_to_approved(entry_id)
+                .map_err(|e| ServerError::StoreError(e.to_string()))?;
+            let entry = state.merge_queue.get(entry_id)
+                .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
+            entry.task_id.clone()
+        };
+
+        // Persist status change (clone entry to avoid holding store lock across await)
+        if let Some(ref store) = self.store {
+            let entry_clone = {
+                let state = self.state.read().await;
+                state.merge_queue.get(entry_id).cloned()
+            };
+            if let Some(entry) = entry_clone {
+                if let Ok(store) = store.lock() {
+                    if let Err(e) = store.save_merge_entry(&entry) {
+                        tracing::error!(entry_id = %entry_id, error = %e, "failed to persist revert-to-approved");
+                    }
+                }
+            }
+        }
+
+        let event = Event::new(
+            EventType::MergeApproved,
+            &task_id,
+            Actor::System,
+            serde_json::json!({
+                "entry_id": entry_id,
+                "pr_url": pr_url,
+                "retry": true,
+                "reason": "reverted from Merging after transient GitHub API failure",
+            }),
+        );
+        self.event_bus.publish(event).await?;
+        Ok(())
+    }
+
     /// Mark a merge queue entry as merged and transition the linked task
     /// to Completed. Emits `merge:completed` and `task:state:completed`.
     pub async fn mark_entry_merged(


### PR DESCRIPTION
## Summary

- When a GitHub merge API call fails (transient error), the merge entry is now reverted from `Merging` back to `Approved` instead of being left in a stuck state
- The GitHub poll loop retries merging any `Approved` entries in Play mode on each cycle, acting as a natural retry queue
- All three merge paths (web approve, flush, orchestrator eval) now handle transient failures with revert-to-approved

## Details

**Problem:** When a user approves a merge in Play mode and the GitHub API is down, the call fails and the entry stays in `Merging` status with no retry mechanism. The approval intent is effectively lost.

**Fix:**
- `MergeQueue::revert_to_approved()` — transitions Merging → Approved
- `Server::revert_entry_to_approved()` — reverts status, persists to store, emits audit event
- Error handlers in `web.rs` (approve + flush) and `run_loop.rs` (orchestrator) call revert on API errors
- Poll loop picks up Approved entries in Play mode and retries merges each cycle

Closes #467

## Test plan

- [x] Unit tests for `revert_to_approved` (success + not-found cases)
- [x] All existing merge queue tests pass
- [x] Compilation check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)