### PR TITLE
Isolate mode into its own Mutex for atomic transitions

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -1765,12 +1765,12 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
 
                                 // Build context from current state
                                 let context = {
-                                    let state = orch_server.state.read().await;
-                                    let mode = match state.mode {
+                                    let mode = match orch_server.mode().await {
                                         server::Mode::Play => "Play",
                                         server::Mode::Pause => "Pause",
                                         server::Mode::Stop => "Stop",
                                     };
+                                    let state = orch_server.state.read().await;
                                     ChatContext {
                                         mode: mode.to_string(),
                                         projects: state.projects.values().cloned().collect(),
@@ -2711,12 +2711,12 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
 
             // Build SystemContext snapshot
             let context = {
-                let state = think_server.state.read().await;
-                let orch_mode = match state.mode {
+                let orch_mode = match think_server.mode().await {
                     server::Mode::Play => OperatingMode::Play,
                     server::Mode::Pause => OperatingMode::Pause,
                     server::Mode::Stop => OperatingMode::Stop,
                 };
+                let state = think_server.state.read().await;
                 SystemContext {
                     mode: orch_mode,
                     projects: state.projects.values().cloned().collect(),

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -384,6 +384,7 @@ struct UpdateAutomationRequest {
 
 /// GET /api/snapshot — Full system state (spec §16.3).
 async fn snapshot(State(state): State<ApiState>) -> Json<SnapshotResponse> {
+    let mode = state.server.mode().await;
     let server_state = state.server.state.read().await;
     let active = server_state
         .tasks
@@ -399,7 +400,7 @@ async fn snapshot(State(state): State<ApiState>) -> Json<SnapshotResponse> {
         .count() as u32;
 
     Json(SnapshotResponse {
-        mode: server_state.mode,
+        mode,
         projects: server_state.projects.values().cloned().collect(),
         tasks: server_state.tasks.values().cloned().collect(),
         merge_queue: server_state.merge_queue.entries_with_positions(),
@@ -819,13 +820,14 @@ async fn approve_merge(
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
     // Get entry details and current mode before modifying state
-    let (pr_url, mode) = {
+    let mode = state.server.mode().await;
+    let pr_url = {
         let server_state = state.server.state.read().await;
         let entry = server_state
             .merge_queue
             .get(&id)
             .ok_or_else(|| ApiError::MergeQueue(format!("entry not found: {}", id)))?;
-        (entry.pr_url.clone(), server_state.mode)
+        entry.pr_url.clone()
     };
 
     // Approve the entry using the server method (emits merge:approved event)

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -61,8 +61,6 @@ pub struct RebuildStats {
 ///
 /// This is the core of the platform. All subsystems operate on this state.
 pub struct ServerState {
-    /// Current operating mode (spec Section 6).
-    pub mode: Mode,
     /// All managed projects (spec Section 3.3).
     pub projects: HashMap<String, Project>,
     /// All tasks indexed by ID.
@@ -76,7 +74,6 @@ pub struct ServerState {
 impl ServerState {
     fn new() -> Self {
         Self {
-            mode: Mode::Pause,
             projects: HashMap::new(),
             tasks: HashMap::new(),
             merge_queue: MergeQueue::new(),
@@ -106,6 +103,9 @@ impl ServerState {
 /// - Orchestrator integration (Section 4.2)
 pub struct Server {
     pub state: Arc<RwLock<ServerState>>,
+    /// Operating mode, isolated from `state` so transitions can hold the lock
+    /// across event publication without blocking reads to tasks/projects/merge queue.
+    pub mode: tokio::sync::Mutex<Mode>,
     pub event_bus: Arc<EventBus>,
     pub presence: Arc<PresenceTracker>,
     pub(crate) store: Option<Arc<tasks_store::Store>>,
@@ -117,6 +117,7 @@ impl Server {
     pub fn new(event_bus: EventBus) -> Self {
         Self {
             state: Arc::new(RwLock::new(ServerState::new())),
+            mode: tokio::sync::Mutex::new(Mode::Pause),
             event_bus: Arc::new(event_bus),
             presence: Arc::new(PresenceTracker::new()),
             store: None,
@@ -128,6 +129,7 @@ impl Server {
     pub fn with_store(event_bus: EventBus, store: Arc<tasks_store::Store>) -> Self {
         Self {
             state: Arc::new(RwLock::new(ServerState::new())),
+            mode: tokio::sync::Mutex::new(Mode::Pause),
             event_bus: Arc::new(event_bus),
             presence: Arc::new(PresenceTracker::new()),
             store: Some(store),
@@ -615,7 +617,7 @@ impl Server {
     // --- Mode management (spec Section 6) ---
 
     pub async fn mode(&self) -> Mode {
-        self.state.read().await.mode
+        *self.mode.lock().await
     }
 
     /// Transition the operating mode.
@@ -624,15 +626,20 @@ impl Server {
     /// - Human can change in any direction
     /// - Orchestrator can only lower
     /// - Takes effect immediately
+    ///
+    /// The mode lock is held across the event publish so that no observer can
+    /// see the new mode before the mode-change event is persisted and broadcast.
+    /// This lock is separate from `self.state`, so reads of tasks/projects/merge
+    /// queue are never blocked by a mode transition.
     pub async fn set_mode(
         &self,
         target: Mode,
         actor: &Actor,
     ) -> Result<Mode, ServerError> {
-        let mut state = self.state.write().await;
-        let new_mode = state.mode.transition(target, actor)?;
-        let old_mode = state.mode;
-        state.mode = new_mode;
+        let mut mode_guard = self.mode.lock().await;
+        let new_mode = mode_guard.transition(target, actor)?;
+        let old_mode = *mode_guard;
+        *mode_guard = new_mode;
 
         // Emit the appropriate mode event
         let event_type = match new_mode {
@@ -641,9 +648,9 @@ impl Server {
             Mode::Play => EventType::SystemModePlay,
         };
 
-        drop(state);
-
-        // Use "system" as the task ID for system events
+        // Use "system" as the task ID for system events.
+        // The mode lock is held so observers cannot read the new mode until
+        // the event has been published.
         let event = Event::new(
             event_type,
             "system",
@@ -1345,14 +1352,11 @@ impl Server {
         per_project_limits: Option<&HashMap<String, u32>>,
     ) -> Result<DispatchPlan, ServerError> {
         // 1. Read current mode — if Stop, return empty plan.
-        {
-            let state = self.state.read().await;
-            if !state.mode.allows_dispatch() {
-                return Ok(DispatchPlan {
-                    resume: Vec::new(),
-                    new_work: Vec::new(),
-                });
-            }
+        if !self.mode().await.allows_dispatch() {
+            return Ok(DispatchPlan {
+                resume: Vec::new(),
+                new_work: Vec::new(),
+            });
         }
 
         // 2. Unblock tasks: find tasks in Blocked state where all blocked_by
@@ -1442,8 +1446,8 @@ impl Server {
     /// as merged - the caller must call mark_entry_merged() or mark_entry_conflict()
     /// based on the result of the GitHub API call.
     pub async fn collect_entries_for_flush(&self) -> Result<Vec<(String, String)>, ServerError> {
+        let mode = self.mode().await;
         let state = self.state.read().await;
-        let mode = state.mode;
         state
             .merge_queue
             .collect_approved_for_flush(mode)


### PR DESCRIPTION
## Summary

- Moves `mode` out of `ServerState` (behind a broad `RwLock`) into a dedicated `tokio::sync::Mutex<Mode>` on `Server`
- Holds the mode lock across `event_bus.publish()` in `set_mode()`, closing the race window where observers could see the new mode before the mode-change event was persisted/broadcast
- Updates all `state.mode` reads (snapshot, dispatch, flush, orchestrator context) to use `server.mode().await` instead

## Approach

The previous PR was rejected because holding the `ServerState` write lock across `publish()` risked deadlocks (event subscribers reading state) and blocked all state access during publish I/O.

This approach uses a **narrower lock scope** — one of the reviewer's suggested alternatives. The mode `Mutex` is independent from the `state` `RwLock`, so:
1. **No deadlock**: event subscribers that read tasks/projects/merge queue acquire `self.state` (the `RwLock`), not the mode `Mutex`
2. **No performance impact**: reads of tasks, projects, and merge queue are never blocked by mode transitions
3. **Atomicity**: concurrent mode reads are serialized with transitions, which is the correct behavior — observers cannot see a new mode until the event is published

## Test plan

- [ ] Verify pre-existing `store.lock()` compilation errors are unrelated (confirmed: same 6 errors on `main`)
- [ ] Mode transition tests (`test_mode_transitions`) pass structurally
- [ ] Review that all `state.mode` accesses have been migrated to `server.mode().await`

Fixes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)