### PR TITLE
Stop sessions when their GitHub issue is closed externally

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -424,6 +424,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     let github_token = config.github_token.clone();
     let poll_config_watcher = workflow_config_watcher.clone();
     let poll_rejected_cooldown = rejected_pr_cooldown.clone();
+    let poll_session_manager = session_manager.clone();
     let mut poll_shutdown_rx = shutdown_tx.subscribe();
 
     let poll_handle = tokio::spawn(async move {
@@ -572,6 +573,23 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                                 updated_fields = ?result.updated_fields,
                                                 "reconciled task from GitHub"
                                             );
+
+                                            // If the issue was closed or cancelled externally,
+                                            // stop any running session for this task (issue #499).
+                                            if new_state.is_terminal() {
+                                                match poll_session_manager.stop_session(&task_id).await {
+                                                    Ok(()) => {
+                                                        info!(
+                                                            task_id = %task_id,
+                                                            new_state = ?new_state,
+                                                            "stopped session for externally closed issue"
+                                                        );
+                                                    }
+                                                    Err(_) => {
+                                                        // No running session — expected for non-active tasks
+                                                    }
+                                                }
+                                            }
                                         } else if !result.updated_fields.is_empty() {
                                             debug!(
                                                 project = %project_id,

--- a/crates/server/src/scheduler.rs
+++ b/crates/server/src/scheduler.rs
@@ -685,6 +685,41 @@ mod tests {
     }
 
     #[test]
+    fn reconcile_closure_transitions_active_task() {
+        // Issue #499: closing an issue on GitHub should transition even active
+        // (Running) tasks to Completed/Cancelled so sessions can be stopped.
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+        task.set_state(TaskState::Running);
+
+        let mut closed_issue = issue.clone();
+        closed_issue.state = GhIssueState::Closed;
+        closed_issue.state_reason = Some(tasks_github::model::IssueStateReason::Completed);
+
+        let result = reconcile_task(&mut task, &closed_issue, &cfg);
+        assert_eq!(result.new_state, Some(TaskState::Completed));
+        assert_eq!(task.state, TaskState::Completed);
+    }
+
+    #[test]
+    fn reconcile_closure_cancels_active_task() {
+        // Issue #499: closing as "not planned" should cancel even active tasks.
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+        task.set_state(TaskState::Running);
+
+        let mut closed_issue = issue.clone();
+        closed_issue.state = GhIssueState::Closed;
+        closed_issue.state_reason = Some(tasks_github::model::IssueStateReason::NotPlanned);
+
+        let result = reconcile_task(&mut task, &closed_issue, &cfg);
+        assert_eq!(result.new_state, Some(TaskState::Cancelled));
+        assert_eq!(task.state, TaskState::Cancelled);
+    }
+
+    #[test]
     fn reconcile_skip_label_trumps_closure_reason() {
         // If an issue has tasks/skip AND is closed-as-completed,
         // skip wins → Cancelled, not Completed. Skip is an explicit

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1510,10 +1510,8 @@ impl Server {
                 state.merge_queue.get(entry_id).cloned()
             };
             if let Some(entry) = entry_clone {
-                if let Ok(store) = store.lock() {
-                    if let Err(e) = store.save_merge_entry(&entry) {
-                        tracing::error!(entry_id = %entry_id, error = %e, "failed to persist revert-to-approved");
-                    }
+                if let Err(e) = store.save_merge_entry(&entry) {
+                    tracing::error!(entry_id = %entry_id, error = %e, "failed to persist revert-to-approved");
                 }
             }
         }
@@ -1690,10 +1688,8 @@ impl Server {
                 .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
             // Persist rejected status to SQLite (issue #463)
             if let Some(ref store) = self.store {
-                if let Ok(store) = store.lock() {
-                    if let Err(e) = store.save_merge_entry(entry) {
-                        tracing::error!(entry_id = %entry_id, error = %e, "failed to persist rejected merge queue entry");
-                    }
+                if let Err(e) = store.save_merge_entry(entry) {
+                    tracing::error!(entry_id = %entry_id, error = %e, "failed to persist rejected merge queue entry");
                 }
             }
             entry.task_id.clone()
@@ -1748,10 +1744,8 @@ impl Server {
                 .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
             // Persist rejected status to SQLite (issue #463)
             if let Some(ref store) = self.store {
-                if let Ok(store) = store.lock() {
-                    if let Err(e) = store.save_merge_entry(entry) {
-                        tracing::error!(entry_id = %entry_id, error = %e, "failed to persist rejected merge queue entry");
-                    }
+                if let Err(e) = store.save_merge_entry(entry) {
+                    tracing::error!(entry_id = %entry_id, error = %e, "failed to persist rejected merge queue entry");
                 }
             }
             entry.task_id.clone()
@@ -2629,7 +2623,7 @@ mod tests {
         server.add_task(task).await.unwrap();
 
         // Verify data is in the store
-        let store_ref = server.store.as_ref().unwrap().lock().unwrap();
+        let store_ref = server.store.as_ref().unwrap();
         assert!(store_ref.get_project("p1").unwrap().is_some());
         assert!(store_ref.get_task("t1").unwrap().is_some());
     }
@@ -2654,7 +2648,7 @@ mod tests {
             .unwrap();
 
         // Verify the store has the updated state
-        let store_ref = server.store.as_ref().unwrap().lock().unwrap();
+        let store_ref = server.store.as_ref().unwrap();
         let stored_task = store_ref.get_task("t1").unwrap().unwrap();
         assert_eq!(stored_task.state, TaskState::Running);
     }


### PR DESCRIPTION
## Summary

Closes #499

- When reconciliation detects a GitHub issue was closed while its task has a running session, the polling loop now sends a stop signal to that session via `SessionManager::stop_session()`
- The closure detection in `reconcile_task` already handled active tasks correctly (it runs before the `is_active` guard that only gates blocked-label logic), but the run loop never acted on terminal state transitions by stopping sessions
- Added two scheduler tests confirming that closing an issue transitions Running tasks to Completed/Cancelled
- Fixed pre-existing `Store::lock()` compilation errors from the connection pool migration (#576)

## Test plan

- [x] All 153 server tests pass (including 2 new scheduler tests)
- [x] `cargo check -p tasks-app` compiles cleanly
- [ ] Manual: close a GitHub issue while a session is Running → session should receive stop signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)