### PR TITLE
Add compiled_at timestamp to invalidate stale compiled workflows

### DIFF
--- a/crates/models/src/automation.rs
+++ b/crates/models/src/automation.rs
@@ -64,6 +64,9 @@ pub struct Automation {
     pub prompt: String,
     /// Compiled/hardened workflow (can be deferred until first run).
     pub compiled_workflow: Option<String>,
+    /// When the workflow was last compiled. Used to detect staleness:
+    /// if `updated_at > compiled_at`, the compiled workflow is outdated.
+    pub compiled_at: Option<DateTime<Utc>>,
     /// What triggers this automation.
     pub trigger: TriggerType,
     /// Current state of the automation.
@@ -88,6 +91,7 @@ impl Automation {
             name: name.into(),
             prompt: prompt.into(),
             compiled_workflow: None,
+            compiled_at: None,
             trigger,
             state: AutomationState::Active,
             created_at: now,
@@ -99,6 +103,23 @@ impl Automation {
     pub fn set_state(&mut self, state: AutomationState) {
         self.state = state;
         self.updated_at = Utc::now();
+    }
+
+    /// Set the compiled workflow and record the compilation timestamp.
+    pub fn set_compiled_workflow(&mut self, workflow: String) {
+        self.compiled_workflow = Some(workflow);
+        self.compiled_at = Some(Utc::now());
+    }
+
+    /// Whether the compiled workflow is stale (definition updated after last compilation).
+    /// Returns `true` if there is a compiled workflow whose `compiled_at` predates `updated_at`,
+    /// or if `compiled_at` is missing despite a workflow being present.
+    pub fn is_compiled_workflow_stale(&self) -> bool {
+        match (&self.compiled_workflow, self.compiled_at) {
+            (Some(_), Some(compiled)) => self.updated_at > compiled,
+            (Some(_), None) => true, // compiled but no timestamp — assume stale
+            _ => false,              // no workflow at all — nothing to be stale
+        }
     }
 }
 

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -681,17 +681,20 @@ impl Store {
         let created_at = automation.created_at.to_rfc3339();
         let updated_at = automation.updated_at.to_rfc3339();
 
+        let compiled_at = automation.compiled_at.map(|dt| dt.to_rfc3339());
+
         self.conn()?.execute(
             "INSERT OR REPLACE INTO automations (
-                id, project_id, name, prompt, compiled_workflow,
+                id, project_id, name, prompt, compiled_workflow, compiled_at,
                 trigger_type, trigger_config, state, created_at, updated_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             params![
                 automation.id,
                 automation.project_id,
                 automation.name,
                 automation.prompt,
                 automation.compiled_workflow,
+                compiled_at,
                 trigger_type,
                 trigger_config,
                 state,
@@ -706,7 +709,7 @@ impl Store {
     pub fn get_automation(&self, id: &str) -> Result<Option<Automation>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
-            "SELECT id, project_id, name, prompt, compiled_workflow,
+            "SELECT id, project_id, name, prompt, compiled_workflow, compiled_at,
                     trigger_type, trigger_config, state, created_at, updated_at
              FROM automations WHERE id = ?1",
         )?;
@@ -721,7 +724,7 @@ impl Store {
     pub fn list_automations_for_project(&self, project_id: &str) -> Result<Vec<Automation>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
-            "SELECT id, project_id, name, prompt, compiled_workflow,
+            "SELECT id, project_id, name, prompt, compiled_workflow, compiled_at,
                     trigger_type, trigger_config, state, created_at, updated_at
              FROM automations WHERE project_id = ?1",
         )?;
@@ -777,7 +780,7 @@ impl Store {
     pub fn list_automations(&self) -> Result<Vec<Automation>, StoreError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
-            "SELECT id, project_id, name, prompt, compiled_workflow,
+            "SELECT id, project_id, name, prompt, compiled_workflow, compiled_at,
                     trigger_type, trigger_config, state, created_at, updated_at
              FROM automations",
         )?;
@@ -1006,21 +1009,33 @@ fn row_to_automation(row: &rusqlite::Row) -> Result<Automation, rusqlite::Error>
     let name: String = row.get(2)?;
     let prompt: String = row.get(3)?;
     let compiled_workflow: Option<String> = row.get(4)?;
-    let trigger_type: String = row.get(5)?;
-    let trigger_config: String = row.get(6)?;
-    let state_str: String = row.get(7)?;
-    let created_at_str: String = row.get(8)?;
-    let updated_at_str: String = row.get(9)?;
+    let compiled_at_str: Option<String> = row.get(5)?;
+    let trigger_type: String = row.get(6)?;
+    let trigger_config: String = row.get(7)?;
+    let state_str: String = row.get(8)?;
+    let created_at_str: String = row.get(9)?;
+    let updated_at_str: String = row.get(10)?;
+
+    // Parse compiled_at
+    let compiled_at = compiled_at_str
+        .map(|s| {
+            DateTime::parse_from_rfc3339(&s)
+                .map(|dt| dt.with_timezone(&Utc))
+                .map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(5, rusqlite::types::Type::Text, Box::new(e))
+                })
+        })
+        .transpose()?;
 
     // Parse trigger
     let trigger = match trigger_type.as_str() {
         "schedule" => {
             let config: serde_json::Value = serde_json::from_str(&trigger_config).map_err(|e| {
-                rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, Box::new(e))
+                rusqlite::Error::FromSqlConversionFailure(7, rusqlite::types::Type::Text, Box::new(e))
             })?;
             let cron = config["cron"].as_str().ok_or_else(|| {
                 rusqlite::Error::FromSqlConversionFailure(
-                    6,
+                    7,
                     rusqlite::types::Type::Text,
                     format!("missing or non-string 'cron' in trigger_config: {trigger_config}").into(),
                 )
@@ -1029,11 +1044,11 @@ fn row_to_automation(row: &rusqlite::Row) -> Result<Automation, rusqlite::Error>
         }
         "event" => {
             let config: serde_json::Value = serde_json::from_str(&trigger_config).map_err(|e| {
-                rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, Box::new(e))
+                rusqlite::Error::FromSqlConversionFailure(7, rusqlite::types::Type::Text, Box::new(e))
             })?;
             let event_type = config["event_type"].as_str().ok_or_else(|| {
                 rusqlite::Error::FromSqlConversionFailure(
-                    6,
+                    7,
                     rusqlite::types::Type::Text,
                     format!("missing or non-string 'event_type' in trigger_config: {trigger_config}").into(),
                 )
@@ -1043,7 +1058,7 @@ fn row_to_automation(row: &rusqlite::Row) -> Result<Automation, rusqlite::Error>
         "manual" => TriggerType::Manual,
         other => {
             return Err(rusqlite::Error::FromSqlConversionFailure(
-                5,
+                6,
                 rusqlite::types::Type::Text,
                 format!("unrecognized trigger_type: {other}").into(),
             ));
@@ -1052,18 +1067,18 @@ fn row_to_automation(row: &rusqlite::Row) -> Result<Automation, rusqlite::Error>
 
     // Parse state
     let state: AutomationState = serde_json::from_str(&format!("\"{state_str}\"")).map_err(|e| {
-        rusqlite::Error::FromSqlConversionFailure(7, rusqlite::types::Type::Text, Box::new(e))
+        rusqlite::Error::FromSqlConversionFailure(8, rusqlite::types::Type::Text, Box::new(e))
     })?;
 
     let created_at = DateTime::parse_from_rfc3339(&created_at_str)
         .map(|dt| dt.with_timezone(&Utc))
         .map_err(|e| {
-            rusqlite::Error::FromSqlConversionFailure(8, rusqlite::types::Type::Text, Box::new(e))
+            rusqlite::Error::FromSqlConversionFailure(9, rusqlite::types::Type::Text, Box::new(e))
         })?;
     let updated_at = DateTime::parse_from_rfc3339(&updated_at_str)
         .map(|dt| dt.with_timezone(&Utc))
         .map_err(|e| {
-            rusqlite::Error::FromSqlConversionFailure(9, rusqlite::types::Type::Text, Box::new(e))
+            rusqlite::Error::FromSqlConversionFailure(10, rusqlite::types::Type::Text, Box::new(e))
         })?;
 
     Ok(Automation {
@@ -1072,6 +1087,7 @@ fn row_to_automation(row: &rusqlite::Row) -> Result<Automation, rusqlite::Error>
         name,
         prompt,
         compiled_workflow,
+        compiled_at,
         trigger,
         state,
         created_at,

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -76,6 +76,7 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
             name TEXT NOT NULL,
             prompt TEXT NOT NULL,
             compiled_workflow TEXT,
+            compiled_at TEXT,
             trigger_type TEXT NOT NULL,
             trigger_config TEXT NOT NULL DEFAULT '{}',
             state TEXT NOT NULL DEFAULT 'active',
@@ -255,6 +256,27 @@ pub(crate) fn initialize(conn: &Connection) -> Result<(), rusqlite::Error> {
         }
         Err(e) => {
             tracing::warn!(error = %e, "could not create unique index on merge_queue.pr_url (duplicates may exist)");
+        }
+    }
+
+    // Migration: add compiled_at column to automations table (issue #522)
+    // Tracks when the workflow was last compiled for staleness detection.
+    match conn.execute(
+        "ALTER TABLE automations ADD COLUMN compiled_at TEXT",
+        [],
+    ) {
+        Ok(_) => {
+            tracing::info!("added compiled_at column to automations table");
+        }
+        Err(rusqlite::Error::SqliteFailure(e, Some(ref msg)))
+            if e.extended_code == rusqlite::ffi::SQLITE_ERROR
+                && msg.contains("duplicate column name") =>
+        {
+            tracing::debug!("compiled_at column already exists");
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "failed to add compiled_at column");
+            return Err(e);
         }
     }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -132,6 +132,7 @@ export interface Automation {
   name: string;
   prompt: string;
   compiled_workflow?: string;
+  compiled_at?: string;
   trigger: TriggerConfig;
   state: AutomationState;
   created_at: string;

--- a/web/src/pages/automations/automation-form-dialog.tsx
+++ b/web/src/pages/automations/automation-form-dialog.tsx
@@ -478,6 +478,10 @@ export function AutomationFormDialog({
                 </div>
                 <p className="text-xs text-muted-foreground">
                   This is the compiled version of your prompt (read-only).
+                  {automation.compiled_at && ` Compiled: ${new Date(automation.compiled_at).toLocaleString()}.`}
+                  {automation.compiled_at && new Date(automation.updated_at) > new Date(automation.compiled_at) && (
+                    <span className="text-warning"> Stale — automation was updated after last compilation.</span>
+                  )}
                 </p>
               </div>
             )}


### PR DESCRIPTION
## Summary
- Adds `compiled_at: Option<DateTime<Utc>>` field to the `Automation` model to track when the workflow was last compiled
- Adds `set_compiled_workflow()` method that sets both the workflow and timestamp atomically
- Adds `is_compiled_workflow_stale()` method that returns `true` when `updated_at > compiled_at`
- Includes SQLite schema migration (ALTER TABLE) for existing databases and updated CREATE TABLE for new ones
- Updates the web UI to display compilation time and a staleness warning

## Test plan
- [x] `cargo test --package models --package tasks-store` — all 43 tests pass
- [x] No new compilation errors introduced (server crate has pre-existing unrelated errors)
- [ ] Verify migration works on an existing database with automations (compiled_at defaults to NULL)
- [ ] Verify staleness detection: create automation, compile, update prompt, confirm `is_compiled_workflow_stale()` returns true

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)