### PR TITLE
Wire up GitHub write operations to web UI

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -727,10 +727,10 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                         // where a merge was reverted to Approved after a transient
                         // GitHub API failure.
                         if poll_server.mode().await == server::Mode::Play {
-                            let approved_entries: Vec<(String, String)> = {
+                            let approved_entries: Vec<(String, String, String)> = {
                                 let state = poll_server.state.read().await;
                                 state.merge_queue.approved().iter().map(|e| {
-                                    (e.id.clone(), e.pr_url.clone())
+                                    (e.id.clone(), e.pr_url.clone(), e.task_id.clone())
                                 }).collect()
                             };
 
@@ -738,7 +738,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                 let retry_token = std::env::var("GITHUB_TOKEN").unwrap_or_default();
                                 if !retry_token.is_empty() {
                                     let retry_client = GitHubClient::new(&retry_token);
-                                    for (entry_id, pr_url) in &approved_entries {
+                                    for (entry_id, pr_url, retry_task_id) in &approved_entries {
                                         if let Some((owner, repo, number)) = tasks_orchestrator::parse_pr_url(pr_url) {
                                             info!(entry_id = %entry_id, pr_url = %pr_url, "retrying merge for approved entry");
                                             if let Err(e) = poll_server.mark_entry_merging(entry_id, pr_url).await {
@@ -750,6 +750,19 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                                     info!(entry_id = %entry_id, pr_url = %pr_url, "PR merged on retry");
                                                     if let Err(e) = poll_server.mark_entry_merged(entry_id, pr_url).await {
                                                         error!(entry_id = %entry_id, error = %e, "failed to mark entry merged on retry");
+                                                    }
+                                                    let event = Event::new(
+                                                        EventType::GitHubPrMerged,
+                                                        retry_task_id,
+                                                        Actor::System,
+                                                        serde_json::json!({
+                                                            "pr_url": pr_url,
+                                                            "entry_id": entry_id,
+                                                            "trigger": "retry",
+                                                        }),
+                                                    );
+                                                    if let Err(e) = poll_server.event_bus.publish(event).await {
+                                                        error!(error = %e, "failed to emit github:pr:merged event");
                                                     }
                                                 }
                                                 Ok(false) => {
@@ -1886,13 +1899,30 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                             feedback
                         ));
                     }
-                    if let Err(e) = merge_github.post_issue_comment(&owner, &repo, number, &comment_body).await {
-                        warn!(
-                            entry_id = %entry_id,
-                            pr_url = %pr_url,
-                            error = %e,
-                            "failed to post evaluation comment on PR (best-effort)"
-                        );
+                    match merge_github.post_issue_comment(&owner, &repo, number, &comment_body).await {
+                        Ok(created) => {
+                            let event = Event::new(
+                                EventType::GitHubCommentPosted,
+                                &task_id,
+                                Actor::Orchestrator,
+                                serde_json::json!({
+                                    "pr_url": pr_url,
+                                    "comment_url": created.html_url,
+                                    "action": "evaluation_comment",
+                                }),
+                            );
+                            if let Err(e) = orch_server.event_bus.publish(event).await {
+                                error!(error = %e, "failed to emit github:comment:posted event");
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                entry_id = %entry_id,
+                                pr_url = %pr_url,
+                                error = %e,
+                                "failed to post evaluation comment on PR (best-effort)"
+                            );
+                        }
                     }
                 }
 
@@ -1936,6 +1966,18 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                     info!(entry_id = %entry_id, pr_url = %pr_url, "PR merged successfully");
                                     if let Err(e) = orch_server.mark_entry_merged(&entry_id, &pr_url).await {
                                         error!(entry_id = %entry_id, error = %e, "failed to mark entry as merged");
+                                    }
+                                    let event = Event::new(
+                                        EventType::GitHubPrMerged,
+                                        &task_id,
+                                        Actor::Orchestrator,
+                                        serde_json::json!({
+                                            "pr_url": pr_url,
+                                            "entry_id": entry_id,
+                                        }),
+                                    );
+                                    if let Err(e) = orch_server.event_bus.publish(event).await {
+                                        error!(error = %e, "failed to emit github:pr:merged event");
                                     }
                                 }
                                 Ok(false) => {
@@ -2026,6 +2068,20 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                                                 if let Err(e) = orch_server.event_bus.publish(event).await {
                                                                     error!(error = %e, "failed to emit rebase success event");
                                                                 }
+                                                                // Emit GitHub write event
+                                                                let gh_event = Event::new(
+                                                                    EventType::GitHubBranchUpdated,
+                                                                    &task_id,
+                                                                    Actor::Orchestrator,
+                                                                    serde_json::json!({
+                                                                        "pr_url": pr_url,
+                                                                        "action": "mechanical_rebase",
+                                                                        "success": true,
+                                                                    }),
+                                                                );
+                                                                if let Err(e) = orch_server.event_bus.publish(gh_event).await {
+                                                                    error!(error = %e, "failed to emit github:branch:updated event");
+                                                                }
                                                                 // Remove from evaluated set so it gets re-evaluated next cycle
                                                                 evaluated_prs.remove(&pr_url);
                                                             }
@@ -2073,6 +2129,20 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                                                 );
                                                                 if let Err(e) = orch_server.event_bus.publish(event).await {
                                                                     error!(error = %e, "failed to emit auto-resolve success event");
+                                                                }
+                                                                // Emit GitHub write event
+                                                                let gh_event = Event::new(
+                                                                    EventType::GitHubBranchUpdated,
+                                                                    &task_id,
+                                                                    Actor::Orchestrator,
+                                                                    serde_json::json!({
+                                                                        "pr_url": pr_url,
+                                                                        "action": "auto_resolve",
+                                                                        "success": true,
+                                                                    }),
+                                                                );
+                                                                if let Err(e) = orch_server.event_bus.publish(gh_event).await {
+                                                                    error!(error = %e, "failed to emit github:branch:updated event");
                                                                 }
                                                                 evaluated_prs.remove(&pr_url);
                                                             }
@@ -2238,6 +2308,19 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                         branch = %branch,
                                         "deleted remote branch for re-dispatch"
                                     );
+                                    let event = Event::new(
+                                        EventType::GitHubBranchDeleted,
+                                        &task_id,
+                                        Actor::Orchestrator,
+                                        serde_json::json!({
+                                            "branch": branch,
+                                            "repo": context.project.repo,
+                                            "reason": "rejection_cleanup",
+                                        }),
+                                    );
+                                    if let Err(e) = orch_server.event_bus.publish(event).await {
+                                        error!(error = %e, "failed to emit github:branch:deleted event");
+                                    }
                                 }
                                 Ok(false) => {
                                     // Branch didn't exist — that's fine

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -26,7 +26,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use tower_http::cors::CorsLayer;
 
 use tasks_agent::CompletionsService;
-use events::Actor;
+use events::{Actor, Event, EventType};
 use server::Server;
 use server::presence::OwnedConnectionGuard;
 use models::Mode;
@@ -726,6 +726,22 @@ async fn create_issue(
         .await
         .map_err(ApiError::GitHubApi)?;
 
+    // Emit github:issue:created event
+    let event = Event::new(
+        EventType::GitHubIssueCreated,
+        "",
+        Actor::Human,
+        serde_json::json!({
+            "issue_number": created.number,
+            "issue_url": created.html_url,
+            "title": req.title,
+            "project_id": req.project_id,
+        }),
+    );
+    if let Err(e) = state.server.event_bus.publish(event).await {
+        tracing::error!(error = %e, "failed to emit github:issue:created event");
+    }
+
     Ok(Json(CreateIssueResponse {
         number: created.number,
         url: created.html_url,
@@ -775,6 +791,12 @@ async fn flush_merge_queue(State(state): State<ApiState>) -> Result<Json<Vec<Str
                 tracing::error!(entry_id = %entry_id, error = %e, "failed to mark entry as merging");
             }
 
+            // Look up associated task_id for event emission
+            let flush_task_id = {
+                let server_state = state.server.state.read().await;
+                server_state.merge_queue.get(entry_id).map(|e| e.task_id.clone()).unwrap_or_default()
+            };
+
             match client.merge_pull_request(&owner, &repo, number).await {
                 Ok(true) => {
                     tracing::info!(entry_id = %entry_id, pr_url = %pr_url, "PR merged via flush");
@@ -782,6 +804,19 @@ async fn flush_merge_queue(State(state): State<ApiState>) -> Result<Json<Vec<Str
                         tracing::error!(entry_id = %entry_id, error = %e, "failed to mark entry merged after flush");
                     } else {
                         merged_ids.push(entry_id.clone());
+                    }
+                    let event = Event::new(
+                        EventType::GitHubPrMerged,
+                        &flush_task_id,
+                        Actor::Human,
+                        serde_json::json!({
+                            "pr_url": pr_url,
+                            "entry_id": entry_id,
+                            "trigger": "flush",
+                        }),
+                    );
+                    if let Err(e) = state.server.event_bus.publish(event).await {
+                        tracing::error!(error = %e, "failed to emit github:pr:merged event");
                     }
                 }
                 Ok(false) => {
@@ -845,12 +880,31 @@ async fn approve_merge(
                     tracing::error!(entry_id = %id, error = %e, "failed to mark entry as merging");
                 }
 
+                // Look up task_id for event emission
+                let approve_task_id = {
+                    let server_state = state.server.state.read().await;
+                    server_state.merge_queue.get(&id).map(|e| e.task_id.clone()).unwrap_or_default()
+                };
+
                 let client = tasks_github::client::GitHubClient::new(&github_token);
                 match client.merge_pull_request(&owner, &repo, number).await {
                     Ok(true) => {
                         tracing::info!(entry_id = %id, pr_url = %pr_url, "PR merged after manual approval (Play mode)");
                         if let Err(e) = state.server.mark_entry_merged(&id, &pr_url).await {
                             tracing::error!(entry_id = %id, error = %e, "failed to mark entry merged");
+                        }
+                        let event = Event::new(
+                            EventType::GitHubPrMerged,
+                            &approve_task_id,
+                            Actor::Human,
+                            serde_json::json!({
+                                "pr_url": pr_url,
+                                "entry_id": id,
+                                "trigger": "manual_approval",
+                            }),
+                        );
+                        if let Err(e) = state.server.event_bus.publish(event).await {
+                            tracing::error!(error = %e, "failed to emit github:pr:merged event");
                         }
                     }
                     Ok(false) => {

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -111,6 +111,22 @@ pub enum EventType {
     SystemUpdateAvailable,
     /// Update is being applied (graceful shutdown in progress).
     SystemUpdateApplying,
+
+    // GitHub write operation events (issue #560)
+    /// A comment was posted to a GitHub issue/PR.
+    GitHubCommentPosted,
+    /// Labels were added to a GitHub issue/PR.
+    GitHubLabelsAdded,
+    /// A GitHub branch was deleted.
+    GitHubBranchDeleted,
+    /// A GitHub branch was updated (rebase via update-branch API).
+    GitHubBranchUpdated,
+    /// A GitHub PR was merged.
+    GitHubPrMerged,
+    /// A GitHub issue was created.
+    GitHubIssueCreated,
+    /// A GitHub issue was updated.
+    GitHubIssueUpdated,
 }
 
 impl EventType {
@@ -174,6 +190,13 @@ impl EventType {
             Self::SystemAccountingSession => "system:accounting:session",
             Self::SystemUpdateAvailable => "system:update:available",
             Self::SystemUpdateApplying => "system:update:applying",
+            Self::GitHubCommentPosted => "github:comment:posted",
+            Self::GitHubLabelsAdded => "github:labels:added",
+            Self::GitHubBranchDeleted => "github:branch:deleted",
+            Self::GitHubBranchUpdated => "github:branch:updated",
+            Self::GitHubPrMerged => "github:pr:merged",
+            Self::GitHubIssueCreated => "github:issue:created",
+            Self::GitHubIssueUpdated => "github:issue:updated",
         }
     }
 
@@ -266,6 +289,13 @@ impl TryFrom<String> for EventType {
             "system:accounting:session" => Ok(Self::SystemAccountingSession),
             "system:update:available" => Ok(Self::SystemUpdateAvailable),
             "system:update:applying" => Ok(Self::SystemUpdateApplying),
+            "github:comment:posted" => Ok(Self::GitHubCommentPosted),
+            "github:labels:added" => Ok(Self::GitHubLabelsAdded),
+            "github:branch:deleted" => Ok(Self::GitHubBranchDeleted),
+            "github:branch:updated" => Ok(Self::GitHubBranchUpdated),
+            "github:pr:merged" => Ok(Self::GitHubPrMerged),
+            "github:issue:created" => Ok(Self::GitHubIssueCreated),
+            "github:issue:updated" => Ok(Self::GitHubIssueUpdated),
             _ => Err(format!("unknown event type: {}", s)),
         }
     }

--- a/web/src/pages/events/page.tsx
+++ b/web/src/pages/events/page.tsx
@@ -25,6 +25,7 @@ const FILTERS = [
   { key: "task", label: "Task" },
   { key: "agent", label: "Agent" },
   { key: "merge", label: "Merge" },
+  { key: "github", label: "GitHub" },
   { key: "system", label: "System" },
   { key: "orchestrator", label: "Orchestrator" },
   { key: "automation", label: "Automation" },
@@ -42,6 +43,7 @@ function badgeClasses(type: string): string {
   if (type.startsWith("system:")) return "bg-gray-500/15 text-gray-400 border-gray-500/30";
   if (type.startsWith("orchestrator:")) return "bg-orange-500/15 text-orange-400 border-orange-500/30";
   if (type.startsWith("automation:")) return "bg-teal-500/15 text-teal-400 border-teal-500/30";
+  if (type.startsWith("github:")) return "bg-sky-500/15 text-sky-400 border-sky-500/30";
   return "bg-muted text-muted-foreground";
 }
 

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -17,6 +17,7 @@ import {
   HelpCircle,
   Brain,
   AlertTriangle,
+  GitBranch,
 } from "lucide-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -104,11 +105,13 @@ function sourceDisplay(task: Task) {
 // ---------------------------------------------------------------------------
 
 interface ParsedBlock {
-  kind: "text" | "thinking" | "tool_use" | "tool_result" | "error" | "system" | "lifecycle" | "human_message" | "agent_question" | "orchestrator_answer" | "session_boundary";
+  kind: "text" | "thinking" | "tool_use" | "tool_result" | "error" | "system" | "lifecycle" | "human_message" | "agent_question" | "orchestrator_answer" | "session_boundary" | "github_action";
   content: string;
   toolName?: string;
   filePath?: string;
   timestamp?: string;
+  /** URL linking to the GitHub resource (comment, PR, issue) */
+  url?: string;
 }
 
 const lifecycleLabels: Record<string, string> = {
@@ -146,6 +149,27 @@ function parseAgentEvents(events: Event[]): ParsedBlock[] {
       if (label) {
         blocks.push({ kind: "lifecycle", content: label, timestamp: event.ts });
       }
+      continue;
+    }
+
+    if (event.type.startsWith("github:")) {
+      const data = event.data ?? {};
+      const url = (data.comment_url ?? data.pr_url ?? data.issue_url) as string | undefined;
+      const githubLabels: Record<string, string> = {
+        "github:comment:posted": "Posted comment on GitHub",
+        "github:labels:added": "Added labels on GitHub",
+        "github:branch:deleted": `Deleted branch${data.branch ? ` ${data.branch}` : ""}`,
+        "github:branch:updated": `Updated branch${data.action === "mechanical_rebase" ? " (rebase)" : data.action === "auto_resolve" ? " (auto-resolve)" : ""}`,
+        "github:pr:merged": "Merged pull request",
+        "github:issue:created": `Created issue${data.title ? `: ${data.title}` : ""}`,
+        "github:issue:updated": "Updated issue on GitHub",
+      };
+      blocks.push({
+        kind: "github_action",
+        content: githubLabels[event.type] ?? event.type,
+        timestamp: event.ts,
+        url,
+      });
       continue;
     }
 
@@ -360,6 +384,26 @@ function BlockView({ block }: { block: ParsedBlock }) {
     return <ToolResultBlock block={block} />;
   }
 
+  if (block.kind === "github_action") {
+    return (
+      <div className="flex items-center gap-2 py-1.5 text-sm text-sky-400">
+        <GitBranch className="h-3.5 w-3.5 shrink-0" />
+        <span>{block.content}</span>
+        {block.url && (
+          <a
+            href={block.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-sky-400 hover:underline"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        )}
+        {timestamp && <span className="text-muted-foreground ml-auto text-xs">{timestamp}</span>}
+      </div>
+    );
+  }
+
   if (block.kind === "lifecycle") {
     return (
       <div className="flex items-center gap-2 py-1.5 text-sm text-muted-foreground">
@@ -416,7 +460,8 @@ function SessionView({ taskId, chatEnabled }: { taskId: string; chatEnabled: boo
       e.type === "agent:error" ||
       e.type === "human:message" ||
       e.type === "orchestrator:feedback" ||
-      e.type.startsWith("task:");
+      e.type.startsWith("task:") ||
+      e.type.startsWith("github:");
 
     fetchTaskEvents(taskId).then((events) => {
       setRawEvents(events.filter(isRelevant).sort((a, b) => a.ts.localeCompare(b.ts)));
@@ -611,11 +656,21 @@ interface TimelineEvent {
   description: string;
 }
 
+const githubTimelineLabels: Record<string, (data: Record<string, unknown>) => string> = {
+  "github:comment:posted": () => "Posted comment on GitHub",
+  "github:labels:added": () => "Added labels on GitHub",
+  "github:branch:deleted": (d) => `Deleted branch${d.branch ? ` ${d.branch}` : ""}`,
+  "github:branch:updated": (d) => `Updated branch${d.action === "mechanical_rebase" ? " (rebase)" : ""}`,
+  "github:pr:merged": () => "Merged pull request",
+  "github:issue:created": (d) => `Created issue${d.title ? `: ${d.title}` : ""}`,
+  "github:issue:updated": () => "Updated issue on GitHub",
+};
+
 function parseTimelineEvents(events: Event[]): TimelineEvent[] {
   const timelineEvents: TimelineEvent[] = [];
 
   for (const event of events) {
-    // Only include lifecycle/state events in timeline
+    // Include lifecycle/state events in timeline
     if (event.type.startsWith("task:")) {
       const label = lifecycleLabels[event.type];
       if (label) {
@@ -625,6 +680,20 @@ function parseTimelineEvents(events: Event[]): TimelineEvent[] {
           ts: event.ts,
           actor: event.actor,
           description: label,
+        });
+      }
+    }
+
+    // Include GitHub write actions in timeline
+    if (event.type.startsWith("github:")) {
+      const labelFn = githubTimelineLabels[event.type];
+      if (labelFn) {
+        timelineEvents.push({
+          id: event.id,
+          type: event.type,
+          ts: event.ts,
+          actor: event.actor,
+          description: labelFn(event.data ?? {}),
         });
       }
     }


### PR DESCRIPTION
## Summary

Closes #560

- Add 7 new `github:*` event types (`comment:posted`, `labels:added`, `branch:deleted`, `branch:updated`, `pr:merged`, `issue:created`, `issue:updated`) to the event system
- Emit events from all GitHub write operation call sites: orchestrator evaluation comments, PR merges (play mode, flush, retry, manual approval), branch deletions (rejection cleanup), branch updates (rebase/auto-resolve), and issue creation (web API)
- Add "GitHub" filter tab to the events page with sky-blue badge styling
- Show GitHub actions inline in the task chat view with a `GitBranch` icon and link to the GitHub resource
- Include GitHub write actions in the task event timeline sidebar

## Test plan

- [ ] Verify `cargo check --package events` passes (confirmed: 51 tests pass)
- [ ] Verify `bun run build` succeeds for the web frontend (confirmed)
- [ ] Verify new event types serialize/deserialize correctly via existing test patterns
- [ ] With a running instance, trigger a PR evaluation and confirm `github:comment:posted` appears in the events page under the "GitHub" tab
- [ ] Confirm merged PRs show `github:pr:merged` in both the events page and task detail timeline
- [ ] Confirm branch deletions on rejection show `github:branch:deleted` in the task timeline
- [ ] Verify links to GitHub resources (comment URLs, PR URLs) are clickable in the task chat view

🤖 Generated with [Claude Code](https://claude.com/claude-code)