### PR TITLE
Truncate automation run output at 1 MB to prevent DB bloat

### DIFF
--- a/crates/models/src/automation.rs
+++ b/crates/models/src/automation.rs
@@ -102,6 +102,25 @@ impl Automation {
     }
 }
 
+/// Maximum size in bytes for automation run output/error stored in SQLite.
+/// Output exceeding this limit is truncated with a marker indicating truncation.
+const MAX_OUTPUT_BYTES: usize = 1_024 * 1_024; // 1 MB
+
+/// Truncate a string to fit within `MAX_OUTPUT_BYTES`, appending a truncation notice.
+fn truncate_output(s: String) -> String {
+    if s.len() <= MAX_OUTPUT_BYTES {
+        return s;
+    }
+    // Find a valid UTF-8 boundary at or before the limit, leaving room for the notice.
+    let notice = "\n\n[truncated — output exceeded 1 MB limit]";
+    let budget = MAX_OUTPUT_BYTES - notice.len();
+    let end = s.floor_char_boundary(budget);
+    let mut truncated = s;
+    truncated.truncate(end);
+    truncated.push_str(notice);
+    truncated
+}
+
 /// A single run of an automation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AutomationRun {
@@ -142,22 +161,87 @@ impl AutomationRun {
     }
 
     /// Mark the run as completed successfully.
+    /// Output is truncated to 1 MB to prevent database bloat.
     pub fn complete(&mut self, output: Option<String>) {
         self.status = RunStatus::Completed;
         self.completed_at = Some(Utc::now());
-        self.output = output;
+        self.output = output.map(truncate_output);
     }
 
     /// Mark the run as failed.
+    /// Error text is truncated to 1 MB to prevent database bloat.
     pub fn fail(&mut self, error: impl Into<String>) {
         self.status = RunStatus::Failed;
         self.completed_at = Some(Utc::now());
-        self.error = Some(error.into());
+        self.error = Some(truncate_output(error.into()));
     }
 
     /// Mark the run as cancelled.
     pub fn cancel(&mut self) {
         self.status = RunStatus::Cancelled;
         self.completed_at = Some(Utc::now());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_output_short_string_unchanged() {
+        let s = "hello world".to_string();
+        assert_eq!(truncate_output(s.clone()), s);
+    }
+
+    #[test]
+    fn truncate_output_at_exact_limit() {
+        let s = "a".repeat(MAX_OUTPUT_BYTES);
+        assert_eq!(truncate_output(s.clone()), s);
+    }
+
+    #[test]
+    fn truncate_output_over_limit() {
+        let s = "a".repeat(MAX_OUTPUT_BYTES + 1000);
+        let result = truncate_output(s);
+        assert!(result.len() <= MAX_OUTPUT_BYTES);
+        assert!(result.ends_with("[truncated — output exceeded 1 MB limit]"));
+    }
+
+    #[test]
+    fn truncate_output_respects_utf8_boundaries() {
+        // Build a string with multi-byte chars that goes over the limit
+        let base = "é".repeat(MAX_OUTPUT_BYTES); // each é is 2 bytes
+        assert!(base.len() > MAX_OUTPUT_BYTES);
+        let result = truncate_output(base);
+        assert!(result.len() <= MAX_OUTPUT_BYTES);
+        // Must be valid UTF-8
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn automation_run_complete_truncates() {
+        let mut run = AutomationRun::new("r1", "a1");
+        let big_output = "x".repeat(MAX_OUTPUT_BYTES + 5000);
+        run.complete(Some(big_output));
+        let output = run.output.unwrap();
+        assert!(output.len() <= MAX_OUTPUT_BYTES);
+        assert!(output.ends_with("[truncated — output exceeded 1 MB limit]"));
+    }
+
+    #[test]
+    fn automation_run_fail_truncates() {
+        let mut run = AutomationRun::new("r1", "a1");
+        let big_error = "e".repeat(MAX_OUTPUT_BYTES + 5000);
+        run.fail(big_error);
+        let error = run.error.unwrap();
+        assert!(error.len() <= MAX_OUTPUT_BYTES);
+        assert!(error.ends_with("[truncated — output exceeded 1 MB limit]"));
+    }
+
+    #[test]
+    fn automation_run_complete_none_output() {
+        let mut run = AutomationRun::new("r1", "a1");
+        run.complete(None);
+        assert!(run.output.is_none());
     }
 }

--- a/crates/server/src/automation_executor.rs
+++ b/crates/server/src/automation_executor.rs
@@ -21,6 +21,9 @@ const DEFAULT_MODEL: &str = "claude-opus-4-6";
 /// Maximum tokens for automation response.
 const MAX_TOKENS: u32 = 32_000;
 
+/// Maximum output size in bytes. Matches the limit in [`tasks_models::automation`].
+const MAX_OUTPUT_BYTES: usize = 1_024 * 1_024; // 1 MB
+
 /// Error type for automation execution.
 #[derive(Debug, thiserror::Error)]
 pub enum ExecutionError {
@@ -106,8 +109,18 @@ impl AutomationExecutor {
             .await
             .map_err(ExecutionError::Provider)?;
 
-        let output = response.text();
+        let mut output = response.text();
         let (input_tokens, output_tokens) = extract_usage(&response);
+
+        if output.len() > MAX_OUTPUT_BYTES {
+            warn!(
+                automation_id = %automation.id,
+                output_len = output.len(),
+                limit = MAX_OUTPUT_BYTES,
+                "Automation output exceeds size limit, truncating"
+            );
+            output = truncate_output(output);
+        }
 
         info!(
             automation_id = %automation.id,
@@ -160,12 +173,25 @@ impl AutomationExecutor {
         let mut output = String::new();
         let mut input_tokens = 0u32;
         let mut output_tokens = 0u32;
+        let mut truncated = false;
 
         while let Some(chunk) = rx.recv().await {
             match chunk {
                 tasks_agent::StreamChunk::Text(text) => {
                     on_chunk(&text);
-                    output.push_str(&text);
+                    if !truncated {
+                        output.push_str(&text);
+                        if output.len() > MAX_OUTPUT_BYTES {
+                            warn!(
+                                automation_id = %automation.id,
+                                output_len = output.len(),
+                                limit = MAX_OUTPUT_BYTES,
+                                "Streaming automation output exceeds size limit, truncating"
+                            );
+                            output = truncate_output(output);
+                            truncated = true;
+                        }
+                    }
                 }
                 tasks_agent::StreamChunk::Thinking(_) => {
                     // Skip thinking chunks — don't emit to callback or output
@@ -253,6 +279,20 @@ fn build_user_prompt(automation: &Automation, context: &ExecutionContext) -> Str
     }
 
     out
+}
+
+/// Truncate a string to fit within `MAX_OUTPUT_BYTES`, appending a truncation notice.
+fn truncate_output(s: String) -> String {
+    if s.len() <= MAX_OUTPUT_BYTES {
+        return s;
+    }
+    let notice = "\n\n[truncated — output exceeded 1 MB limit]";
+    let budget = MAX_OUTPUT_BYTES - notice.len();
+    let end = s.floor_char_boundary(budget);
+    let mut truncated = s;
+    truncated.truncate(end);
+    truncated.push_str(notice);
+    truncated
 }
 
 /// Extract token usage from a response.


### PR DESCRIPTION
## Summary
- Adds a 1 MB size limit on automation run `output` and `error` fields before they are stored in SQLite
- Truncation happens at two levels: `AutomationRun::complete()`/`fail()` in the model layer (safety net), and in `AutomationExecutor` during both regular and streaming execution (caps memory usage)
- Truncated output gets a clear `[truncated — output exceeded 1 MB limit]` notice appended
- Handles UTF-8 boundary correctly using `floor_char_boundary`
- Includes 7 unit tests covering truncation logic, UTF-8 safety, and integration with `AutomationRun`

## Test plan
- [x] `cargo test --package models -- automation::tests` — 7 tests pass
- [x] `cargo test --package tasks-store -- automation` — 11 tests pass
- [ ] Verify no regressions in automation run storage/retrieval

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)