### PR TITLE
Add orchestrator triage and decomposition (spec §4.2)

### DIFF
--- a/crates/orchestrator/src/chat.rs
+++ b/crates/orchestrator/src/chat.rs
@@ -16,6 +16,8 @@ use tasks_agent::{
 };
 
 use crate::error::OrchestratorError;
+use crate::prompt::{build_triage_prompt, triage_system_prompt};
+use crate::types::{TriageIssueSummary, TriageResult};
 
 /// Default model for orchestrator chat.
 const DEFAULT_CHAT_MODEL: &str = "claude-opus-4-6";
@@ -68,6 +70,9 @@ pub struct ChatEvent {
 pub struct ChatResponse {
     /// The orchestrator's response text.
     pub message: String,
+    /// If the orchestrator performed triage decomposition, the result is here.
+    /// The caller should present this to the user for review.
+    pub triage_result: Option<TriageResult>,
 }
 
 /// Handler for orchestrator chat interactions.
@@ -157,6 +162,55 @@ impl OrchestratorChat {
 
         Ok(ChatResponse {
             message: response_text,
+            triage_result: None,
+        })
+    }
+
+    /// Triage and decompose a natural language work description into issues.
+    ///
+    /// This is the "project foreman" flow from spec §4.2. The human describes
+    /// work, and the orchestrator produces a set of draft issues for review.
+    pub async fn triage(
+        &self,
+        description: &str,
+        project: &Project,
+        existing_issues: &[TriageIssueSummary],
+    ) -> Result<ChatResponse, OrchestratorError> {
+        info!(
+            project = %project.repo,
+            description_len = description.len(),
+            "Triaging work request via chat"
+        );
+
+        let system = triage_system_prompt();
+        let user_prompt = build_triage_prompt(description, &project.repo, existing_issues);
+
+        let config = CompletionConfig::new(&self.model).with_max_tokens(self.max_tokens);
+        let request = CompletionRequest::new(config, vec![Message::user(user_prompt)])
+            .with_system(system);
+
+        let response = self
+            .provider
+            .complete(request)
+            .await
+            .map_err(OrchestratorError::Agent)?;
+
+        let response_text = response.text();
+        info!(response_len = response_text.len(), "Triage response received");
+
+        // Try to parse as TriageResult
+        let triage_result = crate::claude::extract_json_from_text(&response_text)
+            .and_then(|json_str| serde_json::from_str::<TriageResult>(json_str).ok());
+
+        let message = if let Some(ref result) = triage_result {
+            format_triage_result(result)
+        } else {
+            response_text
+        };
+
+        Ok(ChatResponse {
+            message,
+            triage_result,
         })
     }
 
@@ -173,6 +227,7 @@ impl OrchestratorChat {
 - You help users understand system status and make decisions
 - You can explain system status and help users make decisions
 - You provide updates on merges, conflicts, and agent progress
+- You decompose work requests into well-formed GitHub issues (triage)
 - You are helpful, concise, and action-oriented
 
 ## Current System State
@@ -254,6 +309,50 @@ impl OrchestratorChat {
             .collect::<Vec<_>>()
             .join("\n")
     }
+}
+
+/// Format a triage result as a human-readable chat message.
+fn format_triage_result(result: &TriageResult) -> String {
+    let mut msg = String::new();
+    msg.push_str("## Triage Result\n\n");
+    msg.push_str(&result.analysis);
+    msg.push_str("\n\n");
+
+    if result.issues.is_empty() {
+        msg.push_str("No issues to create — the request may already be covered by existing issues.\n");
+        return msg;
+    }
+
+    msg.push_str(&format!("### {} Issue(s) to Create\n\n", result.issues.len()));
+
+    for (i, issue) in result.issues.iter().enumerate() {
+        msg.push_str(&format!("**{}. {}**", i + 1, issue.title));
+
+        if !issue.labels.is_empty() {
+            msg.push_str(&format!(" [{}]", issue.labels.join(", ")));
+        }
+
+        if !issue.blocked_by.is_empty() {
+            let deps: Vec<String> = issue.blocked_by.iter().map(|d| format!("#{}", d + 1)).collect();
+            msg.push_str(&format!(" (blocked by: {})", deps.join(", ")));
+        }
+
+        msg.push('\n');
+
+        // Show a preview of the body (first few lines)
+        let preview_lines: Vec<&str> = issue.body.lines().take(4).collect();
+        for line in &preview_lines {
+            msg.push_str(&format!("  > {}\n", line));
+        }
+        let total_lines = issue.body.lines().count();
+        if total_lines > 4 {
+            msg.push_str(&format!("  > ... ({} more lines)\n", total_lines - 4));
+        }
+        msg.push('\n');
+    }
+
+    msg.push_str("Review and confirm to create these issues on GitHub.");
+    msg
 }
 
 /// Convert an event to a chat event summary.

--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -8,10 +8,10 @@ use tracing::{info, warn};
 
 use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
-use crate::prompt::{build_evaluation_prompt, build_deep_review_prompt, parse_pr_url, system_prompt};
+use crate::prompt::{build_evaluation_prompt, build_deep_review_prompt, build_triage_prompt, parse_pr_url, system_prompt, triage_system_prompt};
 use crate::types::{
     default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
-    QualityEvaluation, QuestionContext, SystemContext,
+    QualityEvaluation, QuestionContext, SystemContext, TriageContext, TriageResult,
 };
 use events::EventType;
 use models::task::{Task, TaskSource};
@@ -518,6 +518,74 @@ impl Orchestrator for ClaudeOrchestrator {
 
         Ok(answer)
     }
+
+    async fn triage(
+        &self,
+        context: &TriageContext,
+    ) -> Result<TriageResult, OrchestratorError> {
+        info!(
+            project = %context.project.repo,
+            description_len = context.description.len(),
+            existing_issues = context.existing_issues.len(),
+            "Triaging work request into issues"
+        );
+
+        let system = triage_system_prompt();
+        let user_prompt = build_triage_prompt(
+            &context.description,
+            &context.project.repo,
+            &context.existing_issues,
+        );
+
+        let config = CompletionConfig::new(&self.model).with_max_tokens(self.max_tokens);
+        let request = CompletionRequest::new(config, vec![Message::user(user_prompt)])
+            .with_system(system);
+
+        let response = self
+            .provider
+            .complete(request)
+            .await
+            .map_err(OrchestratorError::Agent)?;
+
+        let response_text = response.text();
+        info!(response_len = response_text.len(), "Triage response received");
+
+        let json_str = extract_json(&response_text).ok_or_else(|| {
+            OrchestratorError::Evaluation(format!(
+                "Could not find JSON in triage response: {}",
+                truncate(&response_text, 200)
+            ))
+        })?;
+
+        let result: TriageResult = serde_json::from_str(json_str).map_err(|e| {
+            OrchestratorError::Evaluation(format!("Failed to parse triage JSON: {}", e))
+        })?;
+
+        // Validate: all blocked_by indices must be in range
+        for (i, issue) in result.issues.iter().enumerate() {
+            for &dep in &issue.blocked_by {
+                if dep >= result.issues.len() {
+                    return Err(OrchestratorError::Evaluation(format!(
+                        "Issue {} references blocked_by index {} but only {} issues exist",
+                        i, dep, result.issues.len()
+                    )));
+                }
+                if dep == i {
+                    return Err(OrchestratorError::Evaluation(format!(
+                        "Issue {} references itself in blocked_by",
+                        i
+                    )));
+                }
+            }
+        }
+
+        info!(
+            issue_count = result.issues.len(),
+            "Triage decomposition complete"
+        );
+
+        Ok(result)
+    }
 }
 
 /// Build the system prompt for answering agent questions.
@@ -563,6 +631,11 @@ fn build_question_answer_prompt(
     ));
 
     prompt
+}
+
+/// Public wrapper for extract_json, used by chat module.
+pub fn extract_json_from_text(text: &str) -> Option<&str> {
+    extract_json(text)
 }
 
 /// Extract JSON from a text response.
@@ -644,6 +717,7 @@ mod tests {
             provider: AnthropicProvider::new("test-key"),
             github: GitHubClient::new("test-token"),
             model: DEFAULT_MODEL.to_string(),
+            max_tokens: DEFAULT_MAX_TOKENS,
         }
     }
 
@@ -727,5 +801,41 @@ That's all."#;
     fn test_extract_json_none() {
         assert!(extract_json("no json here").is_none());
         assert!(extract_json("incomplete { json").is_none());
+    }
+
+    #[test]
+    fn test_parse_triage_result_valid() {
+        let json_val = serde_json::json!({
+            "analysis": "Need to add rate limiting",
+            "issues": [
+                {
+                    "title": "Add rate limiting middleware",
+                    "body": "We need rate limiting.\n\n- [ ] Middleware works",
+                    "labels": ["enhancement"],
+                    "blocked_by": []
+                },
+                {
+                    "title": "Add rate limit configuration",
+                    "body": "Config for rate limits.\n\n- [ ] Config loads",
+                    "labels": ["enhancement"],
+                    "blocked_by": [0]
+                }
+            ]
+        });
+        let json = json_val.to_string();
+        let result: TriageResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(result.issues.len(), 2);
+        assert_eq!(result.issues[0].title, "Add rate limiting middleware");
+        assert_eq!(result.issues[1].blocked_by, vec![0]);
+    }
+
+    #[test]
+    fn test_extract_json_from_text_public() {
+        let text = r#"```json
+{"analysis": "test", "issues": []}
+```"#;
+        let result = extract_json_from_text(text);
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("analysis"));
     }
 }

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -21,6 +21,7 @@ pub use mock::MockOrchestrator;
 pub use orchestrator::Orchestrator;
 pub use prompt::parse_pr_url;
 pub use types::{
-    ConflictContext, ConflictResolution, ConflictTriage, EvaluationContext, OperatingMode,
-    OrchestratorAction, QualityEvaluation, QuestionContext, QueueEntrySummary, SystemContext,
+    ConflictContext, ConflictResolution, ConflictTriage, EvaluationContext, IssueDraft,
+    OperatingMode, OrchestratorAction, QualityEvaluation, QuestionContext, QueueEntrySummary,
+    SystemContext, TriageContext, TriageIssueSummary, TriageResult,
 };

--- a/crates/orchestrator/src/mock.rs
+++ b/crates/orchestrator/src/mock.rs
@@ -5,8 +5,9 @@ use std::sync::Mutex;
 use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
 use crate::types::{
-    default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
-    QualityEvaluation, QuestionContext, SystemContext,
+    default_triage, ConflictContext, ConflictTriage, EvaluationContext, IssueDraft,
+    OrchestratorAction, QualityEvaluation, QuestionContext, SystemContext, TriageContext,
+    TriageResult,
 };
 use models::task::Task;
 
@@ -29,6 +30,10 @@ pub struct MockOrchestrator {
     pub think_count: Mutex<u32>,
     /// Count of answer_question calls (for assertions).
     pub answer_question_count: Mutex<u32>,
+    /// Count of triage calls (for assertions).
+    pub triage_decompose_count: Mutex<u32>,
+    /// Optional triage result override.
+    triage_result: Mutex<Option<TriageResult>>,
 }
 
 impl MockOrchestrator {
@@ -46,6 +51,8 @@ impl MockOrchestrator {
             triage_count: Mutex::new(0),
             think_count: Mutex::new(0),
             answer_question_count: Mutex::new(0),
+            triage_decompose_count: Mutex::new(0),
+            triage_result: Mutex::new(None),
         }
     }
 
@@ -64,6 +71,8 @@ impl MockOrchestrator {
             triage_count: Mutex::new(0),
             think_count: Mutex::new(0),
             answer_question_count: Mutex::new(0),
+            triage_decompose_count: Mutex::new(0),
+            triage_result: Mutex::new(None),
         }
     }
 
@@ -75,6 +84,11 @@ impl MockOrchestrator {
     /// Set what conflict triage to return next.
     pub fn set_conflict_triage(&self, triage: ConflictTriage) {
         *self.conflict_triage.lock().unwrap() = Some(triage);
+    }
+
+    /// Set what triage decomposition to return next.
+    pub fn set_triage_result(&self, result: TriageResult) {
+        *self.triage_result.lock().unwrap() = Some(result);
     }
 }
 
@@ -123,6 +137,23 @@ impl Orchestrator for MockOrchestrator {
     ) -> Result<String, OrchestratorError> {
         *self.answer_question_count.lock().unwrap() += 1;
         Ok("Mock: proceed with whatever approach you think is best.".to_string())
+    }
+
+    async fn triage(
+        &self,
+        _context: &TriageContext,
+    ) -> Result<TriageResult, OrchestratorError> {
+        *self.triage_decompose_count.lock().unwrap() += 1;
+        let override_result = self.triage_result.lock().unwrap().clone();
+        Ok(override_result.unwrap_or_else(|| TriageResult {
+            analysis: "Mock: single issue created from request.".to_string(),
+            issues: vec![IssueDraft {
+                title: "Mock issue".to_string(),
+                body: "Created by mock orchestrator.".to_string(),
+                labels: vec![],
+                blocked_by: vec![],
+            }],
+        }))
     }
 }
 
@@ -263,5 +294,49 @@ mod tests {
         let result = mock.answer_question(&ctx).await.unwrap();
         assert!(!result.is_empty());
         assert_eq!(*mock.answer_question_count.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_triage_default() {
+        let mock = MockOrchestrator::approving();
+        let ctx = TriageContext {
+            description: "Add rate limiting to the API".to_string(),
+            project: Project::new("proj-1", "owner/repo"),
+            existing_issues: vec![],
+        };
+        let result = mock.triage(&ctx).await.unwrap();
+        assert!(!result.issues.is_empty());
+        assert_eq!(*mock.triage_decompose_count.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_triage_custom_result() {
+        let mock = MockOrchestrator::approving();
+        mock.set_triage_result(TriageResult {
+            analysis: "Custom analysis".to_string(),
+            issues: vec![
+                IssueDraft {
+                    title: "First issue".to_string(),
+                    body: "Body 1".to_string(),
+                    labels: vec!["enhancement".to_string()],
+                    blocked_by: vec![],
+                },
+                IssueDraft {
+                    title: "Second issue".to_string(),
+                    body: "Body 2".to_string(),
+                    labels: vec![],
+                    blocked_by: vec![0],
+                },
+            ],
+        });
+        let ctx = TriageContext {
+            description: "Something".to_string(),
+            project: Project::new("proj-1", "owner/repo"),
+            existing_issues: vec![],
+        };
+        let result = mock.triage(&ctx).await.unwrap();
+        assert_eq!(result.analysis, "Custom analysis");
+        assert_eq!(result.issues.len(), 2);
+        assert_eq!(result.issues[1].blocked_by, vec![0]);
     }
 }

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -11,7 +11,7 @@
 use crate::error::OrchestratorError;
 use crate::types::{
     ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction, QualityEvaluation,
-    QuestionContext, SystemContext,
+    QuestionContext, SystemContext, TriageContext, TriageResult,
 };
 use models::task::Task;
 
@@ -80,4 +80,18 @@ pub trait Orchestrator: Sync {
         &self,
         context: &QuestionContext,
     ) -> Result<String, OrchestratorError>;
+
+    /// Triage and decompose natural language into actionable issues.
+    ///
+    /// Spec §4.2: When the human describes work in natural language, the
+    /// orchestrator turns it into well-formed issues — organized, contextualized,
+    /// and split into sub-issues as needed.
+    ///
+    /// Returns a `TriageResult` with draft issues for human review. The caller
+    /// is responsible for presenting these to the human and creating them on
+    /// GitHub after approval.
+    async fn triage(
+        &self,
+        context: &TriageContext,
+    ) -> Result<TriageResult, OrchestratorError>;
 }

--- a/crates/orchestrator/src/prompt.rs
+++ b/crates/orchestrator/src/prompt.rs
@@ -288,6 +288,91 @@ pub fn parse_pr_url(url: &str) -> Option<(String, String, u64)> {
     Some((owner, repo, number))
 }
 
+/// Build the system prompt for triage and decomposition.
+pub fn triage_system_prompt() -> String {
+    r#"You are a project foreman decomposing work into well-formed GitHub issues.
+
+## Your Role
+
+The human has described work in natural language. Your job is to:
+1. Analyze the request and understand its scope
+2. Decompose it into concrete, actionable issues
+3. Define clear acceptance criteria for each issue
+4. Identify dependencies between issues
+5. Reference relevant code when possible
+
+## Output Format
+
+Respond with JSON:
+```json
+{
+  "analysis": "Brief analysis of the request — what it entails, key considerations, estimated complexity",
+  "issues": [
+    {
+      "title": "Short, actionable title (imperative mood, e.g., 'Add rate limiting middleware')",
+      "body": "Markdown body with:\n## Context\nWhy this is needed.\n\n## Requirements\n- Bullet list of specific requirements\n\n## Acceptance Criteria\n- [ ] Checkboxes for done criteria\n\n## Notes\nRelevant code paths, files, or architectural considerations.",
+      "labels": ["enhancement"],
+      "blocked_by": []
+    }
+  ]
+}
+```
+
+## Decomposition Principles
+
+- **Right-sized issues**: Each issue should be completable by a single agent session (a few hours of focused work). If something is too big, split it.
+- **Clear boundaries**: Each issue should have a clear scope — no ambiguity about what "done" looks like.
+- **Dependency ordering**: Use `blocked_by` to reference other issues in the batch by their zero-based index. Issue 0 is the first in the array. Only add dependencies when there's a true ordering constraint (e.g., API must exist before UI can call it).
+- **No unnecessary decomposition**: If the work is simple and fits in one issue, return one issue. Don't split for the sake of splitting.
+- **Actionable titles**: Use imperative mood ("Add X", "Fix Y", "Refactor Z"), not descriptions ("X should be added").
+- **Reference code**: When you know which files, modules, or functions are involved, mention them in the issue body.
+- **Labels**: Use standard labels — "enhancement", "bug", "refactor", "documentation", "testing". Only include labels that genuinely apply.
+
+## Existing Issues
+
+You'll receive a list of existing open issues for context. Avoid creating duplicates. If an existing issue already covers part of the request, reference it instead of creating a new one.
+
+## Key Rules
+
+- Respond ONLY with the JSON object — no prose before or after.
+- The `blocked_by` field uses zero-based indices into the `issues` array.
+- Every issue must have a non-empty title and body.
+- Keep analysis concise (2-4 sentences)."#.to_string()
+}
+
+/// Build the user prompt for triage decomposition.
+pub fn build_triage_prompt(
+    description: &str,
+    repo: &str,
+    existing_issues: &[crate::types::TriageIssueSummary],
+) -> String {
+    let mut prompt = format!(
+        "## Work Request\n\n\
+         **Repository:** {repo}\n\n\
+         {description}\n\n"
+    );
+
+    if !existing_issues.is_empty() {
+        prompt.push_str("## Existing Open Issues\n\n");
+        for issue in existing_issues.iter().take(30) {
+            let labels = if issue.labels.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", issue.labels.join(", "))
+            };
+            prompt.push_str(&format!("- #{}: {}{}\n", issue.number, issue.title, labels));
+        }
+        prompt.push('\n');
+    }
+
+    prompt.push_str("## Instructions\n\n\
+         Decompose the work request above into well-formed GitHub issues. \
+         Consider the existing issues to avoid duplicates. \
+         Respond with your JSON decomposition.");
+
+    prompt
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -580,5 +665,56 @@ mod tests {
         let prompt = system_prompt();
         assert!(prompt.contains("Queue context"));
         assert!(prompt.contains("queue ordering"));
+    }
+
+    #[test]
+    fn test_triage_system_prompt_contains_key_instructions() {
+        let prompt = triage_system_prompt();
+        assert!(prompt.contains("decompos"));
+        assert!(prompt.contains("blocked_by"));
+        assert!(prompt.contains("acceptance criteria"));
+        assert!(prompt.contains("JSON"));
+        assert!(prompt.contains("zero-based"));
+    }
+
+    #[test]
+    fn test_build_triage_prompt_basic() {
+        let prompt = build_triage_prompt(
+            "Add rate limiting to the API",
+            "owner/repo",
+            &[],
+        );
+        assert!(prompt.contains("Add rate limiting to the API"));
+        assert!(prompt.contains("owner/repo"));
+        assert!(prompt.contains("Decompose"));
+    }
+
+    #[test]
+    fn test_build_triage_prompt_with_existing_issues() {
+        use crate::types::TriageIssueSummary;
+
+        let existing = vec![
+            TriageIssueSummary {
+                number: 10,
+                title: "Add auth middleware".to_string(),
+                labels: vec!["enhancement".to_string()],
+            },
+            TriageIssueSummary {
+                number: 11,
+                title: "Fix rate limit header".to_string(),
+                labels: vec!["bug".to_string()],
+            },
+        ];
+
+        let prompt = build_triage_prompt(
+            "Add rate limiting to the API",
+            "owner/repo",
+            &existing,
+        );
+        assert!(prompt.contains("#10: Add auth middleware"));
+        assert!(prompt.contains("[enhancement]"));
+        assert!(prompt.contains("#11: Fix rate limit header"));
+        assert!(prompt.contains("[bug]"));
+        assert!(prompt.contains("avoid duplicates"));
     }
 }

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -279,6 +279,62 @@ pub struct SystemContext {
     pub last_think_at: Option<DateTime<Utc>>,
 }
 
+/// A draft issue produced by triage decomposition.
+///
+/// The orchestrator generates these from natural language input. They are
+/// presented to the human for review before being created on GitHub.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueDraft {
+    /// Issue title — concise, actionable.
+    pub title: String,
+    /// Issue body — context, acceptance criteria, references to code.
+    pub body: String,
+    /// Labels to apply (e.g., "enhancement", "bug").
+    #[serde(default)]
+    pub labels: Vec<String>,
+    /// IDs (indices) of other drafts in the same batch that this depends on.
+    /// Uses zero-based indices into the `issues` vec of `TriageResult`.
+    #[serde(default)]
+    pub blocked_by: Vec<usize>,
+}
+
+/// Context for triage and decomposition — spec §4.2.
+///
+/// When the human describes work in natural language, the orchestrator
+/// decomposes it into concrete, actionable issues.
+pub struct TriageContext {
+    /// The human's natural language description of work to be done.
+    pub description: String,
+    /// The project this work is for.
+    pub project: Project,
+    /// Existing open issues (for dedup and context).
+    pub existing_issues: Vec<TriageIssueSummary>,
+}
+
+/// Summary of an existing issue for triage context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriageIssueSummary {
+    /// Issue number.
+    pub number: u64,
+    /// Issue title.
+    pub title: String,
+    /// Labels on the issue.
+    pub labels: Vec<String>,
+}
+
+/// Result of triage decomposition.
+///
+/// Contains the orchestrator's analysis and a set of draft issues
+/// ready for human review and GitHub creation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriageResult {
+    /// High-level analysis of the request.
+    pub analysis: String,
+    /// Draft issues to create, ordered by suggested execution sequence.
+    /// Dependencies reference indices within this vec.
+    pub issues: Vec<IssueDraft>,
+}
+
 /// Actions the orchestrator can request from its think() pass.
 ///
 /// The run loop interprets these and executes them against the server.
@@ -297,7 +353,11 @@ pub enum OrchestratorAction {
         task_id: String,
         reason: String,
     },
-    // Future: DispatchAgent { task_id: String, config: DispatchConfig }
-    // Future: CreateIssue { repo: String, title: String, body: String }
-    // Future: CommentOnPr { pr_url: String, body: String }
+    /// Create a GitHub issue from a draft produced by triage.
+    CreateIssue {
+        /// Repository in "owner/repo" format.
+        repo: String,
+        /// The issue draft to create.
+        draft: IssueDraft,
+    },
 }


### PR DESCRIPTION
## Summary

Implements the orchestrator's triage and decomposition capability per spec §4.2: "When the human describes work in natural language, the orchestrator turns that into well-formed issues — organized, contextualized, and split into sub-issues as needed."

- **New types**: `TriageContext`, `TriageResult`, `IssueDraft`, `TriageIssueSummary` for representing triage input/output
- **Orchestrator trait**: Added `triage()` method alongside existing `evaluate`, `think`, `answer_question`
- **ClaudeOrchestrator**: LLM-powered decomposition with structured JSON output, dependency validation (blocked_by indices), and error handling
- **Triage prompts**: Detailed system prompt with decomposition principles (right-sized issues, clear boundaries, dependency ordering, no unnecessary splitting) and structured JSON output format
- **OrchestratorChat**: `triage()` method for chat-driven decomposition with human-readable formatting of results
- **OrchestratorAction::CreateIssue**: New action variant replacing the commented-out future placeholder
- **MockOrchestrator**: Full triage support with configurable results for testing
- **7 new tests** (50 total, all passing)

### Architecture

The triage flow:
1. Human describes work via chat → `OrchestratorChat::triage()` or `Orchestrator::triage()`
2. LLM decomposes into `TriageResult` with `IssueDraft` items
3. Each draft has title, body (with acceptance criteria), labels, and `blocked_by` dependency indices
4. Result returned for human review before GitHub creation
5. `OrchestratorAction::CreateIssue` enables the run loop to create issues after approval

The GitHub client already has `create_issue()`, `add_labels()`, and `post_issue_comment()` — wiring the run loop to execute `CreateIssue` actions is a follow-up.

## Test plan

- [x] All 50 orchestrator tests pass (`cargo test --package tasks-orchestrator`)
- [x] Clean compilation with no warnings
- [x] Triage JSON parsing validated with structured test
- [x] Mock orchestrator supports configurable triage results
- [x] Prompt templates tested for key content

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)