### PR TITLE
Fix orphaned merge queue entries surviving project deletion

### DIFF
--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -155,28 +155,52 @@ impl Server {
             state.projects.insert(project.id.clone(), project);
         }
 
-        // Load tasks
+        // Load tasks — skip orphaned tasks whose project no longer exists
         let tasks = store
             .list_tasks()
             .map_err(|e| ServerError::StoreError(e.to_string()))?;
         for task in tasks {
-            state.tasks.insert(task.id.clone(), task);
+            if state.projects.contains_key(&task.project) {
+                state.tasks.insert(task.id.clone(), task);
+            } else {
+                tracing::warn!(
+                    task_id = %task.id,
+                    project_id = %task.project,
+                    "skipping orphaned task (project no longer exists)"
+                );
+            }
         }
 
-        // Load merge queue entries
+        // Load merge queue entries — skip orphaned entries whose task no longer exists
         let entries = store
             .list_merge_entries()
             .map_err(|e| ServerError::StoreError(e.to_string()))?;
         for entry in entries {
-            state.merge_queue.enqueue(entry);
+            if state.tasks.contains_key(&entry.task_id) {
+                state.merge_queue.enqueue(entry);
+            } else {
+                tracing::warn!(
+                    entry_id = %entry.id,
+                    task_id = %entry.task_id,
+                    "skipping orphaned merge queue entry (task no longer exists)"
+                );
+            }
         }
 
-        // Load automations
+        // Load automations — skip orphaned automations whose project no longer exists
         let automations = store
             .list_automations()
             .map_err(|e| ServerError::StoreError(e.to_string()))?;
         for automation in automations {
-            state.automations.insert(automation.id.clone(), automation);
+            if state.projects.contains_key(&automation.project_id) {
+                state.automations.insert(automation.id.clone(), automation);
+            } else {
+                tracing::warn!(
+                    automation_id = %automation.id,
+                    project_id = %automation.project_id,
+                    "skipping orphaned automation (project no longer exists)"
+                );
+            }
         }
 
         Ok(())
@@ -198,13 +222,26 @@ impl Server {
         let mut state = self.state.write().await;
         let removed = state.projects.remove(id).is_some();
         if removed {
-            // Collect task IDs for this project
-            let task_ids: Vec<String> = state
+            // Collect task IDs from both in-memory state and the store to
+            // ensure we clean up everything, even if some tasks were already
+            // removed from memory but still exist in the database.
+            let mut task_ids: Vec<String> = state
                 .tasks
                 .iter()
                 .filter(|(_, task)| task.project == id)
                 .map(|(task_id, _)| task_id.clone())
                 .collect();
+
+            // Also include task IDs from the store that may not be in memory
+            if let Some(ref store) = self.store {
+                if let Ok(db_tasks) = store.list_tasks_by_project(id) {
+                    for task in db_tasks {
+                        if !task_ids.contains(&task.id) {
+                            task_ids.push(task.id);
+                        }
+                    }
+                }
+            }
 
             // Remove tasks from in-memory state
             for task_id in &task_ids {
@@ -227,9 +264,11 @@ impl Server {
                 state.automations.remove(automation_id);
             }
 
-            // Cascade delete in persistent store (transactional)
+            // Cascade delete in persistent store (transactional).
+            // Uses SQL subqueries to delete by project, independent of
+            // the in-memory task list.
             if let Some(ref store) = self.store {
-                    if let Err(e) = store.delete_project_data(id, &task_ids) {
+                    if let Err(e) = store.delete_project_data(id) {
                         tracing::error!(project_id = %id, error = %e, "failed to cascade-delete project data from store");
                     }
                     if let Err(e) = store.delete_automations_for_project(id) {

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -522,17 +522,23 @@ impl Store {
     }
 
     /// Cascade-delete all data for a project's tasks: merge queue entries,
-    /// accounting, then tasks. Runs in a transaction so partial failures
-    /// don't leave the store inconsistent.
-    pub fn delete_project_data(&self, project: &str, task_ids: &[String]) -> Result<(), StoreError> {
+    /// accounting, then tasks. Uses SQL subqueries to find all tasks by
+    /// project, so it catches DB-only entries that may not be in memory.
+    /// Runs in a transaction so partial failures don't leave the store
+    /// inconsistent.
+    pub fn delete_project_data(&self, project: &str) -> Result<(), StoreError> {
         let conn = self.conn()?;
         let tx = conn.unchecked_transaction()?;
 
-        // Delete merge queue entries and accounting for each task
-        for task_id in task_ids {
-            tx.execute("DELETE FROM merge_queue WHERE task_id = ?1", params![task_id])?;
-            tx.execute("DELETE FROM task_accounting WHERE task_id = ?1", params![task_id])?;
-        }
+        // Delete merge queue entries and accounting for all tasks belonging to this project
+        tx.execute(
+            "DELETE FROM merge_queue WHERE task_id IN (SELECT id FROM tasks WHERE project = ?1)",
+            params![project],
+        )?;
+        tx.execute(
+            "DELETE FROM task_accounting WHERE task_id IN (SELECT id FROM tasks WHERE project = ?1)",
+            params![project],
+        )?;
 
         // Delete all tasks for the project
         tx.execute("DELETE FROM tasks WHERE project = ?1", params![project])?;


### PR DESCRIPTION
## Summary

- **Root cause**: `remove_project` collected task IDs only from in-memory state when cascading deletes. Tasks that existed in the database but had already been removed from memory were missed, leaving their merge queue entries and accounting data orphaned in the store. On restart, these orphaned entries were reloaded.
- **Store fix**: `delete_project_data` now uses SQL subqueries (`WHERE task_id IN (SELECT id FROM tasks WHERE project = ?)`) to find all tasks by project directly in the database, independent of the in-memory task list.
- **Defensive loading**: `load_from_store` now filters out orphaned tasks, merge queue entries, and automations whose parent entity no longer exists, preventing stale data from accumulating even if a previous cleanup was interrupted.

## Test plan

- [ ] Existing `remove_project_cascades_to_tasks_and_merge_queue` test continues to pass (blocked by pre-existing compilation errors in unrelated code)
- [ ] Store tests pass (`cargo test --package tasks-store` — 43/43 passing)
- [ ] Manual: delete a project and verify merge queue and tasks are cleaned up
- [ ] Manual: restart server after deletion and verify no orphaned entries reappear

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)