### PR TITLE
Fix automation runs stuck in Running state forever

### DIFF
--- a/crates/app/src/automation_runner.rs
+++ b/crates/app/src/automation_runner.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::task::JoinHandle;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use events::EventBus;
@@ -18,6 +18,13 @@ use tasks_session::{SessionLimits, SessionManager};
 
 /// Prefix used for automation session IDs.
 const SESSION_PREFIX: &str = "automation-run:";
+
+/// Buffer added to hard_limit when detecting stuck runs.
+/// Gives extra grace period before the watchdog intervenes.
+const STUCK_RUN_BUFFER: Duration = Duration::from_secs(5 * 60); // 5 minutes
+
+/// How often the stuck-run watchdog checks for stuck runs.
+const WATCHDOG_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Execute an automation run inside a container session.
 ///
@@ -138,6 +145,134 @@ pub fn run_id_from_session(session_id: &str) -> Option<&str> {
     session_id.strip_prefix(SESSION_PREFIX)
 }
 
+/// Handle a single event for an automation run, returning whether it was a
+/// terminal event that was processed.
+async fn handle_automation_event(
+    event: &events::Event,
+    server: &Server,
+) -> bool {
+    let run_id = match run_id_from_session(&event.task) {
+        Some(id) => id.to_string(),
+        None => return false,
+    };
+
+    match event.event_type {
+        // Agent exited successfully (with or without a PR)
+        events::EventType::TaskStateCompleted
+        | events::EventType::TaskStateAwaitingMerge => {
+            info!(
+                run_id = %run_id,
+                event_type = %event.event_type.as_str(),
+                "automation session completed, marking run as complete"
+            );
+            if let Err(e) = server.complete_automation_run(&run_id, None).await {
+                error!(
+                    run_id = %run_id,
+                    error = %e,
+                    "failed to complete automation run"
+                );
+            }
+            true
+        }
+        // Agent exited with failure
+        events::EventType::TaskStateFailed => {
+            let reason = event
+                .data
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("session failed");
+            info!(
+                run_id = %run_id,
+                reason = %reason,
+                "automation session failed, marking run as failed"
+            );
+            if let Err(e) = server
+                .fail_automation_run(&run_id, reason.to_string())
+                .await
+            {
+                error!(
+                    run_id = %run_id,
+                    error = %e,
+                    "failed to mark automation run as failed"
+                );
+            }
+            true
+        }
+        // Hard time limit hit — the session will be killed, but if we miss
+        // the subsequent TaskStateFailed event, this ensures we still fail
+        // the run. The server methods are idempotent on terminal states.
+        events::EventType::SystemTimeLimitHard => {
+            warn!(
+                run_id = %run_id,
+                "automation session hit hard time limit, marking run as failed"
+            );
+            if let Err(e) = server
+                .fail_automation_run(&run_id, "session exceeded hard time limit".to_string())
+                .await
+            {
+                error!(
+                    run_id = %run_id,
+                    error = %e,
+                    "failed to mark automation run as failed after hard time limit"
+                );
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
+/// On broadcast lag, replay events from the event store to recover any missed
+/// terminal events for automation runs that are still in Running state.
+async fn recover_from_lag(event_bus: &EventBus, server: &Server) {
+    // List all automation session IDs from the event store
+    let task_ids = match event_bus.list_tasks().await {
+        Ok(ids) => ids,
+        Err(e) => {
+            error!(error = %e, "failed to list tasks during lag recovery");
+            return;
+        }
+    };
+
+    for task_id in task_ids {
+        let run_id = match run_id_from_session(&task_id) {
+            Some(id) => id.to_string(),
+            None => continue,
+        };
+
+        // Check if this run is still in a non-terminal state
+        let run = match server.get_automation_run(&run_id) {
+            Ok(Some(run)) if !run.status.is_terminal() => run,
+            _ => continue,
+        };
+
+        // Replay events from store for this session
+        let events = match event_bus.read_task(&task_id).await {
+            Ok(events) => events,
+            Err(e) => {
+                error!(
+                    run_id = %run_id,
+                    error = %e,
+                    "failed to read events during lag recovery"
+                );
+                continue;
+            }
+        };
+
+        // Process events in order; stop at the first terminal one
+        for event in &events {
+            if handle_automation_event(event, server).await {
+                info!(
+                    run_id = %run.id,
+                    event_type = %event.event_type.as_str(),
+                    "recovered missed terminal event for automation run"
+                );
+                break;
+            }
+        }
+    }
+}
+
 /// Spawn a background task that listens for session completion/failure events
 /// and updates automation run records accordingly.
 ///
@@ -145,9 +280,15 @@ pub fn run_id_from_session(session_id: &str) -> Option<&str> {
 /// (`TaskStateCompleted`, `TaskStateAwaitingMerge`, or `TaskStateFailed`), this
 /// listener calls `server.complete_automation_run()` or `server.fail_automation_run()`.
 ///
+/// Also handles `SystemTimeLimitHard` as a redundant failure signal, so that
+/// even if the subsequent `TaskStateFailed` event is missed, the run is failed.
+///
 /// Both `TaskStateCompleted` and `TaskStateAwaitingMerge` are treated as successful
 /// completion — the agent may create a PR and wait for merge, which is a valid
 /// successful outcome for an automation run.
+///
+/// On broadcast lag, replays events from the event store to recover any missed
+/// terminal events.
 ///
 /// The `shutdown_rx` receiver allows graceful shutdown of the listener.
 pub fn spawn_automation_event_listener(
@@ -163,61 +304,14 @@ pub fn spawn_automation_event_listener(
                 result = rx.recv() => {
                     match result {
                         Ok(event) => {
-                            // Only care about automation sessions
-                            let run_id = match run_id_from_session(&event.task) {
-                                Some(id) => id.to_string(),
-                                None => continue,
-                            };
-
-                            match event.event_type {
-                                // Agent exited successfully (with or without a PR)
-                                events::EventType::TaskStateCompleted
-                                | events::EventType::TaskStateAwaitingMerge => {
-                                    info!(
-                                        run_id = %run_id,
-                                        event_type = %event.event_type.as_str(),
-                                        "automation session completed, marking run as complete"
-                                    );
-                                    if let Err(e) = server.complete_automation_run(&run_id, None).await {
-                                        error!(
-                                            run_id = %run_id,
-                                            error = %e,
-                                            "failed to complete automation run"
-                                        );
-                                    }
-                                }
-                                // Agent exited with failure
-                                events::EventType::TaskStateFailed => {
-                                    let reason = event
-                                        .data
-                                        .get("reason")
-                                        .and_then(|v| v.as_str())
-                                        .unwrap_or("session failed");
-                                    info!(
-                                        run_id = %run_id,
-                                        reason = %reason,
-                                        "automation session failed, marking run as failed"
-                                    );
-                                    if let Err(e) = server
-                                        .fail_automation_run(&run_id, reason.to_string())
-                                        .await
-                                    {
-                                        error!(
-                                            run_id = %run_id,
-                                            error = %e,
-                                            "failed to mark automation run as failed"
-                                        );
-                                    }
-                                }
-                                // Ignore all other event types
-                                _ => {}
-                            }
+                            handle_automation_event(&event, &server).await;
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                             error!(
                                 skipped = n,
-                                "automation event listener lagged — {n} events dropped from broadcast channel"
+                                "automation event listener lagged — {n} events dropped, replaying from store"
                             );
+                            recover_from_lag(&server.event_bus, &server).await;
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                             info!("event bus closed, automation event listener shutting down");
@@ -228,6 +322,67 @@ pub fn spawn_automation_event_listener(
                 _ = shutdown_rx.recv() => {
                     info!("automation event listener received shutdown signal");
                     break;
+                }
+            }
+        }
+    })
+}
+
+/// Spawn a watchdog that periodically scans for automation runs stuck in
+/// `Running` state past `hard_limit + buffer` and forcibly fails them.
+///
+/// This is a last-resort safety net: if the event listener misses terminal
+/// events (e.g., due to broadcast lag, process restart, or bugs), the watchdog
+/// ensures runs don't stay in `Running` forever.
+pub fn spawn_stuck_run_watchdog(
+    server: Arc<Server>,
+    hard_limit: Duration,
+    mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+) -> JoinHandle<()> {
+    let cutoff_duration = hard_limit + STUCK_RUN_BUFFER;
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(WATCHDOG_INTERVAL);
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {}
+                _ = shutdown_rx.recv() => {
+                    info!("stuck-run watchdog received shutdown signal");
+                    break;
+                }
+            }
+
+            let cutoff = chrono::Utc::now() - cutoff_duration;
+            let stuck_runs = match server.list_stuck_automation_runs(&cutoff) {
+                Ok(runs) => runs,
+                Err(e) => {
+                    error!(error = %e, "watchdog failed to query stuck runs");
+                    continue;
+                }
+            };
+
+            for run in stuck_runs {
+                warn!(
+                    run_id = %run.id,
+                    started_at = %run.started_at,
+                    "watchdog detected stuck automation run, forcibly failing"
+                );
+                if let Err(e) = server
+                    .fail_automation_run(
+                        &run.id,
+                        format!(
+                            "watchdog: run stuck in Running state past hard limit + {}s buffer",
+                            STUCK_RUN_BUFFER.as_secs()
+                        ),
+                    )
+                    .await
+                {
+                    error!(
+                        run_id = %run.id,
+                        error = %e,
+                        "watchdog failed to mark stuck run as failed"
+                    );
                 }
             }
         }

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -406,7 +406,20 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     );
     info!("automation event listener started");
 
-    // --- 6d. Create rejected PR cooldown tracker (issue #439) ---
+    // --- 6d. Spawn stuck-run watchdog (issue #496) ---
+    //
+    // Periodically scans for automation runs stuck in Running state past
+    // hard_limit + buffer and forcibly fails them. Safety net for missed events.
+
+    let stuck_run_watchdog_shutdown_rx = shutdown_tx.subscribe();
+    let stuck_run_watchdog_handle = crate::automation_runner::spawn_stuck_run_watchdog(
+        server.clone(),
+        config.automation_hard_limit,
+        stuck_run_watchdog_shutdown_rx,
+    );
+    info!("stuck-run watchdog started");
+
+    // --- 6e. Create rejected PR cooldown tracker (issue #439) ---
     //
     // Shared between the poll loop and orchestrator loop to prevent re-queuing
     // PRs that were recently rejected with the same head SHA. The orchestrator
@@ -2776,6 +2789,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
         poll_handle,
         automation_scheduler_handle,
         automation_listener_handle,
+        stuck_run_watchdog_handle,
         dispatch_handle,
         event_handler_handle,
         orchestrator_handle,

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -407,11 +407,36 @@ impl Server {
         removed
     }
 
+    /// Get a single automation run by ID.
+    pub fn get_automation_run(&self, run_id: &str) -> Result<Option<AutomationRun>, ServerError> {
+        let store = self
+            .store
+            .as_ref()
+            .ok_or_else(|| ServerError::StoreError("store not available".into()))?;
+        store
+            .get_automation_run(run_id)
+            .map_err(|e| ServerError::StoreError(e.to_string()))
+    }
+
     /// List runs for an automation.
     pub fn list_automation_runs(&self, automation_id: &str) -> Result<Vec<AutomationRun>, ServerError> {
         let store = self.store.as_ref()
             .ok_or_else(|| ServerError::StoreError("store not available".into()))?;
                 store.list_automation_runs(automation_id)
+            .map_err(|e| ServerError::StoreError(e.to_string()))
+    }
+
+    /// List automation runs stuck in `Running` state past the given cutoff time.
+    pub fn list_stuck_automation_runs(
+        &self,
+        started_before: &chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<AutomationRun>, ServerError> {
+        let store = self
+            .store
+            .as_ref()
+            .ok_or_else(|| ServerError::StoreError("store not available".into()))?;
+        store
+            .list_stuck_automation_runs(&started_before.to_rfc3339())
             .map_err(|e| ServerError::StoreError(e.to_string()))
     }
 

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -836,6 +836,27 @@ impl Store {
         Ok(runs)
     }
 
+    /// List all runs in the `Running` state that started before a given cutoff.
+    ///
+    /// Used by the stuck-run watchdog to find automation runs that have exceeded
+    /// their time limit without transitioning to a terminal state.
+    pub fn list_stuck_automation_runs(
+        &self,
+        started_before: &str,
+    ) -> Result<Vec<AutomationRun>, StoreError> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT id, automation_id, status, started_at, completed_at, output, error
+             FROM automation_runs WHERE status = 'running' AND started_at < ?1",
+        )?;
+        let rows = stmt.query_map(params![started_before], row_to_automation_run)?;
+        let mut runs = Vec::new();
+        for row in rows {
+            runs.push(row?);
+        }
+        Ok(runs)
+    }
+
 }
 
 /// Map a rusqlite Row to a TaskAccounting.


### PR DESCRIPTION
## Summary

Fixes #496 — automation runs could get permanently stuck in "Running" state when the broadcast channel lagged and dropped terminal events (like `TaskStateFailed`).

Three layered defenses:

- **Handle `SystemTimeLimitHard` directly** — the event listener now treats hard time limit events as a failure signal, providing a redundant path to fail the run even if `TaskStateFailed` is subsequently missed
- **Replay from event store on lag** — when the broadcast channel lags and drops events, the listener queries the persistent event store to recover missed terminal events for still-running automation sessions
- **Stuck-run watchdog** — a periodic scan (every 60s) finds runs in `Running` state past `hard_limit + 5min` buffer and forcibly fails them, as a last-resort safety net

Also adds `Store::list_stuck_automation_runs()` and `Server::get_automation_run()` to support the watchdog and lag recovery.

## Test plan

- [ ] Verify `cargo check --package tasks-store` passes (confirmed)
- [ ] Verify all store tests pass (`cargo test --package tasks-store` — 43 passed)
- [ ] Note: `cargo check --package tasks-app` blocked by pre-existing server errors (unrelated `store.lock()` calls from connection pool migration #576)
- [ ] Manual testing: create an automation run, kill the session without emitting terminal events, verify watchdog fails the run within ~35 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)