### PR TITLE
Store PR title on MergeQueueEntry and re-link orphaned entries

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -679,7 +679,8 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                         task_id.clone(),
                                         &pr_url,
                                     )
-                                    .with_head_sha(&pr.head_sha);
+                                    .with_head_sha(&pr.head_sha)
+                                    .with_title(&pr.title);
 
                                     if let Err(e) = poll_server.add_to_merge_queue(entry).await {
                                         warn!(

--- a/crates/models/src/merge_queue.rs
+++ b/crates/models/src/merge_queue.rs
@@ -91,6 +91,10 @@ pub struct MergeQueueEntry {
     pub pr_url: String,
     pub status: MergeStatus,
     pub queued_at: DateTime<Utc>,
+    /// PR title from GitHub. Stored directly on the entry so metadata is
+    /// available even when no linked task exists (issue #589).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Conflict details when status is Conflict.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conflict_info: Option<ConflictInfo>,
@@ -121,6 +125,7 @@ impl MergeQueueEntry {
             pr_url: pr_url.into(),
             status: MergeStatus::Pending,
             queued_at: Utc::now(),
+            title: None,
             conflict_info: None,
             changes_requested_feedback: None,
             head_sha: None,
@@ -132,6 +137,12 @@ impl MergeQueueEntry {
     /// Set the head SHA for this entry (builder pattern).
     pub fn with_head_sha(mut self, sha: impl Into<String>) -> Self {
         self.head_sha = Some(sha.into());
+        self
+    }
+
+    /// Set the PR title for this entry (builder pattern).
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
         self
     }
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1123,15 +1123,15 @@ impl Server {
         &self,
         prs: &[tasks_github::model::PullRequest],
     ) -> Result<u32, ServerError> {
-        // Build a HashMap index of pr_url -> (entry_id, task_id, status) in one read pass.
+        // Build a HashMap index of pr_url -> (entry_id, task_id, status, title) in one read pass.
         // This avoids O(N*M) from acquiring a lock and linear scanning for each PR.
-        let entry_index: HashMap<String, (String, String, MergeStatus)> = {
+        let entry_index: HashMap<String, (String, String, MergeStatus, Option<String>)> = {
             let state = self.state.read().await;
             state
                 .merge_queue
                 .entries()
                 .iter()
-                .map(|e| (e.pr_url.clone(), (e.id.clone(), e.task_id.clone(), e.status)))
+                .map(|e| (e.pr_url.clone(), (e.id.clone(), e.task_id.clone(), e.status, e.title.clone())))
                 .collect()
         };
 
@@ -1143,11 +1143,17 @@ impl Server {
                 pr.owner, pr.repo, pr.number
             );
 
-            let Some((entry_id, task_id, current_status)) = entry_index.get(&pr_url) else {
+            let Some((entry_id, task_id, current_status, current_title)) = entry_index.get(&pr_url) else {
                 continue;
             };
             let entry_id = entry_id.clone();
             let task_id = task_id.clone();
+
+            // Check if title needs updating from GitHub PR data
+            let needs_title_update = current_title.as_deref() != Some(&pr.title);
+
+            // Check if orphaned entry (empty task_id) can be re-linked to a task
+            let needs_task_relink = task_id.is_empty();
 
             let (action, entry_id_for_sha_update) = match pr.state {
                 tasks_github::model::PullRequestState::Merged => {
@@ -1180,12 +1186,16 @@ impl Server {
                     (conflict_action, Some(sha_update_id))
                 }
             };
-            actions.push((action, entry_id_for_sha_update, pr.head_sha.clone()));
+            // Collect linked issue numbers (using PR's owner/repo) for re-linking
+            let relink_issue_numbers: Option<Vec<u64>> = needs_task_relink.then(|| {
+                pr.linked_issues.iter().map(|li| li.number).collect()
+            });
+            actions.push((action, entry_id_for_sha_update, pr.head_sha.clone(), needs_title_update.then(|| pr.title.clone()), needs_task_relink.then(|| pr.head_ref.clone()), relink_issue_numbers, pr.owner.clone(), pr.repo.clone()));
         }
 
         // Execute all actions
         let mut changes = 0u32;
-        for (action, entry_id_for_sha_update, head_sha) in actions {
+        for (action, entry_id_for_sha_update, head_sha, new_title, relink_branch, relink_issue_numbers, pr_owner, pr_repo) in actions {
             if let Some(action) = action {
                 match action {
                     MqAction::MarkMerged { entry_id, pr_url, .. } => {
@@ -1247,9 +1257,9 @@ impl Server {
             }
 
             // Update head_sha for open PRs to detect new commits
-            if let Some(entry_id) = entry_id_for_sha_update {
+            if let Some(ref entry_id) = entry_id_for_sha_update {
                 let mut state = self.state.write().await;
-                match state.merge_queue.update_head_sha(&entry_id, &head_sha) {
+                match state.merge_queue.update_head_sha(entry_id, &head_sha) {
                     Ok(true) => {
                         tracing::debug!(
                             entry_id = %entry_id,
@@ -1260,6 +1270,62 @@ impl Server {
                     Ok(false) => {} // No change
                     Err(e) => {
                         tracing::warn!(entry_id = %entry_id, error = %e, "failed to update head_sha during reconciliation");
+                    }
+                }
+            }
+
+            // Update title from GitHub PR data (issue #589)
+            if let Some(ref title) = new_title {
+                let entry_id = entry_id_for_sha_update.as_deref().unwrap_or_default();
+                if !entry_id.is_empty() {
+                    let mut state = self.state.write().await;
+                    if let Some(entry) = state.merge_queue.get_mut(entry_id) {
+                        entry.title = Some(title.clone());
+                        tracing::debug!(
+                            entry_id = %entry_id,
+                            title = %title,
+                            "reconciliation: updated title for merge entry"
+                        );
+                    }
+                }
+            }
+
+            // Re-link orphaned entries to tasks (issue #589)
+            // If an entry was created before its task existed, try to find the task now.
+            if let Some(ref branch) = relink_branch {
+                let entry_id_str = entry_id_for_sha_update.as_deref().unwrap_or_default();
+                if !entry_id_str.is_empty() {
+                    let mut found_task_id = self.find_task_by_branch(branch).await;
+                    if found_task_id.is_none() {
+                        if let Some(ref issue_numbers) = relink_issue_numbers {
+                            for &number in issue_numbers {
+                                if let Some(tid) = self.find_task_by_github_issue(
+                                    &pr_owner,
+                                    &pr_repo,
+                                    number,
+                                ).await {
+                                    found_task_id = Some(tid);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if let Some(ref new_task_id) = found_task_id {
+                        let mut state = self.state.write().await;
+                        if let Some(entry) = state.merge_queue.get_mut(entry_id_str) {
+                            entry.task_id = new_task_id.clone();
+                            tracing::info!(
+                                entry_id = %entry_id_str,
+                                task_id = %new_task_id,
+                                "reconciliation: re-linked orphaned merge entry to task"
+                            );
+                            // Persist updated entry
+                            if let Some(ref store) = self.store {
+                                if let Err(e) = store.save_merge_entry(entry) {
+                                    tracing::error!(entry_id = %entry_id_str, error = %e, "failed to persist re-linked merge entry");
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -264,9 +264,9 @@ impl Store {
             .to_string();
         let queued_at = entry.queued_at.to_rfc3339();
         self.conn()?.execute(
-            "INSERT INTO merge_queue (id, task_id, pr_url, status, queued_at) VALUES (?1, ?2, ?3, ?4, ?5)
-             ON CONFLICT(id) DO UPDATE SET task_id=excluded.task_id, pr_url=excluded.pr_url, status=excluded.status, queued_at=excluded.queued_at",
-            params![entry.id, entry.task_id, entry.pr_url, status, queued_at],
+            "INSERT INTO merge_queue (id, task_id, pr_url, status, queued_at, title) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(id) DO UPDATE SET task_id=excluded.task_id, pr_url=excluded.pr_url, status=excluded.status, queued_at=excluded.queued_at, title=excluded.title",
+            params![entry.id, entry.task_id, entry.pr_url, status, queued_at, entry.title],
         )?;
         Ok(())
     }
@@ -275,7 +275,7 @@ impl Store {
     pub fn get_merge_entry(&self, id: &str) -> Result<Option<MergeQueueEntry>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
-            "SELECT id, task_id, pr_url, status, queued_at FROM merge_queue WHERE id = ?1",
+            "SELECT id, task_id, pr_url, status, queued_at, title FROM merge_queue WHERE id = ?1",
         )?;
         let mut rows = stmt.query_map(params![id], |row| {
             Ok((
@@ -284,11 +284,12 @@ impl Store {
                 row.get::<_, String>(2)?,
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
+                row.get::<_, Option<String>>(5)?,
             ))
         })?;
         match rows.next() {
             Some(row) => {
-                let (id, task_id, pr_url, status_str, queued_at_str) = row?;
+                let (id, task_id, pr_url, status_str, queued_at_str, title) = row?;
                 let status: MergeStatus = serde_json::from_str(&format!("\"{status_str}\""))?;
                 let queued_at: DateTime<Utc> = queued_at_str
                     .parse()
@@ -301,6 +302,7 @@ impl Store {
                     pr_url,
                     status,
                     queued_at,
+                    title,
                     conflict_info: None, // Not persisted to DB yet
                     changes_requested_feedback: None, // TODO: persist to DB
                     head_sha: None,      // Updated from GitHub on reconciliation
@@ -316,7 +318,7 @@ impl Store {
     pub fn list_merge_entries(&self) -> Result<Vec<MergeQueueEntry>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn
-            .prepare("SELECT id, task_id, pr_url, status, queued_at FROM merge_queue")?;
+            .prepare("SELECT id, task_id, pr_url, status, queued_at, title FROM merge_queue")?;
         let rows = stmt.query_map([], |row| {
             Ok((
                 row.get::<_, String>(0)?,
@@ -324,11 +326,12 @@ impl Store {
                 row.get::<_, String>(2)?,
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
+                row.get::<_, Option<String>>(5)?,
             ))
         })?;
         let mut entries = Vec::new();
         for row in rows {
-            let (id, task_id, pr_url, status_str, queued_at_str) = row?;
+            let (id, task_id, pr_url, status_str, queued_at_str, title) = row?;
             let status: MergeStatus = serde_json::from_str(&format!("\"{status_str}\""))?;
             let queued_at: DateTime<Utc> = queued_at_str
                 .parse()
@@ -341,6 +344,7 @@ impl Store {
                 pr_url,
                 status,
                 queued_at,
+                title,
                 conflict_info: None, // Not persisted to DB yet
                 changes_requested_feedback: None, // TODO: persist to DB
                 head_sha: None,      // Updated from GitHub on reconciliation

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -221,6 +221,27 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
         }
     }
 
+    // Migration: add title column to merge_queue (issue #589)
+    // Stores PR title directly so metadata is available even without a linked task.
+    match conn.execute(
+        "ALTER TABLE merge_queue ADD COLUMN title TEXT",
+        [],
+    ) {
+        Ok(_) => {
+            tracing::info!("added title column to merge_queue table");
+        }
+        Err(rusqlite::Error::SqliteFailure(e, Some(ref msg)))
+            if e.extended_code == rusqlite::ffi::SQLITE_ERROR
+                && msg.contains("duplicate column name") =>
+        {
+            tracing::debug!("merge_queue title column already exists");
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "failed to add title column to merge_queue");
+            return Err(e);
+        }
+    }
+
     // Migration: add UNIQUE constraint on merge_queue.pr_url (issue #464)
     // SQLite cannot add constraints to existing columns, so we create the unique index
     // if it doesn't already exist. The column-level UNIQUE in CREATE TABLE handles new DBs;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -73,6 +73,8 @@ export interface MergeQueueEntry {
   pr_url: string;
   status: MergeStatus;
   queued_at: string;
+  /** PR title from GitHub. Available even without a linked task (issue #589). */
+  title?: string;
   /** Feedback when status is changes_requested */
   changes_requested_feedback?: string;
   /** Position in merge queue (1-indexed). Only set for approved/merging entries. */

--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -137,7 +137,7 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
     },
   },
 
-  // PR title (from linked task, or fallback to PR link)
+  // PR title (from linked task, entry title, or fallback to PR link)
   {
     id: "title",
     header: "Title",
@@ -153,7 +153,20 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
           </Link>
         );
       }
-      // No linked task — show PR repo/number as fallback
+      // Use PR title from entry if available (issue #589)
+      if (row.original.title) {
+        return (
+          <a
+            href={row.original.pr_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm hover:underline truncate max-w-[400px] block"
+          >
+            {row.original.title}
+          </a>
+        );
+      }
+      // No linked task or title — show PR repo/number as fallback
       const repo = prRepo(row.original.pr_url);
       const num = prNumber(row.original.pr_url);
       const label = repo && num ? `${repo}#${num}` : row.original.pr_url;

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -105,6 +105,16 @@ function MergeQueueRow({
           >
             {task.title}
           </Link>
+        ) : entry.title ? (
+          <a
+            href={entry.pr_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline truncate block"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {entry.title}
+          </a>
         ) : (
           <a
             href={entry.pr_url}


### PR DESCRIPTION
## Summary
- **Root cause**: Merge queue entries stored no PR metadata and relied entirely on linked task lookup for titles. When entries were created before their task existed (timing) or for PRs with no linked issue, `task_id` was empty and the UI showed no title, project, or issue link.
- **Fix**: Add a `title` field to `MergeQueueEntry` that stores the GitHub PR title directly. During reconciliation, update the title from GitHub and re-link orphaned entries (empty `task_id`) to tasks via branch name and linked issue lookups.
- **Frontend**: Falls back to `entry.title` when no linked task is found, with a final fallback to `repo#number`.

## Changes
- `crates/models/src/merge_queue.rs` — Add `title: Option<String>` field and `with_title()` builder
- `crates/store/src/schema.rs` — Migration to add `title` column to `merge_queue` table
- `crates/store/src/lib.rs` — Persist and load `title` in save/get/list operations
- `crates/app/src/run_loop.rs` — Populate title from PR data at entry creation
- `crates/server/src/server.rs` — Update title and re-link orphaned entries during reconciliation
- `web/src/lib/types.ts` — Add `title` to TypeScript type
- `web/src/pages/merge-queue/page.tsx` — Use entry title as fallback in list view
- `web/src/pages/merge-queue/columns.tsx` — Use entry title as fallback in table view

## Test plan
- [x] Existing model tests pass (`cargo test --package models`)
- [x] Existing store tests pass (`cargo test --package tasks-store`)
- [x] TypeScript type-checks pass (`npx tsc --noEmit`)
- [ ] Verify merge queue entries show PR titles in the web UI
- [ ] Verify orphaned entries get re-linked on next poll cycle

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)