### PR TITLE
Replace untyped Project.config with typed ProjectConfig struct

### DIFF
--- a/crates/models/src/project.rs
+++ b/crates/models/src/project.rs
@@ -2,6 +2,21 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Typed project-level configuration stored in SQLite.
+///
+/// All fields are optional with sensible defaults so that existing
+/// rows containing `{}` deserialize without errors.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ProjectConfig {
+    /// Maximum retry attempts for failed task sessions.
+    pub max_retries: Option<u32>,
+    /// Session timeout in seconds.
+    pub timeout_seconds: Option<u64>,
+    /// Maximum concurrent sessions for this project.
+    pub max_sessions: Option<u32>,
+}
+
 /// A project — maps to a single repository.
 ///
 /// Spec Section 5.6, 3.3. The server can manage multiple projects
@@ -14,7 +29,7 @@ pub struct Project {
     /// Typically `main`.
     pub default_branch: String,
     /// Project-level configuration.
-    pub config: serde_json::Value,
+    pub config: ProjectConfig,
 }
 
 impl Project {
@@ -23,7 +38,50 @@ impl Project {
             id: id.into(),
             repo: repo.into(),
             default_branch: "main".to_string(),
-            config: serde_json::json!({}),
+            config: ProjectConfig::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_json_deserializes_to_defaults() {
+        let config: ProjectConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(config, ProjectConfig::default());
+    }
+
+    #[test]
+    fn partial_json_deserializes() {
+        let config: ProjectConfig =
+            serde_json::from_str(r#"{"max_retries": 5}"#).unwrap();
+        assert_eq!(config.max_retries, Some(5));
+        assert_eq!(config.timeout_seconds, None);
+        assert_eq!(config.max_sessions, None);
+    }
+
+    #[test]
+    fn full_json_roundtrips() {
+        let config = ProjectConfig {
+            max_retries: Some(3),
+            timeout_seconds: Some(600),
+            max_sessions: Some(4),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: ProjectConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, parsed);
+    }
+
+    #[test]
+    fn default_serializes_to_nulls() {
+        let config = ProjectConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        // All fields are null (None)
+        assert!(parsed["max_retries"].is_null());
+        assert!(parsed["timeout_seconds"].is_null());
+        assert!(parsed["max_sessions"].is_null());
     }
 }

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -19,7 +19,7 @@ use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::params;
 use models::automation::{Automation, AutomationRun, AutomationState, RunStatus, TriggerType};
 use models::merge_queue::{MergeQueueEntry, MergeStatus};
-use models::project::Project;
+use models::project::{Project, ProjectConfig};
 use models::task::{FailureInfo, Task, TaskSource, TaskState};
 use thiserror::Error;
 
@@ -169,7 +169,7 @@ impl Store {
         match rows.next() {
             Some(row) => {
                 let (id, repo, default_branch, config_str) = row?;
-                let config: serde_json::Value = serde_json::from_str(&config_str)?;
+                let config: ProjectConfig = serde_json::from_str(&config_str)?;
                 Ok(Some(Project {
                     id,
                     repo,
@@ -197,7 +197,7 @@ impl Store {
         let mut projects = Vec::new();
         for row in rows {
             let (id, repo, default_branch, config_str) = row?;
-            let config: serde_json::Value = serde_json::from_str(&config_str)?;
+            let config: ProjectConfig = serde_json::from_str(&config_str)?;
             projects.push(Project {
                 id,
                 repo,


### PR DESCRIPTION
## Summary

- Replace `Project.config: serde_json::Value` with a typed `ProjectConfig` struct in `crates/models/src/project.rs`
- `ProjectConfig` has optional fields (`max_retries`, `timeout_seconds`, `max_sessions`) with `#[serde(default)]` for backward compatibility
- Update `crates/store/src/lib.rs` to deserialize into `ProjectConfig` instead of `serde_json::Value`
- Existing SQLite rows containing `{}` continue to deserialize correctly

## Test plan

- [x] Unit tests for empty JSON deserialization, partial fields, full roundtrip, and default serialization
- [x] All 45 models crate tests pass
- [x] Store crate compiles cleanly

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)