### PR TITLE
Add MergeStatus::is_terminal() method

### DIFF
--- a/crates/models/src/merge_queue.rs
+++ b/crates/models/src/merge_queue.rs
@@ -19,6 +19,13 @@ pub enum MergeStatus {
     ChangesRequested,
 }
 
+impl MergeStatus {
+    /// Whether this is a terminal state (no further transitions expected).
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Merged | Self::Rejected)
+    }
+}
+
 /// Type of merge conflict — spec Section 7.4.
 ///
 /// The orchestrator uses this to decide resolution strategy:
@@ -139,6 +146,17 @@ impl MergeQueueEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn merge_status_is_terminal() {
+        assert!(MergeStatus::Merged.is_terminal());
+        assert!(MergeStatus::Rejected.is_terminal());
+        assert!(!MergeStatus::Pending.is_terminal());
+        assert!(!MergeStatus::Approved.is_terminal());
+        assert!(!MergeStatus::Merging.is_terminal());
+        assert!(!MergeStatus::Conflict.is_terminal());
+        assert!(!MergeStatus::ChangesRequested.is_terminal());
+    }
 
     #[test]
     fn conflict_type_is_mechanical() {

--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -298,7 +298,7 @@ impl MergeQueue {
     ) {
         self.entries.retain(|e| {
             // Remove merged and rejected entries after cooldown period (issue #438)
-            if matches!(e.status, MergeStatus::Merged | MergeStatus::Rejected) {
+            if e.status.is_terminal() {
                 match (merged_cutoff, e.completed_at) {
                     // If we have both a cutoff and a completed_at timestamp,
                     // only remove if completed before the cutoff


### PR DESCRIPTION
## Summary
- Adds `MergeStatus::is_terminal()` returning `true` for `Merged` and `Rejected`, consistent with `RunStatus`, `TaskState`, and `SessionStatus` patterns
- Replaces the ad-hoc `matches!(e.status, MergeStatus::Merged | MergeStatus::Rejected)` check in merge queue cleanup with `e.status.is_terminal()`
- Adds a test covering all `MergeStatus` variants

Closes #523

## Test plan
- [x] `cargo test -p models merge_status_is_terminal` passes
- [ ] Verify no other ad-hoc terminal checks remain that should use the new method

🤖 Generated with [Claude Code](https://claude.com/claude-code)