### PR TITLE
Replace unreachable!() with warn log in merge status classification

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -870,7 +870,14 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                         );
                                     }
                                 }
-                                PullRequestState::Open => unreachable!(),
+                                PullRequestState::Open => {
+                                    warn!(
+                                        project = %project_id,
+                                        pr = pr.number,
+                                        task_id = %task_id,
+                                        "unexpected Open PR in merge status classification, skipping"
+                                    );
+                                }
                             }
                         }
 


### PR DESCRIPTION
## Summary

- Replace `unreachable!()` with a `warn!` log in the `PullRequestState::Open` match arm of the merge status classification in the run loop
- While Open PRs are filtered earlier with `continue` (line 780), if that guard is ever bypassed (e.g., future code changes or new PR states), the run loop would panic — now it logs a warning and skips gracefully

Closes #511

## Test plan

- [ ] Verify the `server` crate pre-existing build errors are unrelated (they are — `Store::lock` errors from the connection pool refactor)
- [ ] Confirm the change compiles cleanly for the `tasks-app` crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)