### PR TITLE
Make LLM model and token limits configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ TASKS_DISPATCH_INTERVAL=30
 TASKS_CONTAINER_IMAGE=tasks-agent:latest
 TASKS_DATA_DIR=~/.local/state/tasks
 
+# Optional — LLM model configuration
+# TASKS_ORCHESTRATOR_MODEL=claude-opus-4-6
+# TASKS_ORCHESTRATOR_MAX_TOKENS=32000
+# TASKS_CHAT_MODEL=claude-opus-4-6
+# TASKS_CHAT_MAX_TOKENS=32000
+
 # Path to the supervisor binary (for development — mount into container)
 # Build with: container build, or compile in a container (see CLAUDE.md)
 # TASKS_SUPERVISOR_BIN=/path/to/tasks-supervisor

--- a/crates/orchestrator/src/chat.rs
+++ b/crates/orchestrator/src/chat.rs
@@ -17,8 +17,8 @@ use tasks_agent::{
 
 use crate::error::OrchestratorError;
 
-/// Model for orchestrator chat.
-const CHAT_MODEL: &str = "claude-opus-4-6";
+/// Default model for orchestrator chat.
+const DEFAULT_CHAT_MODEL: &str = "claude-opus-4-6";
 
 /// Convert TaskState to a string representation.
 fn task_state_str(state: &TaskState) -> &'static str {
@@ -37,8 +37,8 @@ fn task_state_str(state: &TaskState) -> &'static str {
     }
 }
 
-/// Maximum tokens for chat response.
-const MAX_TOKENS: u32 = 32_000;
+/// Default maximum tokens for chat response.
+const DEFAULT_CHAT_MAX_TOKENS: u32 = 32_000;
 
 /// Context for orchestrator chat — snapshot of current system state.
 #[derive(Debug, Clone)]
@@ -73,18 +73,51 @@ pub struct ChatResponse {
 /// Handler for orchestrator chat interactions.
 pub struct OrchestratorChat {
     provider: AnthropicProvider,
+    model: String,
+    max_tokens: u32,
 }
 
 impl OrchestratorChat {
     /// Create a new orchestrator chat handler.
     pub fn new(provider: AnthropicProvider) -> Self {
-        Self { provider }
+        Self {
+            provider,
+            model: DEFAULT_CHAT_MODEL.to_string(),
+            max_tokens: DEFAULT_CHAT_MAX_TOKENS,
+        }
     }
 
     /// Create from environment (ANTHROPIC_API_KEY).
+    ///
+    /// Optional env vars for LLM configuration:
+    /// - `TASKS_CHAT_MODEL` — model name (default: `claude-opus-4-6`)
+    /// - `TASKS_CHAT_MAX_TOKENS` — max response tokens (default: 32000)
     pub fn from_env() -> Result<Self, OrchestratorError> {
         let provider = AnthropicProvider::from_env().map_err(OrchestratorError::Agent)?;
-        Ok(Self::new(provider))
+        let mut instance = Self::new(provider);
+
+        if let Ok(model) = std::env::var("TASKS_CHAT_MODEL") {
+            instance.model = model;
+        }
+        if let Ok(max_tokens) = std::env::var("TASKS_CHAT_MAX_TOKENS") {
+            if let Ok(val) = max_tokens.parse::<u32>() {
+                instance.max_tokens = val;
+            }
+        }
+
+        Ok(instance)
+    }
+
+    /// Set a custom model for chat.
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    /// Set custom max tokens for chat responses.
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = max_tokens;
+        self
     }
 
     /// Process a human message and generate a response.
@@ -109,7 +142,7 @@ impl OrchestratorChat {
         let mut messages = conversation_history.to_vec();
         messages.push(Message::user(message));
 
-        let config = CompletionConfig::new(CHAT_MODEL).with_max_tokens(MAX_TOKENS);
+        let config = CompletionConfig::new(&self.model).with_max_tokens(self.max_tokens);
         let request = CompletionRequest::new(config, messages)
             .with_system(system_prompt);
 

--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -21,8 +21,8 @@ use tasks_github::GitHubClient;
 /// Default model for orchestrator evaluation.
 const DEFAULT_MODEL: &str = "claude-opus-4-6";
 
-/// Maximum tokens for evaluation response.
-const MAX_TOKENS: u32 = 32_000;
+/// Default maximum tokens for evaluation response.
+const DEFAULT_MAX_TOKENS: u32 = 32_000;
 
 /// Orchestrator implementation backed by Claude.
 ///
@@ -32,6 +32,7 @@ pub struct ClaudeOrchestrator {
     provider: AnthropicProvider,
     github: GitHubClient,
     model: String,
+    max_tokens: u32,
 }
 
 impl ClaudeOrchestrator {
@@ -41,10 +42,15 @@ impl ClaudeOrchestrator {
             provider,
             github,
             model: DEFAULT_MODEL.to_string(),
+            max_tokens: DEFAULT_MAX_TOKENS,
         }
     }
 
     /// Create from environment variables (ANTHROPIC_API_KEY, GITHUB_TOKEN).
+    ///
+    /// Optional env vars for LLM configuration:
+    /// - `TASKS_ORCHESTRATOR_MODEL` — model name (default: `claude-opus-4-6`)
+    /// - `TASKS_ORCHESTRATOR_MAX_TOKENS` — max response tokens (default: 32000)
     pub fn from_env() -> Result<Self, OrchestratorError> {
         let provider =
             AnthropicProvider::from_env().map_err(OrchestratorError::Agent)?;
@@ -54,12 +60,29 @@ impl ClaudeOrchestrator {
         })?;
         let github = GitHubClient::new(github_token);
 
-        Ok(Self::new(provider, github))
+        let mut instance = Self::new(provider, github);
+
+        if let Ok(model) = std::env::var("TASKS_ORCHESTRATOR_MODEL") {
+            instance.model = model;
+        }
+        if let Ok(max_tokens) = std::env::var("TASKS_ORCHESTRATOR_MAX_TOKENS") {
+            if let Ok(val) = max_tokens.parse::<u32>() {
+                instance.max_tokens = val;
+            }
+        }
+
+        Ok(instance)
     }
 
     /// Set a custom model for evaluation.
     pub fn with_model(mut self, model: impl Into<String>) -> Self {
         self.model = model.into();
+        self
+    }
+
+    /// Set custom max tokens for evaluation responses.
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = max_tokens;
         self
     }
 
@@ -190,7 +213,7 @@ impl Orchestrator for ClaudeOrchestrator {
             &context.queue_context,
         );
 
-        let config = CompletionConfig::new(&self.model).with_max_tokens(MAX_TOKENS);
+        let config = CompletionConfig::new(&self.model).with_max_tokens(self.max_tokens);
         let request = CompletionRequest::new(config, vec![Message::user(user_prompt)])
             .with_system(system.clone());
 
@@ -260,7 +283,7 @@ impl Orchestrator for ClaudeOrchestrator {
             &context.queue_context,
         );
 
-        let config = CompletionConfig::new(&self.model).with_max_tokens(MAX_TOKENS);
+        let config = CompletionConfig::new(&self.model).with_max_tokens(self.max_tokens);
         let request = CompletionRequest::new(config, vec![Message::user(deep_prompt)])
             .with_system(system);
 


### PR DESCRIPTION
## Summary

- Replaces hardcoded model names and `MAX_TOKENS` constants in `ClaudeOrchestrator` and `OrchestratorChat` with configurable fields read from environment variables
- Adds `TASKS_ORCHESTRATOR_MODEL`, `TASKS_ORCHESTRATOR_MAX_TOKENS`, `TASKS_CHAT_MODEL`, `TASKS_CHAT_MAX_TOKENS` env vars with sensible defaults
- Adds `with_model()` and `with_max_tokens()` builder methods on both structs for programmatic configuration
- Updates `.env.example` with new optional vars

Closes #475

## Test plan

- [x] `cargo check --package tasks-orchestrator` passes
- [x] All 40 existing orchestrator tests pass
- [ ] Manual: set `TASKS_ORCHESTRATOR_MODEL` in `.env` and verify it's used in evaluation calls
- [ ] Manual: set `TASKS_CHAT_MODEL` in `.env` and verify chat uses the configured model

🤖 Generated with [Claude Code](https://claude.com/claude-code)