### PR TITLE
Fix empty file list silently degrading deep review evaluation

### DIFF
--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -206,7 +206,10 @@ impl Orchestrator for ClaudeOrchestrator {
         let pass1 = self.parse_evaluation_response(&response_text)?;
 
         // If pass 1 is decisive (no deeper review needed), return immediately
-        if !pass1.needs_deeper_review || pass1.files_to_review.is_none() {
+        if !pass1.needs_deeper_review
+            || pass1.files_to_review.is_none()
+            || pass1.files_to_review.as_ref().is_some_and(|f| f.is_empty())
+        {
             info!(
                 approved = pass1.approved,
                 has_feedback = pass1.feedback.is_some(),


### PR DESCRIPTION
## Summary

- When the LLM returns `needs_deeper_review=true` with `files_to_review=Some([])` (empty list), the code previously entered Pass 2, fetched 0 files, and told the LLM "you now have the file context you requested" — with no files attached.
- Added an `.is_empty()` check alongside the existing `.is_none()` check so that an empty file list correctly short-circuits to the Pass 1 result.

Closes #474

## Test plan

- [ ] Verify compilation passes (`cargo check --package tasks-orchestrator`)
- [ ] Confirm that when `needs_deeper_review=true` and `files_to_review=Some([])`, the evaluation returns the Pass 1 result without entering Pass 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)