### PR TITLE
Add Response::thinking() accessor for thinking blocks

### DIFF
--- a/crates/agent/src/message.rs
+++ b/crates/agent/src/message.rs
@@ -185,6 +185,10 @@ impl Response {
     pub fn text(&self) -> String {
         self.content.iter().filter_map(|c| c.as_text()).collect::<Vec<_>>().join("")
     }
+
+    pub fn thinking(&self) -> String {
+        self.content.iter().filter_map(|c| c.as_thinking()).collect::<Vec<_>>().join("")
+    }
 }
 
 /// Token usage information.
@@ -223,6 +227,21 @@ mod tests {
             Content::text("world"),
         ]);
         assert_eq!(msg.text(), "hello world");
+    }
+
+    #[test]
+    fn test_response_text_excludes_thinking() {
+        let response = Response {
+            content: vec![
+                Content::thinking("let me reason"),
+                Content::text("final answer"),
+            ],
+            tool_calls: vec![],
+            stop_reason: Some(StopReason::EndTurn),
+            usage: None,
+        };
+        assert_eq!(response.text(), "final answer");
+        assert_eq!(response.thinking(), "let me reason");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `Response::text()` already correctly excludes `Content::Thinking` blocks (uses `as_text()` filter), contrary to the issue description
- Added `Response::thinking()` accessor that concatenates all `Content::Thinking` blocks, giving callers a clean way to access model reasoning separately
- Added test verifying `text()` excludes thinking and `thinking()` returns only thinking content

Closes #527

## Test plan

- [x] New test `test_response_text_excludes_thinking` verifies both accessors
- [x] All 49 existing agent crate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)