### PR TITLE
Fix pages stuck in loading state when API calls fail

### DIFF
--- a/web/src/pages/automation-detail.tsx
+++ b/web/src/pages/automation-detail.tsx
@@ -637,7 +637,7 @@ function RunListItem({
 
 export function AutomationDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const { snapshot, automations } = useAppState();
+  const { snapshot, automations, error, refreshSnapshot } = useAppState();
   const [runs, setRuns] = useState<AutomationRun[]>([]);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [loadingRuns, setLoadingRuns] = useState(true);
@@ -704,7 +704,19 @@ export function AutomationDetailPage() {
   if (!snapshot) {
     return (
       <div className="flex items-center justify-center h-full py-32">
-        <p className="text-muted-foreground text-sm">Loading...</p>
+        {error ? (
+          <div className="flex flex-col items-center gap-3">
+            <p className="text-destructive text-sm">Failed to load data: {error.message}</p>
+            <button
+              onClick={() => refreshSnapshot()}
+              className="text-sm text-muted-foreground hover:text-foreground underline"
+            >
+              Retry
+            </button>
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">Loading...</p>
+        )}
       </div>
     );
   }

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -854,7 +854,7 @@ function PropertiesSidebar({ task, projectName }: { task: Task; projectName: str
 
 export function TaskDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const { snapshot } = useAppState();
+  const { snapshot, error, refreshSnapshot } = useAppState();
   const [cancelling, setCancelling] = useState(false);
 
   const task = snapshot?.tasks.find((t) => t.id === id);
@@ -879,7 +879,19 @@ export function TaskDetailPage() {
   if (!snapshot) {
     return (
       <div className="flex items-center justify-center h-full py-32">
-        <p className="text-muted-foreground text-sm">Loading...</p>
+        {error ? (
+          <div className="flex flex-col items-center gap-3">
+            <p className="text-destructive text-sm">Failed to load data: {error.message}</p>
+            <button
+              onClick={() => refreshSnapshot()}
+              className="text-sm text-muted-foreground hover:text-foreground underline"
+            >
+              Retry
+            </button>
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">Loading...</p>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- Show error message with retry button on task-detail and automation-detail pages when the initial snapshot fetch fails, instead of showing "Loading..." indefinitely
- Uses the existing `error` and `refreshSnapshot` from `useAppState()` which were already available but unused in these pages

## Test plan

- [ ] Verify task detail page shows error + retry when server is unreachable
- [ ] Verify automation detail page shows error + retry when server is unreachable
- [ ] Verify normal loading state still works when server is available
- [ ] Verify retry button triggers a new snapshot fetch

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)