### PR TITLE
Add typed event payloads for compile-time safety in web UI

### DIFF
--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -81,14 +81,180 @@ export interface MergeQueueEntry {
 
 export type Actor = "human" | "orchestrator" | "scheduler" | "agent" | "system";
 
-export interface Event {
+// ---------------------------------------------------------------------------
+// Event payload types — shared type definitions for backend event data
+// ---------------------------------------------------------------------------
+
+/** agent:message — stdout/stderr from agent session */
+export interface AgentMessageData {
+  text: string;
+  stream?: string;
+}
+
+/** agent:question — agent asking for user input */
+export interface AgentQuestionData {
+  question?: string;
+  message?: string;
+  text?: string;
+}
+
+/** agent:error — agent error condition */
+export interface AgentErrorData {
+  text?: string;
+  [key: string]: unknown;
+}
+
+/** human:message — user message to agent or orchestrator */
+export interface HumanMessageData {
+  message: string;
+  source?: string;
+}
+
+/** orchestrator:decision — merge decision */
+export interface OrchestratorDecisionData {
+  task_id?: string;
+  approved: boolean;
+  reasoning?: string;
+  entry_id?: string;
+}
+
+/** orchestrator:feedback — feedback sent to agent */
+export interface OrchestratorFeedbackData {
+  task_id?: string;
+  feedback?: string;
+  context?: string;
+}
+
+/** orchestrator:escalation — escalation for human review */
+export interface OrchestratorEscalationData {
+  action?: string;
+  reasoning?: string;
+  reason?: string;
+  message?: string;
+  entry_id?: string;
+  pr_url?: string;
+  from?: string;
+  to?: string;
+}
+
+/** orchestrator:message / orchestrator:response / orchestrator:thought */
+export interface OrchestratorMessageData {
+  message?: string;
+  error?: boolean;
+}
+
+/** automation:run:output — streaming output chunk */
+export interface AutomationRunOutputData {
+  chunk?: string;
+}
+
+/** task:state:* and task:created — lifecycle events (data is often empty or minimal) */
+export interface TaskLifecycleData {
+  reason?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code protocol message types (parsed from agent:message text field)
+// ---------------------------------------------------------------------------
+
+export interface ClaudeTextBlock {
+  type: "text";
+  text: string;
+}
+
+export interface ClaudeThinkingBlock {
+  type: "thinking";
+  thinking?: string;
+}
+
+export interface ClaudeToolInput {
+  file_path?: string;
+  filePath?: string;
+  path?: string;
+  pattern?: string;
+  command?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+export interface ClaudeToolUseBlock {
+  type: "tool_use";
+  name: string;
+  input?: ClaudeToolInput;
+}
+
+export interface ClaudeToolResultBlock {
+  type: "tool_result";
+  content?: string;
+}
+
+export type ClaudeContentBlock =
+  | ClaudeTextBlock
+  | ClaudeThinkingBlock
+  | ClaudeToolUseBlock
+  | ClaudeToolResultBlock;
+
+export interface ClaudeResultMessage {
+  type: "result";
+  result?: { text?: string };
+}
+
+export interface ClaudeSystemMessage {
+  type: "system";
+}
+
+export interface ClaudeAssistantMessage {
+  type: "assistant" | undefined;
+  message?: { content?: ClaudeContentBlock[] };
+  content?: ClaudeContentBlock[];
+}
+
+export type ClaudeProtocolMessage =
+  | ClaudeResultMessage
+  | ClaudeSystemMessage
+  | ClaudeAssistantMessage;
+
+// ---------------------------------------------------------------------------
+// Event — discriminated union for compile-time type safety
+// ---------------------------------------------------------------------------
+
+interface EventBase {
   id: string;
-  type: string;
   task: string;
   actor: Actor;
   ts: string;
-  data: Record<string, unknown>;
 }
+
+export type Event =
+  | (EventBase & { type: "agent:message"; data: AgentMessageData })
+  | (EventBase & { type: "agent:question"; data: AgentQuestionData })
+  | (EventBase & { type: "agent:error"; data: AgentErrorData })
+  | (EventBase & { type: "human:message"; data: HumanMessageData })
+  | (EventBase & { type: "orchestrator:decision"; data: OrchestratorDecisionData })
+  | (EventBase & { type: "orchestrator:feedback"; data: OrchestratorFeedbackData })
+  | (EventBase & { type: "orchestrator:escalation"; data: OrchestratorEscalationData })
+  | (EventBase & { type: "orchestrator:message"; data: OrchestratorMessageData })
+  | (EventBase & { type: "orchestrator:response"; data: OrchestratorMessageData })
+  | (EventBase & { type: "orchestrator:thought"; data: OrchestratorMessageData })
+  | (EventBase & { type: "automation:run:output"; data: AutomationRunOutputData })
+  | (EventBase & { type: "automation:run:started"; data: TaskLifecycleData })
+  | (EventBase & { type: "automation:run:completed"; data: TaskLifecycleData })
+  | (EventBase & { type: "automation:run:failed"; data: TaskLifecycleData })
+  | (EventBase & { type: "automation:run:cancelled"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:created"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:state:running"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:state:question"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:state:waiting"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:state:blocked"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:state:testing"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:state:awaiting_merge"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:state:conflict"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:state:changes_requested"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:state:completed"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:state:failed"; data: TaskLifecycleData })
+  | (EventBase & { type: "task:state:cancelled"; data: TaskLifecycleData });
 
 export interface SlotUtilization {
   active: number;

--- a/web/src/pages/automation-detail.tsx
+++ b/web/src/pages/automation-detail.tsx
@@ -39,7 +39,15 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import type { Automation, AutomationRun, AutomationState, Event } from "@/lib/types";
+import type {
+  Automation,
+  AutomationRun,
+  AutomationState,
+  Event,
+  ClaudeProtocolMessage,
+  ClaudeContentBlock,
+  ClaudeToolInput,
+} from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // State badge configuration
@@ -188,15 +196,20 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
 
   for (const event of events) {
     // Handle automation lifecycle events
-    if (event.type.startsWith("automation:run:")) {
-      if (event.type === "automation:run:output") {
-        // Streaming output chunk
-        const chunk = event.data?.chunk as string | undefined;
-        if (chunk) {
-          blocks.push({ kind: "output_chunk", content: chunk, timestamp: event.ts });
-        }
-        continue;
+    if (event.type === "automation:run:output") {
+      // Streaming output chunk
+      const chunk = event.data.chunk;
+      if (chunk) {
+        blocks.push({ kind: "output_chunk", content: chunk, timestamp: event.ts });
       }
+      continue;
+    }
+
+    if (
+      event.type === "automation:run:started" ||
+      event.type === "automation:run:completed" ||
+      event.type === "automation:run:failed"
+    ) {
       const label = lifecycleLabels[event.type];
       if (label) {
         blocks.push({ kind: "lifecycle", content: label, timestamp: event.ts });
@@ -208,19 +221,21 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
     if (event.type === "agent:error") {
       blocks.push({
         kind: "error",
-        content: typeof event.data?.text === "string" ? event.data.text : JSON.stringify(event.data),
+        content: typeof event.data.text === "string" ? event.data.text : JSON.stringify(event.data),
         timestamp: event.ts,
       });
       continue;
     }
 
     // Handle agent messages (same parsing as task-detail)
-    const raw = event.data?.text;
+    if (event.type !== "agent:message") continue;
+
+    const raw = event.data.text;
     if (typeof raw !== "string") continue;
 
-    let msg: Record<string, unknown>;
+    let msg: ClaudeProtocolMessage;
     try {
-      msg = JSON.parse(raw);
+      msg = JSON.parse(raw) as ClaudeProtocolMessage;
     } catch {
       if (raw.trim()) blocks.push({ kind: "text", content: raw });
       continue;
@@ -229,24 +244,21 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
     if (msg.type === "system") continue;
 
     if (msg.type === "result") {
-      const result = msg.result as Record<string, unknown> | undefined;
-      if (typeof result?.text === "string" && result.text) {
-        blocks.push({ kind: "text", content: result.text });
+      const text = msg.result?.text;
+      if (text) {
+        blocks.push({ kind: "text", content: text });
       }
       continue;
     }
 
-    const message = msg.message as Record<string, unknown> | undefined;
-    const contentBlocks = (message?.content ?? msg.content) as unknown[] | undefined;
+    const contentBlocks: ClaudeContentBlock[] | undefined =
+      msg.message?.content ?? msg.content;
     if (!Array.isArray(contentBlocks)) continue;
 
-    for (const block of contentBlocks) {
-      if (typeof block !== "object" || block === null) continue;
-      const b = block as Record<string, unknown>;
-
+    for (const b of contentBlocks) {
       if (b.type === "thinking") continue;
 
-      if (b.type === "text" && typeof b.text === "string") {
+      if (b.type === "text") {
         if (b.text.trim()) {
           blocks.push({ kind: "text", content: b.text, timestamp: event.ts });
         }
@@ -254,8 +266,7 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
       }
 
       if (b.type === "tool_use") {
-        const name = typeof b.name === "string" ? b.name : "tool";
-        const input = (b.input ?? {}) as Record<string, unknown>;
+        const input: ClaudeToolInput = b.input ?? {};
         const filePath = input.file_path ?? input.filePath ?? input.path ?? input.pattern;
         const command = input.command;
         const description = input.description;
@@ -263,7 +274,7 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
         blocks.push({
           kind: "tool_use",
           content: detail ? String(detail) : "",
-          toolName: name,
+          toolName: b.name,
           filePath: filePath ? String(filePath) : undefined,
           timestamp: event.ts,
         });
@@ -271,7 +282,7 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
       }
 
       if (b.type === "tool_result") {
-        const content = typeof b.content === "string" ? b.content : "";
+        const content = b.content ?? "";
         if (!content) continue;
         const lines = content.split("\n");
         const preview =

--- a/web/src/pages/dashboard/page.tsx
+++ b/web/src/pages/dashboard/page.tsx
@@ -640,19 +640,18 @@ interface EscalationAlert {
 
 function parseEscalationEvents(events: Event[]): EscalationAlert[] {
   return events
-    .filter((e) => e.type === "orchestrator:escalation")
+    .filter((e): e is Extract<Event, { type: "orchestrator:escalation" }> =>
+      e.type === "orchestrator:escalation"
+    )
     .map((event) => ({
       id: event.id,
       timestamp: event.ts,
-      action: typeof event.data?.action === "string" ? event.data.action : "unknown",
-      reasoning:
-        typeof event.data?.reasoning === "string" ? event.data.reasoning :
-        typeof event.data?.reason === "string" ? event.data.reason :
-        undefined,
-      prUrl: typeof event.data?.pr_url === "string" ? event.data.pr_url : undefined,
+      action: event.data.action ?? "unknown",
+      reasoning: event.data.reasoning ?? event.data.reason,
+      prUrl: event.data.pr_url,
       taskId: event.task,
-      fromMode: typeof event.data?.from === "string" ? event.data.from : undefined,
-      toMode: typeof event.data?.to === "string" ? event.data.to : undefined,
+      fromMode: event.data.from,
+      toMode: event.data.to,
     }))
     .sort((a, b) => b.timestamp.localeCompare(a.timestamp)); // Most recent first
 }

--- a/web/src/pages/events/page.tsx
+++ b/web/src/pages/events/page.tsx
@@ -51,7 +51,7 @@ function matchesFilter(event: Event, filter: FilterKey): boolean {
   return event.type.startsWith(`${filter}:`);
 }
 
-function truncateData(data: Record<string, unknown>, max = 100): string {
+function truncateData(data: object, max = 100): string {
   const raw = JSON.stringify(data);
   return raw.length > max ? `${raw.slice(0, max)}...` : raw;
 }

--- a/web/src/pages/orchestrator/page.tsx
+++ b/web/src/pages/orchestrator/page.tsx
@@ -91,53 +91,48 @@ function parseOrchestratorEvents(
   const blocks: OrchestratorBlock[] = [];
   for (const event of events) {
     if (event.type === "orchestrator:decision") {
-      const taskId = typeof event.data?.task_id === "string" ? event.data.task_id : event.task;
+      const { data } = event;
+      const taskId = data.task_id ?? event.task;
       blocks.push({
         kind: "decision",
         id: event.id,
         timestamp: event.ts,
-        approved: event.data?.approved === true,
-        reasoning: typeof event.data?.reasoning === "string" ? event.data.reasoning : undefined,
+        approved: data.approved,
+        reasoning: data.reasoning,
         taskId,
         taskInfo: getTaskInfo(taskId, tasks, projects) ?? undefined,
-        entryId: typeof event.data?.entry_id === "string" ? event.data.entry_id : undefined,
+        entryId: data.entry_id,
       });
     } else if (event.type === "orchestrator:feedback") {
-      const taskId = typeof event.data?.task_id === "string" ? event.data.task_id : event.task;
-      const context = typeof event.data?.context === "string" ? event.data.context : undefined;
+      const { data } = event;
+      const taskId = data.task_id ?? event.task;
       // Distinguish question answers from regular feedback
       blocks.push({
-        kind: context === "question_answer" ? "question_answer" : "feedback",
+        kind: data.context === "question_answer" ? "question_answer" : "feedback",
         id: event.id,
         timestamp: event.ts,
-        feedback: typeof event.data?.feedback === "string" ? event.data.feedback : undefined,
+        feedback: data.feedback,
         taskId,
         taskInfo: getTaskInfo(taskId, tasks, projects) ?? undefined,
-        content: context,
+        content: data.context,
       });
     } else if (event.type === "orchestrator:escalation") {
-      const action = typeof event.data?.action === "string" ? event.data.action : undefined;
+      const { data } = event;
       // Extract reasoning - backend sends "reasoning" for conflicts, "reason" for mode changes
-      const reasoning =
-        typeof event.data?.reasoning === "string" ? event.data.reasoning :
-        typeof event.data?.reason === "string" ? event.data.reason :
-        undefined;
-      const taskId = event.task;
+      const reasoning = data.reasoning ?? data.reason;
       // For agent_question escalations, the message field contains the question
-      const message = typeof event.data?.message === "string" ? event.data.message : undefined;
-
       blocks.push({
         kind: "escalation",
         id: event.id,
         timestamp: event.ts,
-        content: action === "agent_question" ? message : reasoning,
-        taskId,
-        taskInfo: getTaskInfo(taskId, tasks, projects) ?? undefined,
-        entryId: typeof event.data?.entry_id === "string" ? event.data.entry_id : undefined,
-        escalationAction: action,
-        prUrl: typeof event.data?.pr_url === "string" ? event.data.pr_url : undefined,
-        fromMode: typeof event.data?.from === "string" ? event.data.from : undefined,
-        toMode: typeof event.data?.to === "string" ? event.data.to : undefined,
+        content: data.action === "agent_question" ? data.message : reasoning,
+        taskId: event.task,
+        taskInfo: getTaskInfo(event.task, tasks, projects) ?? undefined,
+        entryId: data.entry_id,
+        escalationAction: data.action,
+        prUrl: data.pr_url,
+        fromMode: data.from,
+        toMode: data.to,
       });
     } else if (event.type === "orchestrator:message") {
       // Human message to orchestrator
@@ -145,7 +140,7 @@ function parseOrchestratorEvents(
         kind: "message",
         id: event.id,
         timestamp: event.ts,
-        content: typeof event.data?.message === "string" ? event.data.message : undefined,
+        content: event.data.message,
         actor: "human",
       });
     } else if (event.type === "orchestrator:response") {
@@ -154,7 +149,7 @@ function parseOrchestratorEvents(
         kind: "message",
         id: event.id,
         timestamp: event.ts,
-        content: typeof event.data?.message === "string" ? event.data.message : undefined,
+        content: event.data.message,
         actor: "orchestrator",
       });
     } else if (event.type === "orchestrator:thought") {
@@ -163,7 +158,7 @@ function parseOrchestratorEvents(
         kind: "thought",
         id: event.id,
         timestamp: event.ts,
-        content: typeof event.data?.message === "string" ? event.data.message : undefined,
+        content: event.data.message,
       });
     }
   }

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -43,7 +43,15 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import type { Event, FailureInfo, Task, TaskState } from "@/lib/types";
+import type {
+  Event,
+  FailureInfo,
+  Task,
+  TaskState,
+  ClaudeProtocolMessage,
+  ClaudeContentBlock,
+  ClaudeToolInput,
+} from "@/lib/types";
 import { taskStateMeta } from "./tasks/columns";
 
 // ---------------------------------------------------------------------------
@@ -150,7 +158,7 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
     }
 
     if (event.type === "agent:question") {
-      const question = (event.data?.question ?? event.data?.message ?? event.data?.text) as string | undefined;
+      const question = event.data.question ?? event.data.message ?? event.data.text;
       if (question) {
         blocks.push({ kind: "agent_question", content: question, timestamp: event.ts });
       }
@@ -158,8 +166,7 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
     }
 
     if (event.type === "human:message") {
-      const message = event.data?.message as string | undefined;
-      const source = event.data?.source as string | undefined;
+      const { message, source } = event.data;
       if (message) {
         // Orchestrator answers come as human:message with source "orchestrator_answer"
         blocks.push({
@@ -174,18 +181,20 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
     if (event.type === "agent:error") {
       blocks.push({
         kind: "error",
-        content: typeof event.data?.text === "string" ? event.data.text : JSON.stringify(event.data),
+        content: typeof event.data.text === "string" ? event.data.text : JSON.stringify(event.data),
         timestamp: event.ts,
       });
       continue;
     }
 
-    const raw = event.data?.text;
+    if (event.type !== "agent:message") continue;
+
+    const raw = event.data.text;
     if (typeof raw !== "string") continue;
 
-    let msg: Record<string, unknown>;
+    let msg: ClaudeProtocolMessage;
     try {
-      msg = JSON.parse(raw);
+      msg = JSON.parse(raw) as ClaudeProtocolMessage;
     } catch {
       if (raw.trim()) blocks.push({ kind: "text", content: raw });
       continue;
@@ -194,24 +203,21 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
     if (msg.type === "system") continue;
 
     if (msg.type === "result") {
-      const result = msg.result as Record<string, unknown> | undefined;
-      if (typeof result?.text === "string" && result.text) {
-        blocks.push({ kind: "text", content: result.text });
+      const text = msg.result?.text;
+      if (text) {
+        blocks.push({ kind: "text", content: text });
       }
       continue;
     }
 
-    const message = msg.message as Record<string, unknown> | undefined;
-    const contentBlocks = (message?.content ?? msg.content) as unknown[] | undefined;
+    const contentBlocks: ClaudeContentBlock[] | undefined =
+      msg.message?.content ?? msg.content;
     if (!Array.isArray(contentBlocks)) continue;
 
-    for (const block of contentBlocks) {
-      if (typeof block !== "object" || block === null) continue;
-      const b = block as Record<string, unknown>;
-
+    for (const b of contentBlocks) {
       if (b.type === "thinking") continue;
 
-      if (b.type === "text" && typeof b.text === "string") {
+      if (b.type === "text") {
         if (b.text.trim()) {
           blocks.push({ kind: "text", content: b.text, timestamp: event.ts });
         }
@@ -219,8 +225,7 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
       }
 
       if (b.type === "tool_use") {
-        const name = typeof b.name === "string" ? b.name : "tool";
-        const input = (b.input ?? {}) as Record<string, unknown>;
+        const input: ClaudeToolInput = b.input ?? {};
         const filePath = input.file_path ?? input.filePath ?? input.path ?? input.pattern;
         const command = input.command;
         const description = input.description;
@@ -228,7 +233,7 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
         blocks.push({
           kind: "tool_use",
           content: detail ? String(detail) : "",
-          toolName: name,
+          toolName: b.name,
           filePath: filePath ? String(filePath) : undefined,
           timestamp: event.ts,
         });
@@ -236,7 +241,7 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
       }
 
       if (b.type === "tool_result") {
-        const content = typeof b.content === "string" ? b.content : "";
+        const content = b.content ?? "";
         if (!content) continue;
         const lines = content.split("\n");
         const preview =


### PR DESCRIPTION
## Summary

- Defines shared TypeScript interfaces for all event data payloads (`AgentMessageData`, `OrchestratorDecisionData`, `HumanMessageData`, etc.) and Claude Code protocol message types (`ClaudeContentBlock`, `ClaudeProtocolMessage`, etc.) in `web/src/lib/types.ts`
- Changes `Event` from a single interface with `data: Record<string, unknown>` to a discriminated union keyed on `type`, enabling automatic type narrowing when checking `event.type`
- Removes all `as Record<string, unknown>` casts and manual `typeof` guards from event processing in `task-detail.tsx`, `orchestrator/page.tsx`, `automation-detail.tsx`, and `dashboard/page.tsx`

## Test plan

- [x] `tsc --noEmit` passes with no errors
- [x] `vite build` succeeds
- [ ] Verify task detail page renders agent messages, tool use, errors correctly
- [ ] Verify orchestrator page renders decisions, feedback, escalations correctly
- [ ] Verify automation detail page renders run output and agent messages correctly

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)