### PR TITLE
Add Request Changes button to merge queue UI

### DIFF
--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -1,10 +1,21 @@
+import { useState } from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { Link } from "react-router-dom";
-import { ExternalLink, Check, X } from "lucide-react";
+import { ExternalLink, Check, X, MessageSquare } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
 import { formatRelativeTime, projectLabel } from "@/lib/utils";
-import { approveMerge, rejectMerge } from "@/lib/api";
+import { approveMerge, rejectMerge, requestChanges } from "@/lib/api";
 import type { MergeQueueEntry, MergeStatus, Project, Task } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -105,6 +116,77 @@ export function prRepoShort(url: string): string | null {
 export function getTask(taskId: string, tasks: Task[]): Task | undefined {
   if (!taskId) return undefined;
   return tasks.find((t) => t.id === taskId);
+}
+
+// ---------------------------------------------------------------------------
+// Request Changes action (needs state for dialog)
+// ---------------------------------------------------------------------------
+
+function RequestChangesAction({
+  entryId,
+  onDone,
+}: {
+  entryId: string;
+  onDone?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [feedback, setFeedback] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    if (!feedback.trim()) return;
+    setSubmitting(true);
+    try {
+      await requestChanges(entryId, feedback.trim(), feedback.trim());
+      setOpen(false);
+      setFeedback("");
+      onDone?.();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 gap-1 border-r border-border rounded-none"
+        onClick={() => setOpen(true)}
+      >
+        <MessageSquare className="h-3.5 w-3.5" />
+        Changes
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Request Changes</DialogTitle>
+            <DialogDescription>
+              Describe what changes are needed. This feedback will be sent back to the agent.
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            placeholder="Describe the changes needed..."
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+            rows={4}
+          />
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline" size="sm">Cancel</Button>
+            </DialogClose>
+            <Button
+              size="sm"
+              onClick={handleSubmit}
+              disabled={!feedback.trim() || submitting}
+            >
+              {submitting ? "Submitting..." : "Request Changes"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -291,6 +373,7 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
             <Check className="h-3.5 w-3.5" />
             Approve
           </Button>
+          <RequestChangesAction entryId={entry.id} onDone={refresh} />
           <Button
             variant="ghost"
             size="sm"

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -1,11 +1,21 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { ExternalLink, Check, X } from "lucide-react";
+import { ExternalLink, Check, X, MessageSquare } from "lucide-react";
 import { toast } from "sonner";
 import { useAppState } from "@/hooks/use-app-state";
-import { flushMergeQueue, approveMerge, rejectMerge } from "@/lib/api";
+import { flushMergeQueue, approveMerge, rejectMerge, requestChanges } from "@/lib/api";
 import { formatRelativeTime, projectLabel } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
 import { ListView, ListEmptyState } from "@/components/ui/list-view";
 import { ListHeader, ListHeaderTabs } from "@/components/ui/list-header";
 import {
@@ -81,6 +91,25 @@ function MergeQueueRow({
       onRefresh();
     } catch {
       toast.error("Failed to reject merge entry");
+    }
+  }
+
+  const [requestChangesOpen, setRequestChangesOpen] = useState(false);
+  const [feedback, setFeedback] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleRequestChanges() {
+    if (!feedback.trim()) return;
+    setSubmitting(true);
+    try {
+      await requestChanges(entry.id, feedback.trim(), feedback.trim());
+      setRequestChangesOpen(false);
+      setFeedback("");
+      onRefresh();
+    } catch {
+      toast.error("Failed to request changes");
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -164,6 +193,15 @@ function MergeQueueRow({
             <Button
               variant="ghost"
               size="sm"
+              className="h-7 gap-1 border-r border-border rounded-none"
+              onClick={() => setRequestChangesOpen(true)}
+            >
+              <MessageSquare className="h-3.5 w-3.5" />
+              Changes
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
               className="h-7 gap-1 rounded-l-none"
               onClick={handleReject}
             >
@@ -171,6 +209,34 @@ function MergeQueueRow({
               Reject
             </Button>
           </div>
+          <Dialog open={requestChangesOpen} onOpenChange={setRequestChangesOpen}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Request Changes</DialogTitle>
+                <DialogDescription>
+                  Describe what changes are needed. This feedback will be sent back to the agent.
+                </DialogDescription>
+              </DialogHeader>
+              <Textarea
+                placeholder="Describe the changes needed..."
+                value={feedback}
+                onChange={(e) => setFeedback(e.target.value)}
+                rows={4}
+              />
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button variant="outline" size="sm">Cancel</Button>
+                </DialogClose>
+                <Button
+                  size="sm"
+                  onClick={handleRequestChanges}
+                  disabled={!feedback.trim() || submitting}
+                >
+                  {submitting ? "Submitting..." : "Request Changes"}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         </ActionsCell>
       )}
     </ListRow>


### PR DESCRIPTION
## Summary
- Wires the existing `requestChanges()` API function (`api.ts:78-88`) into the merge queue UI
- Adds a "Changes" button between Approve and Reject for pending merge entries
- Opens a dialog where users can provide feedback text, which is sent to the agent via `POST /api/merge-queue/:id/request-changes`
- Updated both `page.tsx` (ListView rows) and `columns.tsx` (TanStack Table column definitions) for consistency

## Test plan
- [ ] Navigate to the merge queue page with pending entries
- [ ] Verify the "Changes" button appears between Approve and Reject
- [ ] Click "Changes" and verify the dialog opens with a textarea
- [ ] Submit feedback and verify the API call succeeds
- [ ] Verify the entry status updates to `changes_requested` after submission
- [ ] Verify the feedback text appears as a subtitle on the entry row

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)