### PR TITLE
Fix race window in set_mode() between state change and event

### DIFF
--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -641,9 +641,10 @@ impl Server {
             Mode::Play => EventType::SystemModePlay,
         };
 
-        drop(state);
-
-        // Use "system" as the task ID for system events
+        // Publish the event while still holding the write lock so that no
+        // other request can observe the new mode before the event is emitted.
+        // This is safe because event_bus uses its own internal locks and
+        // tokio::sync::RwLock supports holding guards across .await points.
         let event = Event::new(
             event_type,
             "system",
@@ -651,6 +652,8 @@ impl Server {
             serde_json::json!({ "from": format!("{:?}", old_mode) }),
         );
         self.event_bus.publish(event).await?;
+
+        drop(state);
 
         Ok(new_mode)
     }


### PR DESCRIPTION
## Summary

- Move `event_bus.publish()` inside the write lock scope in `set_mode()` so the state change and event emission are atomic
- Prevents concurrent requests from observing the new mode before the mode-change event is emitted
- Eliminates the Pause→Stop race window that could leave a PR half-merged

## Details

Previously, `set_mode()` dropped the `RwLock` write guard before publishing the event. Between the drop and the publish, another request could observe the new mode and act on it before clients received the mode-change event.

The fix is safe because:
- `event_bus` uses its own internal locks (not the server state `RwLock`)
- `tokio::sync::RwLock` supports holding guards across `.await` points

Note: There are pre-existing compilation errors on `main` (unrelated `store.lock()` calls) — this PR does not introduce any new issues.

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)