### PR TITLE
Add event log retention, compaction, and orphan cleanup

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -2391,7 +2391,50 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
         }
     });
 
-    // --- 8d. Spawn stop mode listener (spec §6.1) ---
+    // --- 8d. Event log compaction loop (#470) ---
+    //
+    // Periodically compact event logs to enforce retention limits and clean up
+    // orphaned task directories, preventing unbounded storage growth.
+
+    let compaction_event_bus = server.event_bus.clone();
+    let mut compaction_shutdown_rx = shutdown_tx.subscribe();
+
+    let compaction_handle = tokio::spawn(async move {
+        // Run compaction every hour.
+        let mut interval = tokio::time::interval(Duration::from_secs(3600));
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {}
+                _ = compaction_shutdown_rx.recv() => {
+                    info!("compaction loop received shutdown signal");
+                    break;
+                }
+            }
+
+            match compaction_event_bus.compact().await {
+                Ok(removed) if removed > 0 => {
+                    info!(removed, "event log compaction removed events");
+                }
+                Err(e) => {
+                    warn!(error = %e, "event log compaction failed");
+                }
+                _ => {}
+            }
+
+            match compaction_event_bus.cleanup_orphaned_tasks().await {
+                Ok(removed) if removed > 0 => {
+                    info!(removed, "cleaned up orphaned task directories");
+                }
+                Err(e) => {
+                    warn!(error = %e, "orphaned task cleanup failed");
+                }
+                _ => {}
+            }
+        }
+    });
+
+    // --- 8e. Spawn stop mode listener (spec §6.1) ---
     //
     // When mode changes to Stop, terminate all running sessions.
     // This is event-driven so that any mode change source (web, CLI, orchestrator)
@@ -2739,6 +2782,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
         think_handle,
         watchdog_handle,
         cleanup_handle,
+        compaction_handle,
         stop_mode_handle,
     ];
     if let Some(h) = update_handle {

--- a/crates/events/src/bus.rs
+++ b/crates/events/src/bus.rs
@@ -77,6 +77,20 @@ impl EventBus {
     pub async fn list_tasks(&self) -> Result<Vec<String>, StoreError> {
         self.store.list_tasks().await
     }
+
+    /// Compact all task event logs according to the retention policy.
+    ///
+    /// Returns the total number of events removed.
+    pub async fn compact(&self) -> Result<usize, StoreError> {
+        self.store.compact_all().await
+    }
+
+    /// Remove orphaned (empty) task directories.
+    ///
+    /// Returns the number of directories removed.
+    pub async fn cleanup_orphaned_tasks(&self) -> Result<usize, StoreError> {
+        self.store.cleanup_orphaned_tasks().await
+    }
 }
 
 /// Filter events by pattern.

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -8,5 +8,5 @@ mod store;
 mod bus;
 
 pub use event::{Event, EventType, Actor};
-pub use store::{EventStore, StoreError, EVENT_FORMAT_VERSION};
+pub use store::{EventStore, RetentionPolicy, StoreError, EVENT_FORMAT_VERSION};
 pub use bus::{EventBus, matches_pattern, matches_task};

--- a/crates/events/src/store.rs
+++ b/crates/events/src/store.rs
@@ -8,11 +8,20 @@
 //!   lines with a warning instead of failing the entire read.
 //! - **Concurrent write protection (#468):** Writes to the same task file are
 //!   serialized via a per-task `tokio::sync::Mutex` to prevent byte interleaving.
+//!
+//! ## Retention & compaction (#470)
+//!
+//! Event logs are compacted per-task according to a configurable
+//! [`RetentionPolicy`]. Compaction keeps only the most recent N events and/or
+//! events newer than a max age. Orphaned task directories (those without a
+//! corresponding events file) can also be cleaned up.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
+use chrono::Utc;
 use thiserror::Error;
 use tokio::fs::{self, OpenOptions};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -37,6 +46,27 @@ pub enum StoreError {
     FormatMismatch { found: u32, expected: u32 },
 }
 
+/// Configures retention limits for event log compaction.
+///
+/// Both limits are applied together — an event is kept only if it satisfies
+/// *both* constraints. Set a field to `None` to disable that limit.
+#[derive(Debug, Clone)]
+pub struct RetentionPolicy {
+    /// Maximum number of events to keep per task log.
+    pub max_events: Option<usize>,
+    /// Maximum age of events to keep.
+    pub max_age: Option<Duration>,
+}
+
+impl Default for RetentionPolicy {
+    fn default() -> Self {
+        Self {
+            max_events: Some(10_000),
+            max_age: Some(Duration::from_secs(30 * 24 * 3600)), // 30 days
+        }
+    }
+}
+
 /// Append-only event store backed by the filesystem.
 ///
 /// Events are stored per-task in JSONL format. Each task gets its own
@@ -48,14 +78,23 @@ pub struct EventStore {
     root: PathBuf,
     /// Per-task write locks to serialize concurrent appends to the same file.
     write_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+    /// Retention policy for compaction.
+    retention: RetentionPolicy,
 }
 
 impl EventStore {
-    /// Create a new event store at the given root directory.
+    /// Create a new event store at the given root directory with default
+    /// retention policy.
     pub fn new(root: impl AsRef<Path>) -> Self {
+        Self::with_retention(root, RetentionPolicy::default())
+    }
+
+    /// Create a new event store with a custom retention policy.
+    pub fn with_retention(root: impl AsRef<Path>, retention: RetentionPolicy) -> Self {
         Self {
             root: root.as_ref().to_path_buf(),
             write_locks: Mutex::new(HashMap::new()),
+            retention,
         }
     }
 
@@ -266,6 +305,188 @@ impl EventStore {
         }
 
         Ok(tasks)
+    }
+
+    /// Compact event logs for all tasks according to the retention policy.
+    ///
+    /// Returns the number of events removed across all tasks.
+    pub async fn compact_all(&self) -> Result<usize, StoreError> {
+        let task_ids = self.list_tasks().await?;
+        let mut total_removed = 0;
+
+        for task_id in &task_ids {
+            total_removed += self.compact_task(task_id).await?;
+        }
+
+        // Also compact system-wide events (empty task ID).
+        total_removed += self.compact_task("").await?;
+
+        if total_removed > 0 {
+            tracing::info!(
+                removed = total_removed,
+                tasks = task_ids.len(),
+                "event log compaction complete"
+            );
+        }
+
+        Ok(total_removed)
+    }
+
+    /// Compact a single task's event log according to the retention policy.
+    ///
+    /// Rewrites the JSONL file in-place (via atomic rename) keeping only
+    /// events that satisfy both the `max_events` and `max_age` limits.
+    /// Returns the number of events removed.
+    pub async fn compact_task(&self, task_id: &str) -> Result<usize, StoreError> {
+        let path = self.task_log_path(task_id);
+        if !path.exists() {
+            return Ok(0);
+        }
+
+        let lock = self.task_lock(task_id).await;
+        let _guard = lock.lock().await;
+
+        // Read all events.
+        let events = self.read_task_unlocked(&path).await?;
+        let original_count = events.len();
+
+        // Apply retention policy.
+        let kept = self.apply_retention(events);
+        let removed = original_count - kept.len();
+
+        if removed == 0 {
+            return Ok(0);
+        }
+
+        // Write retained events to a temp file, then atomically rename.
+        let tmp_path = path.with_extension("jsonl.tmp");
+        {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&tmp_path)
+                .await?;
+
+            for event in &kept {
+                let mut line = serde_json::to_string(event)?;
+                line.push('\n');
+                file.write_all(line.as_bytes()).await?;
+            }
+            file.flush().await?;
+        }
+
+        fs::rename(&tmp_path, &path).await?;
+
+        tracing::debug!(
+            task_id,
+            original = original_count,
+            kept = kept.len(),
+            removed,
+            "compacted task event log"
+        );
+
+        Ok(removed)
+    }
+
+    /// Remove task directories that have no events file or are empty.
+    ///
+    /// Returns the number of directories removed.
+    pub async fn cleanup_orphaned_tasks(&self) -> Result<usize, StoreError> {
+        if !self.root.exists() {
+            return Ok(0);
+        }
+
+        let mut removed = 0;
+        let mut entries = fs::read_dir(&self.root).await?;
+
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            // Skip the version file or non-task entries.
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+
+            let events_file = path.join("events.jsonl");
+            let should_remove = if events_file.exists() {
+                // Remove if the events file is empty (0 bytes).
+                let metadata = fs::metadata(&events_file).await?;
+                metadata.len() == 0
+            } else {
+                // No events file at all — check if directory is empty.
+                let mut dir = fs::read_dir(&path).await?;
+                dir.next_entry().await?.is_none()
+            };
+
+            if should_remove {
+                if let Err(e) = fs::remove_dir_all(&path).await {
+                    tracing::warn!(
+                        task_id = name,
+                        error = %e,
+                        "failed to remove orphaned task directory"
+                    );
+                } else {
+                    tracing::debug!(task_id = name, "removed orphaned task directory");
+                    removed += 1;
+                }
+            }
+        }
+
+        if removed > 0 {
+            // Clean up write locks for removed tasks.
+            let mut locks = self.write_locks.lock().await;
+            locks.retain(|_, lock| Arc::strong_count(lock) > 1);
+        }
+
+        Ok(removed)
+    }
+
+    /// Read events from a path without acquiring the task lock.
+    ///
+    /// Caller must hold the lock.
+    async fn read_task_unlocked(&self, path: &Path) -> Result<Vec<Event>, StoreError> {
+        if !path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let file = fs::File::open(path).await?;
+        let reader = BufReader::new(file);
+        let mut lines = reader.lines();
+        let mut events = Vec::new();
+
+        while let Some(line) = lines.next_line().await? {
+            if line.is_empty() {
+                continue;
+            }
+            if let Ok(event) = serde_json::from_str::<Event>(&line) {
+                events.push(event);
+            }
+        }
+
+        Ok(events)
+    }
+
+    /// Apply retention policy to a list of events, returning the events to keep.
+    fn apply_retention(&self, mut events: Vec<Event>) -> Vec<Event> {
+        // Apply max_age: drop events older than the cutoff.
+        if let Some(max_age) = self.retention.max_age {
+            let cutoff = Utc::now() - chrono::Duration::from_std(max_age).unwrap_or(chrono::Duration::MAX);
+            events.retain(|e| e.ts >= cutoff);
+        }
+
+        // Apply max_events: keep only the most recent N.
+        if let Some(max) = self.retention.max_events {
+            if events.len() > max {
+                events = events.split_off(events.len() - max);
+            }
+        }
+
+        events
     }
 }
 
@@ -533,5 +754,185 @@ mod tests {
         // All 20 events should be readable without corruption.
         let events = store.read_task(task_id).await.unwrap();
         assert_eq!(events.len(), 20, "expected 20 events, got {}", events.len());
+    }
+
+    #[tokio::test]
+    async fn compact_task_enforces_max_events() {
+        let dir = tempdir().unwrap();
+        let policy = RetentionPolicy {
+            max_events: Some(3),
+            max_age: None,
+        };
+        let store = EventStore::with_retention(dir.path(), policy);
+
+        // Write 10 events.
+        for i in 0..10 {
+            store
+                .append(&Event::new(
+                    EventType::AgentMessage,
+                    "task-1",
+                    Actor::Agent,
+                    serde_json::json!({"index": i}),
+                ))
+                .await
+                .unwrap();
+        }
+
+        let removed = store.compact_task("task-1").await.unwrap();
+        assert_eq!(removed, 7);
+
+        let events = store.read_task("task-1").await.unwrap();
+        assert_eq!(events.len(), 3);
+
+        // Should be the last 3 events.
+        let indices: Vec<i64> = events
+            .iter()
+            .map(|e| e.data["index"].as_i64().unwrap())
+            .collect();
+        assert_eq!(indices, vec![7, 8, 9]);
+    }
+
+    #[tokio::test]
+    async fn compact_task_enforces_max_age() {
+        let dir = tempdir().unwrap();
+        let policy = RetentionPolicy {
+            max_events: None,
+            max_age: Some(Duration::from_secs(60)), // 1 minute
+        };
+        let store = EventStore::with_retention(dir.path(), policy);
+
+        // Create an old event by manipulating the timestamp.
+        let mut old_event = Event::new(
+            EventType::TaskCreated,
+            "task-1",
+            Actor::System,
+            serde_json::json!({"old": true}),
+        );
+        old_event.ts = Utc::now() - chrono::Duration::seconds(3600); // 1 hour ago
+
+        // Write old event directly to disk.
+        let path = dir.path().join("task-1");
+        std::fs::create_dir_all(&path).unwrap();
+        let mut line = serde_json::to_string(&old_event).unwrap();
+        line.push('\n');
+        std::fs::write(path.join("events.jsonl"), &line).unwrap();
+
+        // Write a fresh event through the store.
+        store
+            .append(&Event::new(
+                EventType::AgentMessage,
+                "task-1",
+                Actor::Agent,
+                serde_json::json!({"new": true}),
+            ))
+            .await
+            .unwrap();
+
+        let removed = store.compact_task("task-1").await.unwrap();
+        assert_eq!(removed, 1);
+
+        let events = store.read_task("task-1").await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(events[0].data["new"].as_bool().unwrap());
+    }
+
+    #[tokio::test]
+    async fn compact_all_processes_all_tasks() {
+        let dir = tempdir().unwrap();
+        let policy = RetentionPolicy {
+            max_events: Some(2),
+            max_age: None,
+        };
+        let store = EventStore::with_retention(dir.path(), policy);
+
+        for task in ["task-a", "task-b"] {
+            for i in 0..5 {
+                store
+                    .append(&Event::new(
+                        EventType::AgentMessage,
+                        task,
+                        Actor::Agent,
+                        serde_json::json!({"i": i}),
+                    ))
+                    .await
+                    .unwrap();
+            }
+        }
+
+        let removed = store.compact_all().await.unwrap();
+        assert_eq!(removed, 6); // 3 removed per task
+
+        for task in ["task-a", "task-b"] {
+            let events = store.read_task(task).await.unwrap();
+            assert_eq!(events.len(), 2);
+        }
+    }
+
+    #[tokio::test]
+    async fn compact_noop_when_within_limits() {
+        let dir = tempdir().unwrap();
+        let policy = RetentionPolicy {
+            max_events: Some(100),
+            max_age: None,
+        };
+        let store = EventStore::with_retention(dir.path(), policy);
+
+        store
+            .append(&Event::new(
+                EventType::TaskCreated,
+                "task-1",
+                Actor::System,
+                serde_json::json!({}),
+            ))
+            .await
+            .unwrap();
+
+        let removed = store.compact_task("task-1").await.unwrap();
+        assert_eq!(removed, 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_orphaned_removes_empty_dirs() {
+        let dir = tempdir().unwrap();
+        let store = EventStore::new(dir.path());
+
+        // Create an orphaned directory with no events file.
+        std::fs::create_dir_all(dir.path().join("orphan-task")).unwrap();
+
+        // Create a valid task.
+        store
+            .append(&Event::new(
+                EventType::TaskCreated,
+                "valid-task",
+                Actor::System,
+                serde_json::json!({}),
+            ))
+            .await
+            .unwrap();
+
+        let removed = store.cleanup_orphaned_tasks().await.unwrap();
+        assert_eq!(removed, 1);
+
+        // Valid task still exists.
+        let tasks = store.list_tasks().await.unwrap();
+        assert_eq!(tasks, vec!["valid-task"]);
+
+        // Orphan is gone.
+        assert!(!dir.path().join("orphan-task").exists());
+    }
+
+    #[tokio::test]
+    async fn cleanup_orphaned_removes_empty_events_file() {
+        let dir = tempdir().unwrap();
+        let store = EventStore::new(dir.path());
+
+        // Create a task directory with an empty events file.
+        let task_dir = dir.path().join("empty-task");
+        std::fs::create_dir_all(&task_dir).unwrap();
+        std::fs::write(task_dir.join("events.jsonl"), "").unwrap();
+
+        let removed = store.cleanup_orphaned_tasks().await.unwrap();
+        assert_eq!(removed, 1);
+        assert!(!task_dir.exists());
     }
 }


### PR DESCRIPTION
## Summary

- Adds `RetentionPolicy` to `EventStore` with configurable `max_events` (default 10,000) and `max_age` (default 30 days) per task
- Implements `compact_task()` / `compact_all()` that atomically rewrite JSONL files keeping only retained events
- Implements `cleanup_orphaned_tasks()` to remove empty or stale task directories
- Wires up an hourly compaction loop in the run loop alongside existing workspace cleanup
- Exposes `compact()` and `cleanup_orphaned_tasks()` through `EventBus`
- Adds 6 new tests: max_events enforcement, max_age enforcement, compact_all across tasks, noop when within limits, orphan dir cleanup, and empty events file cleanup

Closes #470

## Test plan

- [x] All 45 events crate tests pass (including 6 new compaction/cleanup tests)
- [x] `cargo check` passes for both `events` and `tasks-app` crates
- [ ] Manual: verify compaction runs on long-lived deployment and reduces file sizes
- [ ] Manual: verify orphaned task directories are cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)