### PR TITLE
Fix detail pages stuck in loading state on API failure

### DIFF
--- a/web/src/pages/automation-detail.tsx
+++ b/web/src/pages/automation-detail.tsx
@@ -637,7 +637,7 @@ function RunListItem({
 
 export function AutomationDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const { snapshot, automations } = useAppState();
+  const { snapshot, automations, error, refreshSnapshot } = useAppState();
   const [runs, setRuns] = useState<AutomationRun[]>([]);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [loadingRuns, setLoadingRuns] = useState(true);
@@ -704,7 +704,19 @@ export function AutomationDetailPage() {
   if (!snapshot) {
     return (
       <div className="flex items-center justify-center h-full py-32">
-        <p className="text-muted-foreground text-sm">Loading...</p>
+        {error ? (
+          <div className="flex flex-col items-center gap-3">
+            <p className="text-destructive text-sm">Failed to load data: {error.message}</p>
+            <button
+              onClick={() => refreshSnapshot()}
+              className="text-sm text-muted-foreground hover:text-foreground underline"
+            >
+              Retry
+            </button>
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">Loading...</p>
+        )}
       </div>
     );
   }

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -854,7 +854,7 @@ function PropertiesSidebar({ task, projectName }: { task: Task; projectName: str
 
 export function TaskDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const { snapshot } = useAppState();
+  const { snapshot, error, refreshSnapshot } = useAppState();
   const [cancelling, setCancelling] = useState(false);
 
   const task = snapshot?.tasks.find((t) => t.id === id);
@@ -879,7 +879,19 @@ export function TaskDetailPage() {
   if (!snapshot) {
     return (
       <div className="flex items-center justify-center h-full py-32">
-        <p className="text-muted-foreground text-sm">Loading...</p>
+        {error ? (
+          <div className="flex flex-col items-center gap-3">
+            <p className="text-destructive text-sm">Failed to load data: {error.message}</p>
+            <button
+              onClick={() => refreshSnapshot()}
+              className="text-sm text-muted-foreground hover:text-foreground underline"
+            >
+              Retry
+            </button>
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">Loading...</p>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Task detail and automation detail pages now show an error message with a retry button when the initial snapshot API call fails, instead of showing "Loading..." indefinitely.
- Uses the existing `error` and `refreshSnapshot` from `useAppState()` that were already available but unused in these pages.

Closes #519

## Test plan
- [ ] Navigate to a task detail page while the server is unreachable — should show error with retry button
- [ ] Navigate to an automation detail page while the server is unreachable — should show error with retry button
- [ ] Click retry button — should attempt to reload the snapshot
- [ ] Normal operation (server available) — loading state should resolve as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)