### PR TITLE
Remove API key written to disk in supervisor

### DIFF
--- a/crates/supervisor/src/main.rs
+++ b/crates/supervisor/src/main.rs
@@ -382,35 +382,9 @@ async fn main() {
     // the main loop emits them to the host.
     let (event_tx, mut event_rx) = mpsc::unbounded_channel::<Ev>();
 
-    // Set up Claude Code auth for the agent user.
-    // Write credential helper to the agent user's home directory.
-    let agent_user = std::env::var("AGENT_USER").unwrap_or_else(|_| "agent".to_string());
-    let agent_home = format!("/home/{agent_user}");
-    if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
-        let claude_dir = format!("{agent_home}/.claude");
-        if let Err(e) = std::fs::create_dir_all(&claude_dir) {
-            log!("failed to create claude config dir {claude_dir}: {e}");
-        }
-        let script = format!("#!/bin/bash\necho \"{api_key}\"\n");
-        let script_path = format!("{claude_dir}/anthropic_key.sh");
-        if let Err(e) = std::fs::write(&script_path, &script) {
-            log!("failed to write anthropic_key.sh: {e}");
-        }
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            if let Err(e) = std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o700)) {
-                log!("failed to set permissions on anthropic_key.sh: {e}");
-            }
-            // Ensure the agent user owns the .claude directory
-            let chown = std::process::Command::new("chown")
-                .args(["-R", &format!("{agent_user}:{agent_user}"), &claude_dir])
-                .status();
-            if let Err(e) = chown {
-                log!("failed to chown {claude_dir}: {e}");
-            }
-        }
-    }
+    // Credentials (ANTHROPIC_API_KEY, GITHUB_TOKEN, etc.) are passed to the
+    // agent process via `sudo --preserve-env` in spawn_agent(). No credentials
+    // are written to disk.
 
     // Emit system:ready (§4.2).
     emit(&Ev::SystemReady {});


### PR DESCRIPTION
## Summary

- Remove code that wrote `ANTHROPIC_API_KEY` to `~/.claude/anthropic_key.sh` inside the container, eliminating credential-on-disk exposure risk
- The key is already passed to the agent process via `sudo --preserve-env` in `spawn_agent()`, so the shell script was redundant
- No functional change — credentials flow through environment variables only

Closes #491

## Test plan

- [ ] Verify supervisor compiles (`cargo check --package tasks-supervisor`)
- [ ] Verify agent still receives `ANTHROPIC_API_KEY` via environment when spawned
- [ ] Confirm no `anthropic_key.sh` is created inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)