### PR TITLE
Store PR metadata on merge queue entries for display

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -679,7 +679,9 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                         task_id.clone(),
                                         &pr_url,
                                     )
-                                    .with_head_sha(&pr.head_sha);
+                                    .with_head_sha(&pr.head_sha)
+                                    .with_pr_title(&pr.title)
+                                    .with_pr_number(pr.number);
 
                                     if let Err(e) = poll_server.add_to_merge_queue(entry).await {
                                         warn!(

--- a/crates/models/src/merge_queue.rs
+++ b/crates/models/src/merge_queue.rs
@@ -91,6 +91,13 @@ pub struct MergeQueueEntry {
     pub pr_url: String,
     pub status: MergeStatus,
     pub queued_at: DateTime<Utc>,
+    /// PR title from GitHub. Stored directly so the UI can display it
+    /// even when no task is linked (issue #589).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_title: Option<String>,
+    /// PR number from GitHub.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u64>,
     /// Conflict details when status is Conflict.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conflict_info: Option<ConflictInfo>,
@@ -121,6 +128,8 @@ impl MergeQueueEntry {
             pr_url: pr_url.into(),
             status: MergeStatus::Pending,
             queued_at: Utc::now(),
+            pr_title: None,
+            pr_number: None,
             conflict_info: None,
             changes_requested_feedback: None,
             head_sha: None,
@@ -132,6 +141,18 @@ impl MergeQueueEntry {
     /// Set the head SHA for this entry (builder pattern).
     pub fn with_head_sha(mut self, sha: impl Into<String>) -> Self {
         self.head_sha = Some(sha.into());
+        self
+    }
+
+    /// Set the PR title for this entry (builder pattern).
+    pub fn with_pr_title(mut self, title: impl Into<String>) -> Self {
+        self.pr_title = Some(title.into());
+        self
+    }
+
+    /// Set the PR number for this entry (builder pattern).
+    pub fn with_pr_number(mut self, number: u64) -> Self {
+        self.pr_number = Some(number);
         self
     }
 }

--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -241,6 +241,13 @@ impl MergeQueue {
         Ok(changed)
     }
 
+    /// Update the pr_title on an entry (issue #589).
+    pub fn update_pr_title(&mut self, id: &str, title: &str) {
+        if let Some(entry) = self.get_mut(id) {
+            entry.pr_title = Some(title.to_string());
+        }
+    }
+
     /// Get all entries with conflicts.
     pub fn conflicting(&self) -> Vec<&MergeQueueEntry> {
         self.entries

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1180,12 +1180,12 @@ impl Server {
                     (conflict_action, Some(sha_update_id))
                 }
             };
-            actions.push((action, entry_id_for_sha_update, pr.head_sha.clone()));
+            actions.push((action, entry_id_for_sha_update, pr.head_sha.clone(), pr.title.clone()));
         }
 
         // Execute all actions
         let mut changes = 0u32;
-        for (action, entry_id_for_sha_update, head_sha) in actions {
+        for (action, entry_id_for_sha_update, head_sha, pr_title) in actions {
             if let Some(action) = action {
                 match action {
                     MqAction::MarkMerged { entry_id, pr_url, .. } => {
@@ -1246,9 +1246,11 @@ impl Server {
                 }
             }
 
-            // Update head_sha for open PRs to detect new commits
+            // Update head_sha and pr_title for open PRs
             if let Some(entry_id) = entry_id_for_sha_update {
                 let mut state = self.state.write().await;
+                // Always refresh pr_title from GitHub (issue #589)
+                state.merge_queue.update_pr_title(&entry_id, &pr_title);
                 match state.merge_queue.update_head_sha(&entry_id, &head_sha) {
                     Ok(true) => {
                         tracing::debug!(

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -264,9 +264,9 @@ impl Store {
             .to_string();
         let queued_at = entry.queued_at.to_rfc3339();
         self.conn()?.execute(
-            "INSERT INTO merge_queue (id, task_id, pr_url, status, queued_at) VALUES (?1, ?2, ?3, ?4, ?5)
-             ON CONFLICT(id) DO UPDATE SET task_id=excluded.task_id, pr_url=excluded.pr_url, status=excluded.status, queued_at=excluded.queued_at",
-            params![entry.id, entry.task_id, entry.pr_url, status, queued_at],
+            "INSERT INTO merge_queue (id, task_id, pr_url, status, queued_at, pr_title, pr_number) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(id) DO UPDATE SET task_id=excluded.task_id, pr_url=excluded.pr_url, status=excluded.status, queued_at=excluded.queued_at, pr_title=excluded.pr_title, pr_number=excluded.pr_number",
+            params![entry.id, entry.task_id, entry.pr_url, status, queued_at, entry.pr_title, entry.pr_number.map(|n| n as i64)],
         )?;
         Ok(())
     }
@@ -275,7 +275,7 @@ impl Store {
     pub fn get_merge_entry(&self, id: &str) -> Result<Option<MergeQueueEntry>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
-            "SELECT id, task_id, pr_url, status, queued_at FROM merge_queue WHERE id = ?1",
+            "SELECT id, task_id, pr_url, status, queued_at, pr_title, pr_number FROM merge_queue WHERE id = ?1",
         )?;
         let mut rows = stmt.query_map(params![id], |row| {
             Ok((
@@ -284,11 +284,13 @@ impl Store {
                 row.get::<_, String>(2)?,
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, Option<i64>>(6)?,
             ))
         })?;
         match rows.next() {
             Some(row) => {
-                let (id, task_id, pr_url, status_str, queued_at_str) = row?;
+                let (id, task_id, pr_url, status_str, queued_at_str, pr_title, pr_number) = row?;
                 let status: MergeStatus = serde_json::from_str(&format!("\"{status_str}\""))?;
                 let queued_at: DateTime<Utc> = queued_at_str
                     .parse()
@@ -301,6 +303,8 @@ impl Store {
                     pr_url,
                     status,
                     queued_at,
+                    pr_title,
+                    pr_number: pr_number.map(|n| n as u64),
                     conflict_info: None, // Not persisted to DB yet
                     changes_requested_feedback: None, // TODO: persist to DB
                     head_sha: None,      // Updated from GitHub on reconciliation
@@ -316,7 +320,7 @@ impl Store {
     pub fn list_merge_entries(&self) -> Result<Vec<MergeQueueEntry>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn
-            .prepare("SELECT id, task_id, pr_url, status, queued_at FROM merge_queue")?;
+            .prepare("SELECT id, task_id, pr_url, status, queued_at, pr_title, pr_number FROM merge_queue")?;
         let rows = stmt.query_map([], |row| {
             Ok((
                 row.get::<_, String>(0)?,
@@ -324,11 +328,13 @@ impl Store {
                 row.get::<_, String>(2)?,
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, Option<i64>>(6)?,
             ))
         })?;
         let mut entries = Vec::new();
         for row in rows {
-            let (id, task_id, pr_url, status_str, queued_at_str) = row?;
+            let (id, task_id, pr_url, status_str, queued_at_str, pr_title, pr_number) = row?;
             let status: MergeStatus = serde_json::from_str(&format!("\"{status_str}\""))?;
             let queued_at: DateTime<Utc> = queued_at_str
                 .parse()
@@ -341,6 +347,8 @@ impl Store {
                 pr_url,
                 status,
                 queued_at,
+                pr_title,
+                pr_number: pr_number.map(|n| n as u64),
                 conflict_info: None, // Not persisted to DB yet
                 changes_requested_feedback: None, // TODO: persist to DB
                 head_sha: None,      // Updated from GitHub on reconciliation

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -221,6 +221,29 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
         }
     }
 
+    // Migration: add pr_title and pr_number columns to merge_queue (issue #589)
+    // These store PR metadata directly so the UI can display titles even without a linked task.
+    for (col, col_type) in &[("pr_title", "TEXT"), ("pr_number", "INTEGER")] {
+        match conn.execute(
+            &format!("ALTER TABLE merge_queue ADD COLUMN {} {}", col, col_type),
+            [],
+        ) {
+            Ok(_) => {
+                tracing::info!("added {} column to merge_queue table", col);
+            }
+            Err(rusqlite::Error::SqliteFailure(e, Some(ref msg)))
+                if e.extended_code == rusqlite::ffi::SQLITE_ERROR
+                    && msg.contains("duplicate column name") =>
+            {
+                tracing::debug!("{} column already exists in merge_queue", col);
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "failed to add {} column to merge_queue", col);
+                return Err(e);
+            }
+        }
+    }
+
     // Migration: add UNIQUE constraint on merge_queue.pr_url (issue #464)
     // SQLite cannot add constraints to existing columns, so we create the unique index
     // if it doesn't already exist. The column-level UNIQUE in CREATE TABLE handles new DBs;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -73,6 +73,10 @@ export interface MergeQueueEntry {
   pr_url: string;
   status: MergeStatus;
   queued_at: string;
+  /** PR title from GitHub (issue #589). */
+  pr_title?: string;
+  /** PR number from GitHub (issue #589). */
+  pr_number?: number;
   /** Feedback when status is changes_requested */
   changes_requested_feedback?: string;
   /** Position in merge queue (1-indexed). Only set for approved/merging entries. */

--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -153,10 +153,10 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
           </Link>
         );
       }
-      // No linked task — show PR repo/number as fallback
+      // No linked task — show PR title or repo/number as fallback
       const repo = prRepo(row.original.pr_url);
       const num = prNumber(row.original.pr_url);
-      const label = repo && num ? `${repo}#${num}` : row.original.pr_url;
+      const label = row.original.pr_title ?? (repo && num ? `${repo}#${num}` : row.original.pr_url);
       return (
         <a
           href={row.original.pr_url}

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -113,7 +113,7 @@ function MergeQueueRow({
             className="text-muted-foreground hover:underline truncate block"
             onClick={(e) => e.stopPropagation()}
           >
-            {prRepo(entry.pr_url)}#{num}
+            {entry.pr_title ?? `${prRepo(entry.pr_url)}#${num}`}
           </a>
         )}
         {entry.changes_requested_feedback && (


### PR DESCRIPTION
## Summary

- **Root cause**: Merge queue entries relied entirely on a linked task (`task_id`) for displaying titles in the UI. When task linking failed (no branch name match, no linked GitHub issue), entries showed without any metadata — just a raw URL fallback.
- **Fix**: Store `pr_title` and `pr_number` directly on `MergeQueueEntry`, populated from GitHub PR data when entries are created and refreshed during reconciliation. The frontend now uses `pr_title` as fallback when no linked task exists.

### Changes across layers:
- **Model** (`crates/models`): Added `pr_title` and `pr_number` fields with builder methods
- **Store** (`crates/store`): DB migration adds columns; save/load queries updated
- **Server** (`crates/server`): Reconciliation refreshes `pr_title` on each poll cycle
- **Run loop** (`crates/app`): Populates PR metadata when creating new merge queue entries
- **Frontend** (`web/`): Uses `pr_title` as display fallback in both list view and table columns; updated TypeScript types

## Test plan

- [x] All existing tests pass (84 tests across models + store crates)
- [ ] Verify merge queue items display PR titles even when no task is linked
- [ ] Verify titles refresh when PR title is edited on GitHub
- [ ] Verify existing entries with linked tasks still show task title (preferred over PR title)

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)