### PR TITLE
Replace empty string task ID with SYSTEM_TASK_ID constant

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex as StdMutex;
 
 use tracing::{debug, error, info, warn};
 
-use events::{Actor, Event, EventBus, EventStore, EventType};
+use events::{Actor, Event, EventBus, EventStore, EventType, SYSTEM_TASK_ID};
 use uuid::Uuid;
 use runtime::{AppleContainerRuntime, ContainerConfig, ContainerRuntime};
 use server::Server;
@@ -1872,7 +1872,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                             }
                                             let resp_event = Event::new(
                                                 EventType::OrchestratorResponse,
-                                                "",
+                                                SYSTEM_TASK_ID,
                                                 Actor::Orchestrator,
                                                 serde_json::json!({
                                                     "message": response.message,
@@ -1887,7 +1887,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                             tracing::error!(error = %e, "Failed to process orchestrator chat message");
                                             let err_event = Event::new(
                                                 EventType::OrchestratorResponse,
-                                                "",
+                                                SYSTEM_TASK_ID,
                                                 Actor::Orchestrator,
                                                 serde_json::json!({
                                                     "message": format!("I encountered an error processing your message: {}", e),
@@ -2806,7 +2806,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                             OrchestratorAction::EmitThought(message) => {
                                 let event = Event::new(
                                     EventType::OrchestratorThought,
-                                    "",
+                                    SYSTEM_TASK_ID,
                                     Actor::Orchestrator,
                                     serde_json::json!({ "message": message }),
                                 );

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -26,7 +26,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use tower_http::cors::CorsLayer;
 
 use tasks_agent::CompletionsService;
-use events::Actor;
+use events::{Actor, SYSTEM_TASK_ID};
 use server::Server;
 use server::presence::OwnedConnectionGuard;
 use models::Mode;
@@ -1018,7 +1018,7 @@ async fn orchestrator_chat(
     // The orchestrator can pick this up and respond accordingly.
     let event = events::Event::new(
         events::EventType::OrchestratorMessage,
-        "", // No specific task - this is a system-wide message
+        SYSTEM_TASK_ID,
         Actor::Human,
         serde_json::json!({
             "message": req.message,

--- a/crates/events/src/bus.rs
+++ b/crates/events/src/bus.rs
@@ -108,7 +108,7 @@ pub fn matches_task(event: &Event, task_id: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Actor, EventType};
+    use crate::{Actor, EventType, SYSTEM_TASK_ID};
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -421,7 +421,7 @@ mod tests {
             Event::new(EventType::TaskCreated, "task-1", Actor::System, serde_json::json!({})),
             Event::new(EventType::AgentMessage, "task-2", Actor::Agent, serde_json::json!({})),
             Event::new(EventType::MergeCompleted, "task-3", Actor::System, serde_json::json!({})),
-            Event::new(EventType::SystemStarted, "", Actor::System, serde_json::json!({})),
+            Event::new(EventType::SystemStarted, SYSTEM_TASK_ID, Actor::System, serde_json::json!({})),
         ];
 
         for event in &events {
@@ -434,15 +434,15 @@ mod tests {
     }
 
     #[test]
-    fn filter_empty_task_id() {
+    fn filter_system_task_id() {
         let event = Event::new(
             EventType::SystemStarted,
-            "",
+            SYSTEM_TASK_ID,
             Actor::System,
             serde_json::json!({}),
         );
 
-        assert!(matches_task(&event, ""));
+        assert!(matches_task(&event, SYSTEM_TASK_ID));
         assert!(!matches_task(&event, "task-1"));
     }
 

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -4,6 +4,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// Task ID used for system-wide events not tied to any specific task
+/// (e.g. orchestrator decisions, system updates, task reordering).
+pub const SYSTEM_TASK_ID: &str = "__system__";
+
 /// Who produced this event.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -611,7 +615,7 @@ mod tests {
     fn update_available_event_serializes() {
         let e = Event::new(
             EventType::SystemUpdateAvailable,
-            "",
+            SYSTEM_TASK_ID,
             Actor::System,
             serde_json::json!({
                 "target_commit": "def5678",
@@ -628,7 +632,7 @@ mod tests {
     fn update_applying_event_serializes() {
         let e = Event::new(
             EventType::SystemUpdateApplying,
-            "",
+            SYSTEM_TASK_ID,
             Actor::System,
             serde_json::json!({
                 "target_commit": "def5678",

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -7,6 +7,6 @@ mod event;
 mod store;
 mod bus;
 
-pub use event::{Event, EventType, Actor, CURRENT_SCHEMA_VERSION};
+pub use event::{Event, EventType, Actor, CURRENT_SCHEMA_VERSION, SYSTEM_TASK_ID};
 pub use store::{EventStore, RetentionPolicy, StoreError, EVENT_FORMAT_VERSION};
 pub use bus::{EventBus, matches_pattern, matches_task};

--- a/crates/events/src/store.rs
+++ b/crates/events/src/store.rs
@@ -44,6 +44,8 @@ pub enum StoreError {
     Json(#[from] serde_json::Error),
     #[error("event format version mismatch: found v{found}, expected v{expected}")]
     FormatMismatch { found: u32, expected: u32 },
+    #[error("invalid task ID: empty string (use SYSTEM_TASK_ID for system-wide events)")]
+    EmptyTaskId,
 }
 
 /// Configures retention limits for event log compaction.
@@ -150,6 +152,10 @@ impl EventStore {
     /// the same task file are serialized via a per-task mutex to prevent byte
     /// interleaving.
     pub async fn append(&self, event: &Event) -> Result<(), StoreError> {
+        if event.task.is_empty() {
+            return Err(StoreError::EmptyTaskId);
+        }
+
         let path = self.task_log_path(&event.task);
         let lock = self.task_lock(&event.task).await;
 
@@ -274,14 +280,6 @@ impl EventStore {
             }
         }
 
-        // Also scan the empty-string task dir (system-wide events like orchestrator messages)
-        let empty_events = self.read_task("").await?;
-        for event in empty_events {
-            if event.event_type.as_str().starts_with(type_prefix) {
-                matching.push(event);
-            }
-        }
-
         // Sort by timestamp ascending
         matching.sort_by(|a, b| a.ts.cmp(&b.ts));
 
@@ -329,9 +327,6 @@ impl EventStore {
         for task_id in &task_ids {
             total_removed += self.compact_task(task_id).await?;
         }
-
-        // Also compact system-wide events (empty task ID).
-        total_removed += self.compact_task("").await?;
 
         if total_removed > 0 {
             tracing::info!(
@@ -505,9 +500,42 @@ impl EventStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Actor, EventType};
+    use crate::{Actor, EventType, SYSTEM_TASK_ID};
     use std::io::Write;
     use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn append_rejects_empty_task_id() {
+        let dir = tempdir().unwrap();
+        let store = EventStore::new(dir.path());
+
+        let event = Event::new(
+            EventType::OrchestratorMessage,
+            "",
+            Actor::System,
+            serde_json::json!({}),
+        );
+
+        let err = store.append(&event).await.unwrap_err();
+        assert!(matches!(err, StoreError::EmptyTaskId));
+    }
+
+    #[tokio::test]
+    async fn append_accepts_system_task_id() {
+        let dir = tempdir().unwrap();
+        let store = EventStore::new(dir.path());
+
+        let event = Event::new(
+            EventType::OrchestratorMessage,
+            SYSTEM_TASK_ID,
+            Actor::System,
+            serde_json::json!({}),
+        );
+
+        store.append(&event).await.unwrap();
+        let events = store.read_task(SYSTEM_TASK_ID).await.unwrap();
+        assert_eq!(events.len(), 1);
+    }
 
     #[tokio::test]
     async fn append_and_read() {
@@ -596,7 +624,7 @@ mod tests {
         store
             .append(&Event::new(
                 EventType::OrchestratorMessage,
-                "", // system-wide
+                SYSTEM_TASK_ID,
                 Actor::Human,
                 serde_json::json!({"message": "hello"}),
             ))

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use thiserror::Error;
 use tokio::sync::RwLock;
 
-use events::{Actor, Event, EventBus, EventType};
+use events::{Actor, Event, EventBus, EventType, SYSTEM_TASK_ID};
 
 use crate::merge_queue::MergeQueue;
 use crate::model::merge_queue::MergeStatus;
@@ -979,7 +979,7 @@ impl Server {
         // Emit task:reordered event to notify clients
         let event = Event::new(
             EventType::TaskReordered,
-            "",
+            SYSTEM_TASK_ID,
             actor,
             serde_json::json!({ "task_ids": task_ids }),
         );


### PR DESCRIPTION
## Summary

- Introduces `SYSTEM_TASK_ID` constant (`"__system__"`) in `crates/events/src/event.rs` for system-wide events not tied to any specific task
- Adds `StoreError::EmptyTaskId` validation in `EventStore::append` to reject empty string task IDs at write time
- Replaces all `""` task ID usages across `events`, `app`, and `server` crates with the new constant
- Removes redundant separate scans for empty-string task dirs in `query_by_type_prefix` and `compact_all` (the `__system__` directory is now naturally discovered by `list_tasks`)

## Test plan

- [x] All 53 existing events crate tests pass
- [x] New `append_rejects_empty_task_id` test verifies empty string is rejected
- [x] New `append_accepts_system_task_id` test verifies the constant works correctly
- [x] `query_by_type_prefix` test updated to use `SYSTEM_TASK_ID` and passes

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)