### PR TITLE
Add missing_context field to QualityEvaluation

### DIFF
--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -172,6 +172,9 @@ impl Orchestrator for ClaudeOrchestrator {
             "Fetched PR details"
         );
 
+        // Track any context we fail to fetch
+        let mut missing_context: Vec<String> = Vec::new();
+
         // Fetch the actual diff
         let diff = match self.github.get_pr_diff(&owner, &repo, pr_number).await {
             Ok(d) => {
@@ -180,6 +183,7 @@ impl Orchestrator for ClaudeOrchestrator {
             }
             Err(e) => {
                 warn!(error = %e, "Failed to fetch PR diff, continuing without it");
+                missing_context.push("pr_diff".to_string());
                 None
             }
         };
@@ -202,6 +206,7 @@ impl Orchestrator for ClaudeOrchestrator {
                     }
                     Err(e) => {
                         warn!(error = %e, "Failed to fetch associated issue, continuing without it");
+                        missing_context.push("linked_issue".to_string());
                         None
                     }
                 }
@@ -249,6 +254,7 @@ impl Orchestrator for ClaudeOrchestrator {
                 approved: pass1.approved,
                 reasoning: pass1.reasoning,
                 feedback: pass1.feedback,
+                missing_context: missing_context.clone(),
             });
         }
 
@@ -318,6 +324,7 @@ impl Orchestrator for ClaudeOrchestrator {
             approved: pass2.approved,
             reasoning: pass2.reasoning,
             feedback: pass2.feedback,
+            missing_context,
         })
     }
 

--- a/crates/orchestrator/src/mock.rs
+++ b/crates/orchestrator/src/mock.rs
@@ -39,6 +39,7 @@ impl MockOrchestrator {
                 approved: true,
                 reasoning: "Mock: approved".to_string(),
                 feedback: None,
+                missing_context: Vec::new(),
             }),
             conflict_triage: Mutex::new(None),
             evaluate_count: Mutex::new(0),
@@ -57,6 +58,7 @@ impl MockOrchestrator {
                 approved: false,
                 reasoning: "Mock: rejected".to_string(),
                 feedback: Some(feedback),
+                missing_context: Vec::new(),
             }),
             conflict_triage: Mutex::new(None),
             evaluate_count: Mutex::new(0),
@@ -176,6 +178,7 @@ mod tests {
             approved: false,
             reasoning: "changed my mind".to_string(),
             feedback: Some("redo everything".to_string()),
+            missing_context: Vec::new(),
         });
         let ctx = test_context();
         let result = mock.evaluate(&ctx).await.unwrap();

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -86,6 +86,10 @@ pub struct QualityEvaluation {
     /// Specific feedback for the implementor, if the PR needs work.
     /// Used to re-engage the task's agent session.
     pub feedback: Option<String>,
+    /// Context that was unavailable during evaluation (e.g. "pr_diff", "linked_issue").
+    /// Empty means the evaluation had full context.
+    #[serde(default)]
+    pub missing_context: Vec<String>,
 }
 
 /// Context for conflict triage — spec §7.4.


### PR DESCRIPTION
## Summary
- Adds `missing_context: Vec<String>` field to `QualityEvaluation` that records which data sources were unavailable during evaluation (e.g. `"pr_diff"`, `"linked_issue"`)
- Populates the field in `ClaudeOrchestrator::evaluate()` when PR diff or linked issue fetch fails
- Uses `#[serde(default)]` for backward-compatible deserialization of existing stored evaluations

## Test plan
- [x] `cargo build --package tasks-orchestrator` passes
- [ ] Verify evaluations with full context produce empty `missing_context`
- [ ] Verify failed diff fetch records `"pr_diff"` in `missing_context`
- [ ] Verify failed issue fetch records `"linked_issue"` in `missing_context`

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)