### PR TITLE
Orchestrator: diagnose failures and suggest recovery actions

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -22,8 +22,8 @@ use tasks_github::model::{IssueState, MergeableState, PullRequestState};
 use tasks_github::poller::RepoPoller;
 
 use tasks_orchestrator::{
-    ChatContext, ConflictContext, ConflictResolution, OperatingMode, Orchestrator,
-    OrchestratorAction, OrchestratorChat, QuestionContext, SystemContext,
+    ChatContext, ConflictContext, ConflictResolution, FailureContext, OperatingMode, Orchestrator,
+    OrchestratorAction, OrchestratorChat, QuestionContext, RecoveryAction, SystemContext,
 };
 
 use crate::config::AppConfig;
@@ -917,6 +917,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     let event_handler_server = server.clone();
     let event_handler_bus = server.event_bus.clone();
     let event_handler_max_retries = config.max_retries;
+    let event_handler_orch = orchestrator.clone();
     let mut event_handler_shutdown_rx = shutdown_tx.subscribe();
 
     let event_handler_handle = tokio::spawn(async move {
@@ -1017,17 +1018,35 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                 let failure_info = event.data.get("failure_info")
                     .and_then(|v| serde_json::from_value(v.clone()).ok());
 
-                if let Err(e) = event_handler_server
+                match event_handler_server
                     .handle_task_failure(task_id, made_progress, event_handler_max_retries, failure_info)
                     .await
                 {
-                    if !matches!(e, server::ServerError::TaskNotFound(_)) {
-                        error!(
-                            task_id = %task_id,
-                            made_progress = made_progress,
-                            error = %e,
-                            "failed to handle task failure"
-                        );
+                    Ok(will_retry) => {
+                        if !will_retry {
+                            // Retries exhausted — ask orchestrator to diagnose (spec §14.4)
+                            let task_id_owned = task_id.to_string();
+                            let diag_server = event_handler_server.clone();
+                            let diag_orch = event_handler_orch.clone();
+                            tokio::spawn(async move {
+                                diagnose_and_act(
+                                    &diag_server,
+                                    diag_orch.as_ref(),
+                                    &task_id_owned,
+                                )
+                                .await;
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        if !matches!(e, server::ServerError::TaskNotFound(_)) {
+                            error!(
+                                task_id = %task_id,
+                                made_progress = made_progress,
+                                error = %e,
+                                "failed to handle task failure"
+                            );
+                        }
                     }
                 }
                 continue;
@@ -2590,6 +2609,15 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                             OrchestratorAction::PrioritizeTask { task_id, reason } => {
                                 info!(task_id = %task_id, reason = %reason, "orchestrator requested task prioritization (not yet implemented)");
                             }
+                            OrchestratorAction::RetryWithGuidance { task_id, guidance } => {
+                                info!(task_id = %task_id, "orchestrator requested retry with guidance");
+                                if let Err(e) = think_server
+                                    .retry_failed_task_with_guidance(&task_id, &guidance)
+                                    .await
+                                {
+                                    error!(task_id = %task_id, error = %e, "failed to retry task with guidance from think()");
+                                }
+                            }
                         }
                     }
                 }
@@ -2919,5 +2947,143 @@ async fn load_workflow_settings_for_project(
     ProjectWorkflowSettings {
         system_prompt,
         progress_threshold,
+    }
+}
+
+/// Diagnose a failed task and take recovery action (spec §14.4).
+///
+/// Called asynchronously when a task reaches terminal Failed state (retries
+/// exhausted). The orchestrator analyzes the failure and suggests a recovery.
+/// In Play mode with high confidence, the recovery is executed automatically.
+/// Otherwise, the diagnosis is emitted as narration for the human.
+async fn diagnose_and_act(
+    server: &Server,
+    orchestrator: &(dyn Orchestrator + Send + Sync),
+    task_id: &str,
+) {
+    // Fetch task and project
+    let (task, project) = {
+        let state = server.state.read().await;
+        let Some(task) = state.tasks.get(task_id).cloned() else {
+            return;
+        };
+        let Some(project) = state.projects.get(&task.project).cloned() else {
+            return;
+        };
+        (task, project)
+    };
+
+    let mode = match server.mode().await {
+        server::Mode::Play => OperatingMode::Play,
+        server::Mode::Pause => OperatingMode::Pause,
+        server::Mode::Stop => return, // No diagnosis in Stop mode
+    };
+
+    let context = FailureContext {
+        task: task.clone(),
+        project,
+        mode,
+        human_present: server.is_human_present(),
+    };
+
+    let diagnosis = match orchestrator.diagnose_failure(&context).await {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(
+                task_id = %task_id,
+                error = %e,
+                "failed to diagnose task failure"
+            );
+            return;
+        }
+    };
+
+    info!(
+        task_id = %task_id,
+        category = ?diagnosis.category,
+        confidence = diagnosis.confidence,
+        "failure diagnosis complete"
+    );
+
+    // Emit the diagnosis as an orchestrator thought
+    let thought = format!(
+        "Diagnosed failure for task {}: {:?} (confidence: {:.0}%). {}",
+        &task_id[..8.min(task_id.len())],
+        diagnosis.category,
+        diagnosis.confidence * 100.0,
+        diagnosis.reasoning,
+    );
+    let event = Event::new(
+        EventType::OrchestratorThought,
+        task_id,
+        Actor::Orchestrator,
+        serde_json::json!({
+            "message": thought,
+            "diagnosis": diagnosis,
+        }),
+    );
+    if let Err(e) = server.event_bus.publish(event).await {
+        error!(error = %e, "failed to publish diagnosis thought");
+    }
+
+    // In Play mode with high confidence, execute recovery automatically
+    let auto_confidence_threshold = 0.7;
+    let should_auto_recover =
+        mode == OperatingMode::Play && diagnosis.confidence >= auto_confidence_threshold;
+
+    match &diagnosis.recovery {
+        RecoveryAction::Retry { guidance } if should_auto_recover => {
+            info!(
+                task_id = %task_id,
+                "auto-recovering: retry with guidance"
+            );
+            // Store guidance as rejection_feedback (reuses existing mechanism
+            // for delivering orchestrator feedback to re-dispatched agents)
+            if let Err(e) = server
+                .retry_failed_task_with_guidance(task_id, guidance)
+                .await
+            {
+                error!(
+                    task_id = %task_id,
+                    error = %e,
+                    "failed to retry task with guidance"
+                );
+            }
+        }
+        RecoveryAction::Retry { guidance } => {
+            // Not auto-recovering — emit suggestion for the human
+            let suggestion = Event::new(
+                EventType::OrchestratorThought,
+                task_id,
+                Actor::Orchestrator,
+                serde_json::json!({
+                    "message": format!(
+                        "Suggested recovery for task {}: retry with guidance — {}",
+                        &task_id[..8.min(task_id.len())],
+                        guidance,
+                    ),
+                }),
+            );
+            if let Err(e) = server.event_bus.publish(suggestion).await {
+                error!(error = %e, "failed to publish recovery suggestion");
+            }
+        }
+        RecoveryAction::Escalate { summary } => {
+            let escalation = Event::new(
+                EventType::OrchestratorThought,
+                task_id,
+                Actor::Orchestrator,
+                serde_json::json!({
+                    "message": format!(
+                        "Escalating task {} to human: {}",
+                        &task_id[..8.min(task_id.len())],
+                        summary,
+                    ),
+                }),
+            );
+            if let Err(e) = server.event_bus.publish(escalation).await {
+                error!(error = %e, "failed to publish escalation");
+            }
+        }
     }
 }

--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -8,10 +8,14 @@ use tracing::{info, warn};
 
 use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
-use crate::prompt::{build_evaluation_prompt, build_deep_review_prompt, parse_pr_url, system_prompt};
+use crate::prompt::{
+    build_evaluation_prompt, build_deep_review_prompt, build_failure_diagnosis_prompt,
+    failure_diagnosis_system_prompt, parse_pr_url, system_prompt,
+};
 use crate::types::{
-    default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
-    QualityEvaluation, QuestionContext, SystemContext,
+    default_triage, ConflictContext, ConflictTriage, EvaluationContext, FailureCategory,
+    FailureContext, FailureDiagnosis, OrchestratorAction, QualityEvaluation, QuestionContext,
+    RecoveryAction, SystemContext,
 };
 use events::EventType;
 use models::task::{Task, TaskSource};
@@ -518,6 +522,116 @@ impl Orchestrator for ClaudeOrchestrator {
 
         Ok(answer)
     }
+
+    async fn diagnose_failure(
+        &self,
+        context: &FailureContext,
+    ) -> Result<FailureDiagnosis, OrchestratorError> {
+        info!(
+            task_id = %context.task.id,
+            retry_count = context.task.retry_count,
+            "Diagnosing task failure"
+        );
+
+        let system = failure_diagnosis_system_prompt();
+
+        let user_prompt = build_failure_diagnosis_prompt(
+            &context.task.title,
+            context.task.description.as_deref(),
+            &context.project.repo,
+            context.task.last_failure.as_ref(),
+            context.task.retry_count,
+        );
+
+        // Use a smaller max_tokens — diagnosis responses are concise
+        let config = CompletionConfig::new(&self.model).with_max_tokens(4096);
+        let request = CompletionRequest::new(config, vec![Message::user(user_prompt)])
+            .with_system(system);
+
+        let response = self
+            .provider
+            .complete(request)
+            .await
+            .map_err(OrchestratorError::Agent)?;
+
+        let response_text = response.text();
+        info!(
+            task_id = %context.task.id,
+            response_len = response_text.len(),
+            "Received failure diagnosis response"
+        );
+
+        parse_diagnosis_response(&response_text)
+    }
+}
+
+/// Parse the LLM's failure diagnosis JSON response.
+fn parse_diagnosis_response(text: &str) -> Result<FailureDiagnosis, OrchestratorError> {
+    let json_str = extract_json(text).ok_or_else(|| {
+        OrchestratorError::Evaluation(format!(
+            "Could not find JSON in diagnosis response: {}",
+            truncate(text, 200)
+        ))
+    })?;
+
+    let parsed: DiagnosisResponse = serde_json::from_str(json_str).map_err(|e| {
+        OrchestratorError::Evaluation(format!("Failed to parse diagnosis JSON: {}", e))
+    })?;
+
+    if parsed.reasoning.trim().is_empty() {
+        return Err(OrchestratorError::Evaluation(
+            "Diagnosis reasoning must not be empty".to_string(),
+        ));
+    }
+
+    let confidence = parsed.confidence.clamp(0.0, 1.0);
+
+    let recovery = match parsed.recovery.action.as_str() {
+        "retry" => RecoveryAction::Retry {
+            guidance: parsed.recovery.guidance.unwrap_or_else(|| {
+                "Retry the task with a different approach.".to_string()
+            }),
+        },
+        "escalate" => RecoveryAction::Escalate {
+            summary: parsed.recovery.summary.unwrap_or_else(|| {
+                parsed.reasoning.clone()
+            }),
+        },
+        other => {
+            warn!(action = %other, "Unknown recovery action, defaulting to escalate");
+            RecoveryAction::Escalate {
+                summary: parsed.reasoning.clone(),
+            }
+        }
+    };
+
+    Ok(FailureDiagnosis {
+        category: parsed.category,
+        reasoning: parsed.reasoning,
+        recovery,
+        confidence,
+    })
+}
+
+/// Internal struct for parsing the LLM's diagnosis JSON response.
+#[derive(Deserialize)]
+struct DiagnosisResponse {
+    category: FailureCategory,
+    reasoning: String,
+    recovery: DiagnosisRecovery,
+    #[serde(default = "default_confidence")]
+    confidence: f32,
+}
+
+#[derive(Deserialize)]
+struct DiagnosisRecovery {
+    action: String,
+    guidance: Option<String>,
+    summary: Option<String>,
+}
+
+fn default_confidence() -> f32 {
+    0.5
 }
 
 /// Build the system prompt for answering agent questions.
@@ -644,6 +758,7 @@ mod tests {
             provider: AnthropicProvider::new("test-key"),
             github: GitHubClient::new("test-token"),
             model: DEFAULT_MODEL.to_string(),
+            max_tokens: DEFAULT_MAX_TOKENS,
         }
     }
 
@@ -727,5 +842,82 @@ That's all."#;
     fn test_extract_json_none() {
         assert!(extract_json("no json here").is_none());
         assert!(extract_json("incomplete { json").is_none());
+    }
+
+    #[test]
+    fn test_parse_diagnosis_retry() {
+        let text = r#"```json
+{
+  "category": "code_bug",
+  "reasoning": "The agent used the wrong API endpoint",
+  "recovery": {
+    "action": "retry",
+    "guidance": "Use /api/v2/users instead of /api/v1/users"
+  },
+  "confidence": 0.85
+}
+```"#;
+        let result = parse_diagnosis_response(text).unwrap();
+        assert_eq!(result.category, FailureCategory::CodeBug);
+        assert!(result.reasoning.contains("wrong API endpoint"));
+        assert!(matches!(result.recovery, RecoveryAction::Retry { .. }));
+        assert!((result.confidence - 0.85).abs() < f32::EPSILON);
+        if let RecoveryAction::Retry { guidance } = &result.recovery {
+            assert!(guidance.contains("/api/v2/users"));
+        }
+    }
+
+    #[test]
+    fn test_parse_diagnosis_escalate() {
+        let text = r#"{
+  "category": "task_too_complex",
+  "reasoning": "The task requires changes across 15 files",
+  "recovery": {
+    "action": "escalate",
+    "summary": "Break this task into smaller subtasks"
+  },
+  "confidence": 0.6
+}"#;
+        let result = parse_diagnosis_response(text).unwrap();
+        assert_eq!(result.category, FailureCategory::TaskTooComplex);
+        assert!(matches!(result.recovery, RecoveryAction::Escalate { .. }));
+        assert!((result.confidence - 0.6).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_diagnosis_environment() {
+        let text = r#"{"category": "environment", "reasoning": "OOM kill", "recovery": {"action": "retry", "guidance": "Process files in smaller batches"}, "confidence": 0.9}"#;
+        let result = parse_diagnosis_response(text).unwrap();
+        assert_eq!(result.category, FailureCategory::Environment);
+        assert!((result.confidence - 0.9).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_diagnosis_missing_confidence_defaults() {
+        let text = r#"{"category": "flaky", "reasoning": "Intermittent failure", "recovery": {"action": "retry", "guidance": "Just retry"}}"#;
+        let result = parse_diagnosis_response(text).unwrap();
+        assert_eq!(result.category, FailureCategory::Flaky);
+        assert!((result.confidence - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_diagnosis_clamps_confidence() {
+        let text = r#"{"category": "code_bug", "reasoning": "Bug", "recovery": {"action": "escalate", "summary": "Help"}, "confidence": 1.5}"#;
+        let result = parse_diagnosis_response(text).unwrap();
+        assert!((result.confidence - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_diagnosis_unknown_action_defaults_to_escalate() {
+        let text = r#"{"category": "code_bug", "reasoning": "Bug", "recovery": {"action": "break_down"}, "confidence": 0.5}"#;
+        let result = parse_diagnosis_response(text).unwrap();
+        assert!(matches!(result.recovery, RecoveryAction::Escalate { .. }));
+    }
+
+    #[test]
+    fn test_parse_diagnosis_empty_reasoning_rejected() {
+        let text = r#"{"category": "flaky", "reasoning": "", "recovery": {"action": "retry", "guidance": "Try again"}, "confidence": 0.8}"#;
+        let result = parse_diagnosis_response(text);
+        assert!(result.is_err());
     }
 }

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -21,6 +21,7 @@ pub use mock::MockOrchestrator;
 pub use orchestrator::Orchestrator;
 pub use prompt::parse_pr_url;
 pub use types::{
-    ConflictContext, ConflictResolution, ConflictTriage, EvaluationContext, OperatingMode,
-    OrchestratorAction, QualityEvaluation, QuestionContext, QueueEntrySummary, SystemContext,
+    ConflictContext, ConflictResolution, ConflictTriage, EvaluationContext, FailureCategory,
+    FailureContext, FailureDiagnosis, OperatingMode, OrchestratorAction, QualityEvaluation,
+    QuestionContext, QueueEntrySummary, RecoveryAction, SystemContext,
 };

--- a/crates/orchestrator/src/mock.rs
+++ b/crates/orchestrator/src/mock.rs
@@ -5,8 +5,9 @@ use std::sync::Mutex;
 use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
 use crate::types::{
-    default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
-    QualityEvaluation, QuestionContext, SystemContext,
+    default_triage, ConflictContext, ConflictTriage, EvaluationContext, FailureCategory,
+    FailureContext, FailureDiagnosis, OrchestratorAction, QualityEvaluation, QuestionContext,
+    RecoveryAction, SystemContext,
 };
 use models::task::Task;
 
@@ -29,6 +30,10 @@ pub struct MockOrchestrator {
     pub think_count: Mutex<u32>,
     /// Count of answer_question calls (for assertions).
     pub answer_question_count: Mutex<u32>,
+    /// Count of diagnose_failure calls (for assertions).
+    pub diagnose_failure_count: Mutex<u32>,
+    /// Optional failure diagnosis override.
+    failure_diagnosis: Mutex<Option<FailureDiagnosis>>,
 }
 
 impl MockOrchestrator {
@@ -46,6 +51,8 @@ impl MockOrchestrator {
             triage_count: Mutex::new(0),
             think_count: Mutex::new(0),
             answer_question_count: Mutex::new(0),
+            diagnose_failure_count: Mutex::new(0),
+            failure_diagnosis: Mutex::new(None),
         }
     }
 
@@ -64,6 +71,8 @@ impl MockOrchestrator {
             triage_count: Mutex::new(0),
             think_count: Mutex::new(0),
             answer_question_count: Mutex::new(0),
+            diagnose_failure_count: Mutex::new(0),
+            failure_diagnosis: Mutex::new(None),
         }
     }
 
@@ -75,6 +84,11 @@ impl MockOrchestrator {
     /// Set what conflict triage to return next.
     pub fn set_conflict_triage(&self, triage: ConflictTriage) {
         *self.conflict_triage.lock().unwrap() = Some(triage);
+    }
+
+    /// Set what failure diagnosis to return next.
+    pub fn set_failure_diagnosis(&self, diagnosis: FailureDiagnosis) {
+        *self.failure_diagnosis.lock().unwrap() = Some(diagnosis);
     }
 }
 
@@ -123,6 +137,22 @@ impl Orchestrator for MockOrchestrator {
     ) -> Result<String, OrchestratorError> {
         *self.answer_question_count.lock().unwrap() += 1;
         Ok("Mock: proceed with whatever approach you think is best.".to_string())
+    }
+
+    async fn diagnose_failure(
+        &self,
+        _context: &FailureContext,
+    ) -> Result<FailureDiagnosis, OrchestratorError> {
+        *self.diagnose_failure_count.lock().unwrap() += 1;
+        let override_diagnosis = self.failure_diagnosis.lock().unwrap().clone();
+        Ok(override_diagnosis.unwrap_or_else(|| FailureDiagnosis {
+            category: FailureCategory::CodeBug,
+            reasoning: "Mock: default diagnosis".to_string(),
+            recovery: RecoveryAction::Escalate {
+                summary: "Mock: task failed, needs human review".to_string(),
+            },
+            confidence: 0.5,
+        }))
     }
 }
 
@@ -263,5 +293,45 @@ mod tests {
         let result = mock.answer_question(&ctx).await.unwrap();
         assert!(!result.is_empty());
         assert_eq!(*mock.answer_question_count.lock().unwrap(), 1);
+    }
+
+    fn test_failure_context() -> FailureContext {
+        let mut task = Task::new("task-1", TaskSource::Internal, "Test task", "proj-1");
+        task.state = models::task::TaskState::Failed;
+        task.retry_count = 3;
+        FailureContext {
+            task,
+            project: Project::new("proj-1", "owner/repo"),
+            mode: OperatingMode::Play,
+            human_present: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_diagnose_failure_default() {
+        let mock = MockOrchestrator::approving();
+        let ctx = test_failure_context();
+        let result = mock.diagnose_failure(&ctx).await.unwrap();
+        assert_eq!(result.category, FailureCategory::CodeBug);
+        assert!(matches!(result.recovery, RecoveryAction::Escalate { .. }));
+        assert_eq!(*mock.diagnose_failure_count.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_diagnose_failure_override() {
+        let mock = MockOrchestrator::approving();
+        mock.set_failure_diagnosis(FailureDiagnosis {
+            category: FailureCategory::Environment,
+            reasoning: "OOM kill".to_string(),
+            recovery: RecoveryAction::Retry {
+                guidance: "Use smaller batch size".to_string(),
+            },
+            confidence: 0.9,
+        });
+        let ctx = test_failure_context();
+        let result = mock.diagnose_failure(&ctx).await.unwrap();
+        assert_eq!(result.category, FailureCategory::Environment);
+        assert!(matches!(result.recovery, RecoveryAction::Retry { .. }));
+        assert!((result.confidence - 0.9).abs() < f32::EPSILON);
     }
 }

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -10,8 +10,8 @@
 
 use crate::error::OrchestratorError;
 use crate::types::{
-    ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction, QualityEvaluation,
-    QuestionContext, SystemContext,
+    ConflictContext, ConflictTriage, EvaluationContext, FailureContext, FailureDiagnosis,
+    OrchestratorAction, QualityEvaluation, QuestionContext, SystemContext,
 };
 use models::task::Task;
 
@@ -80,4 +80,19 @@ pub trait Orchestrator: Sync {
         &self,
         context: &QuestionContext,
     ) -> Result<String, OrchestratorError>;
+
+    /// Diagnose a task failure and suggest recovery — spec §14.4.
+    ///
+    /// Called when a task reaches terminal Failed state (retries exhausted).
+    /// The orchestrator examines the failure context (exit code, stderr,
+    /// failure classification) and returns a diagnosis with a concrete
+    /// recovery action.
+    ///
+    /// The caller (run loop) decides whether to execute the recovery
+    /// automatically (Play mode + high confidence) or present it to
+    /// the human.
+    async fn diagnose_failure(
+        &self,
+        context: &FailureContext,
+    ) -> Result<FailureDiagnosis, OrchestratorError>;
 }

--- a/crates/orchestrator/src/prompt.rs
+++ b/crates/orchestrator/src/prompt.rs
@@ -255,6 +255,112 @@ pub fn build_deep_review_prompt(
     prompt
 }
 
+/// Build the system prompt for failure diagnosis (spec §14.4).
+pub fn failure_diagnosis_system_prompt() -> String {
+    r#"You are an engineering manager diagnosing why a coding task failed.
+
+A task was assigned to an AI coding agent. The agent attempted the task (possibly multiple times) but ultimately failed. Your job is to analyze the failure evidence and recommend a concrete recovery action.
+
+## Failure categories
+
+Classify the failure into exactly one:
+- **environment**: Container, network, or resource issues (OOM, disk full, rate limits, DNS failures, timeouts). These are infrastructure problems, not code problems.
+- **task_too_complex**: The task is too large or ambiguous for a single agent session. The agent made partial progress but couldn't complete everything.
+- **missing_context**: The agent lacked necessary context — unclear requirements, missing information about the codebase, or ambiguous acceptance criteria.
+- **code_bug**: The agent's implementation approach was wrong — compilation errors, test failures from incorrect logic, wrong API usage.
+- **flaky**: The failure appears intermittent — the agent made progress on some attempts but not others, or the error is non-deterministic.
+
+## Recovery actions
+
+Recommend exactly one:
+- **retry**: Retry with specific guidance. Provide clear, actionable instructions that address the root cause. Good for: environment issues (with workaround), code bugs (with correction), flaky failures.
+- **escalate**: Surface to the human. Provide a clear summary of what went wrong and what the human should look at. Good for: complex tasks that need decomposition, missing context that only a human can provide, repeated failures with no clear fix.
+
+## Confidence
+
+Rate your confidence 0.0–1.0:
+- **0.8–1.0**: Root cause is clear from the evidence. Recovery action is specific and likely to work.
+- **0.5–0.7**: Probable cause identified but some uncertainty. Recovery might work.
+- **0.0–0.4**: Unclear what went wrong. Leaning toward escalation.
+
+## Response format (JSON)
+
+```json
+{
+  "category": "environment|task_too_complex|missing_context|code_bug|flaky",
+  "reasoning": "Analysis of the failure evidence",
+  "recovery": {
+    "action": "retry|escalate",
+    "guidance": "Specific instructions for retry (required if action=retry)",
+    "summary": "What to tell the human (required if action=escalate)"
+  },
+  "confidence": 0.75
+}
+```
+
+## Key principles
+
+- Be specific. "Retry with different parameters" is useless. "The OOM kill suggests the container needs more memory, but since we can't change that, retry with guidance to process files in smaller batches" is useful.
+- If the task failed 3+ times with no progress, lean toward escalation unless the failure is clearly environmental.
+- Look at the stderr output — it often contains the actual error.
+- Short sessions (< 30s) that fail usually indicate setup/environment problems. Longer sessions that fail usually indicate task complexity or code issues.
+- If multiple retry attempts all failed the same way, a retry with the same approach won't help. Either suggest a fundamentally different approach or escalate."#.to_string()
+}
+
+/// Build the user prompt for failure diagnosis.
+pub fn build_failure_diagnosis_prompt(
+    task_title: &str,
+    task_description: Option<&str>,
+    repo: &str,
+    failure_info: Option<&models::task::FailureInfo>,
+    retry_count: u32,
+) -> String {
+    let mut prompt = format!(
+        "## Failed Task\n\
+         **Repository:** {repo}\n\
+         **Title:** {task_title}\n"
+    );
+
+    if let Some(desc) = task_description {
+        prompt.push_str(&format!("**Description:** {}\n", truncate_text(desc, 2000)));
+    }
+
+    prompt.push_str(&format!("**Retry count:** {retry_count}\n\n"));
+
+    if let Some(info) = failure_info {
+        prompt.push_str("## Failure Details\n\n");
+        prompt.push_str(&format!("**Summary:** {}\n", info.summary));
+        prompt.push_str(&format!("**Type:** {:?}\n", info.failure_type));
+        prompt.push_str(&format!("**Duration:** {}s\n", info.duration_secs));
+
+        if let Some(code) = info.exit_code {
+            prompt.push_str(&format!("**Exit code:** {code}\n"));
+        }
+        if let Some(ref signal) = info.signal {
+            prompt.push_str(&format!("**Signal:** {signal}\n"));
+        }
+
+        if !info.stderr_tail.is_empty() {
+            prompt.push_str("\n### stderr (last lines)\n\n```\n");
+            // Include up to 50 lines of stderr, truncated to 5000 chars total
+            let stderr_text = info.stderr_tail.join("\n");
+            prompt.push_str(&truncate_text(&stderr_text, 5000));
+            prompt.push_str("\n```\n");
+        }
+    } else {
+        prompt.push_str("## Failure Details\n\n");
+        prompt.push_str("No detailed failure information available.\n");
+    }
+
+    prompt.push_str(
+        "\n## Instructions\n\n\
+         Diagnose the failure and recommend a recovery action. \
+         Respond with your diagnosis in the JSON format specified in your instructions."
+    );
+
+    prompt
+}
+
 /// Truncate text to a maximum length, adding ellipsis if truncated.
 fn truncate_text(text: &str, max_len: usize) -> String {
     if text.len() <= max_len {
@@ -580,5 +686,63 @@ mod tests {
         let prompt = system_prompt();
         assert!(prompt.contains("Queue context"));
         assert!(prompt.contains("queue ordering"));
+    }
+
+    #[test]
+    fn test_failure_diagnosis_system_prompt() {
+        let prompt = failure_diagnosis_system_prompt();
+        assert!(prompt.contains("environment"));
+        assert!(prompt.contains("task_too_complex"));
+        assert!(prompt.contains("missing_context"));
+        assert!(prompt.contains("code_bug"));
+        assert!(prompt.contains("retry"));
+        assert!(prompt.contains("escalate"));
+        assert!(prompt.contains("confidence"));
+    }
+
+    #[test]
+    fn test_build_failure_diagnosis_prompt_basic() {
+        let prompt = build_failure_diagnosis_prompt(
+            "Fix auth bug",
+            Some("The login flow is broken"),
+            "owner/repo",
+            None,
+            3,
+        );
+        assert!(prompt.contains("Fix auth bug"));
+        assert!(prompt.contains("login flow is broken"));
+        assert!(prompt.contains("owner/repo"));
+        assert!(prompt.contains("**Retry count:** 3"));
+        assert!(prompt.contains("No detailed failure information"));
+    }
+
+    #[test]
+    fn test_build_failure_diagnosis_prompt_with_failure_info() {
+        use models::task::{FailureInfo, FailureType};
+
+        let failure_info = FailureInfo {
+            exit_code: Some(1),
+            signal: None,
+            duration_secs: 45,
+            stderr_tail: vec![
+                "error[E0308]: mismatched types".to_string(),
+                "  --> src/main.rs:42:5".to_string(),
+            ],
+            failure_type: FailureType::Deterministic,
+            summary: "Process exited with code 1 (error)".to_string(),
+        };
+
+        let prompt = build_failure_diagnosis_prompt(
+            "Fix auth bug",
+            None,
+            "owner/repo",
+            Some(&failure_info),
+            1,
+        );
+        assert!(prompt.contains("**Exit code:** 1"));
+        assert!(prompt.contains("**Duration:** 45s"));
+        assert!(prompt.contains("Deterministic"));
+        assert!(prompt.contains("mismatched types"));
+        assert!(prompt.contains("src/main.rs:42:5"));
     }
 }

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -297,7 +297,78 @@ pub enum OrchestratorAction {
         task_id: String,
         reason: String,
     },
+    /// Retry a failed task with additional guidance for the agent.
+    ///
+    /// The run loop transitions the task to Waiting and stores the guidance
+    /// so it's included in the agent's prompt on re-dispatch.
+    RetryWithGuidance {
+        task_id: String,
+        guidance: String,
+    },
     // Future: DispatchAgent { task_id: String, config: DispatchConfig }
     // Future: CreateIssue { repo: String, title: String, body: String }
     // Future: CommentOnPr { pr_url: String, body: String }
+}
+
+/// Context for diagnosing a task failure — spec §14.4.
+///
+/// Provided to the orchestrator when a task reaches terminal Failed state
+/// (retries exhausted) so it can analyze the failure and suggest recovery.
+pub struct FailureContext {
+    /// The failed task (in Failed state).
+    pub task: Task,
+    /// The project this task belongs to.
+    pub project: Project,
+    /// Current operating mode.
+    pub mode: OperatingMode,
+    /// Whether a human is currently connected.
+    pub human_present: bool,
+}
+
+/// Classification of why a task failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureCategory {
+    /// Container, network, or resource issues (OOM, disk, rate limits).
+    Environment,
+    /// Task is too large or complex for a single agent session.
+    TaskTooComplex,
+    /// Agent lacked necessary context (unclear requirements, missing info).
+    MissingContext,
+    /// Implementation bug — the agent's approach was wrong.
+    CodeBug,
+    /// Intermittent issue that may resolve on a simple retry.
+    Flaky,
+}
+
+/// A concrete recovery action suggested by the orchestrator.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum RecoveryAction {
+    /// Retry the task with specific guidance to avoid the same failure.
+    Retry {
+        /// Guidance to include in the agent's prompt on retry.
+        guidance: String,
+    },
+    /// Escalate to the human with a specific question or summary.
+    Escalate {
+        /// Summary of what went wrong and what the human should look at.
+        summary: String,
+    },
+}
+
+/// Orchestrator's diagnosis of a task failure — spec §14.4.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailureDiagnosis {
+    /// What category of failure this is.
+    pub category: FailureCategory,
+    /// Explanation of the diagnosis.
+    pub reasoning: String,
+    /// Suggested recovery action.
+    pub recovery: RecoveryAction,
+    /// Confidence in the diagnosis (0.0–1.0).
+    /// Higher confidence means the orchestrator is more sure about the
+    /// root cause and recovery. In Play mode, high confidence (≥0.7)
+    /// enables automatic recovery execution.
+    pub confidence: f32,
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -2251,6 +2251,60 @@ impl Server {
         Ok(will_retry)
     }
 
+    /// Retry a failed task with orchestrator guidance (spec §14.4).
+    ///
+    /// Transitions the task from Failed to Waiting and stores the guidance
+    /// as `rejection_feedback` so it's included in the agent's prompt on
+    /// re-dispatch. Also resets retry_count to allow fresh attempts.
+    pub async fn retry_failed_task_with_guidance(
+        &self,
+        task_id: &str,
+        guidance: &str,
+    ) -> Result<(), ServerError> {
+        {
+            let mut state = self.state.write().await;
+            let task = state
+                .tasks
+                .get_mut(task_id)
+                .ok_or_else(|| ServerError::TaskNotFound(task_id.to_string()))?;
+
+            if task.state != TaskState::Failed {
+                return Err(ServerError::InvalidOperation(format!(
+                    "cannot retry task {} in state {:?} (expected Failed)",
+                    task_id, task.state
+                )));
+            }
+
+            task.retry_count = 0;
+            task.last_failure_at = None;
+            task.rejection_feedback = Some(guidance.to_string());
+            task.set_state(TaskState::Waiting);
+
+            if let Some(ref store) = self.store {
+                if let Err(e) = store.save_task(task) {
+                    tracing::error!(
+                        task_id = %task_id,
+                        error = %e,
+                        "failed to persist guided retry state to store"
+                    );
+                }
+            }
+        }
+
+        let event = Event::new(
+            EventType::TaskStateWaiting,
+            task_id,
+            Actor::Orchestrator,
+            serde_json::json!({
+                "reason": "orchestrator_guided_retry",
+                "has_guidance": true,
+            }),
+        );
+        self.event_bus.publish(event).await?;
+
+        Ok(())
+    }
+
     // --- Restart recovery (spec §13.3) ---
 
     /// Apply the results of orphan detection to task state.


### PR DESCRIPTION
## Summary

Implements spec §14.4: when a task exhausts retries and enters terminal Failed state, the orchestrator now diagnoses the failure and suggests concrete recovery actions.

- Adds `diagnose_failure` method to the `Orchestrator` trait with LLM-backed implementation
- Classifies failures into categories: environment, task_too_complex, missing_context, code_bug, flaky
- Suggests recovery actions: retry with specific guidance, or escalate to human
- In Play mode with high confidence (≥0.7), executes recovery automatically (retries the task with guidance)
- In Pause mode or low confidence, emits diagnosis as orchestrator narration for the human
- Adds `RetryWithGuidance` orchestrator action and `retry_failed_task_with_guidance` server method
- Integrates into the run_loop event handler — diagnosis runs asynchronously when retries exhaust
- 12 new tests covering diagnosis JSON parsing, mock orchestrator, and prompt generation

Closes #535

## Test plan

- [x] All 55 orchestrator tests pass (12 new)
- [x] Diagnosis JSON parsing handles all categories and recovery actions
- [x] Unknown actions default to escalation
- [x] Empty reasoning is rejected
- [x] Confidence is clamped to 0.0–1.0
- [x] Mock orchestrator supports configurable diagnosis responses
- [x] Prompt includes failure info (exit code, signal, stderr, duration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)