### PR TITLE
Show task state transitions and surface API errors in web UI

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -12,10 +12,35 @@ import type {
   UpdateStatus,
 } from "./types";
 
+/** An API error with the status code and server-provided message. */
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+async function extractErrorMessage(
+  res: Response,
+  path: string
+): Promise<string> {
+  try {
+    const body = await res.json();
+    if (typeof body?.error === "string") return body.error;
+  } catch {
+    // body wasn't JSON — fall through
+  }
+  return `${res.status} ${res.statusText}: ${path}`;
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(path, init);
   if (!res.ok) {
-    throw new Error(`${res.status} ${res.statusText}: ${path}`);
+    const msg = await extractErrorMessage(res, path);
+    throw new ApiError(res.status, msg);
   }
   return res.json();
 }
@@ -23,7 +48,8 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 async function requestVoid(path: string, init?: RequestInit): Promise<void> {
   const res = await fetch(path, init);
   if (!res.ok) {
-    throw new Error(`${res.status} ${res.statusText}: ${path}`);
+    const msg = await extractErrorMessage(res, path);
+    throw new ApiError(res.status, msg);
   }
 }
 

--- a/web/src/lib/task-states.ts
+++ b/web/src/lib/task-states.ts
@@ -1,0 +1,53 @@
+import type { TaskState } from "./types";
+
+/**
+ * Valid state transitions mirroring the server's TaskState::can_transition_to().
+ * See crates/models/src/task.rs for the authoritative source.
+ */
+const TRANSITIONS: Record<TaskState, TaskState[]> = {
+  waiting: ["running", "blocked", "cancelled"],
+  blocked: ["waiting", "cancelled"],
+  running: [
+    "question",
+    "testing",
+    "awaiting_merge",
+    "conflict",
+    "changes_requested",
+    "completed",
+    "failed",
+    "cancelled",
+    "waiting",
+  ],
+  question: ["running", "waiting", "failed", "cancelled"],
+  testing: ["running", "awaiting_merge", "waiting", "failed", "cancelled"],
+  awaiting_merge: [
+    "completed",
+    "conflict",
+    "changes_requested",
+    "failed",
+    "cancelled",
+  ],
+  conflict: ["running", "changes_requested", "failed", "cancelled"],
+  changes_requested: ["running", "waiting", "failed", "cancelled"],
+  failed: ["waiting"],
+  completed: [],
+  cancelled: [],
+};
+
+/** Get the list of states a task can transition to from its current state. */
+export function allowedTransitions(state: TaskState): TaskState[] {
+  return TRANSITIONS[state] ?? [];
+}
+
+/** Check whether a specific transition is valid. */
+export function canTransitionTo(
+  from: TaskState,
+  to: TaskState
+): boolean {
+  return TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+/** Whether a state is terminal (no outbound transitions). */
+export function isTerminalState(state: TaskState): boolean {
+  return (TRANSITIONS[state]?.length ?? 0) === 0;
+}

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { ExternalLink, Check, X } from "lucide-react";
 import { toast } from "sonner";
 import { useAppState } from "@/hooks/use-app-state";
-import { flushMergeQueue, approveMerge, rejectMerge } from "@/lib/api";
+import { ApiError, flushMergeQueue, approveMerge, rejectMerge } from "@/lib/api";
 import { formatRelativeTime, projectLabel } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ListView, ListEmptyState } from "@/components/ui/list-view";
@@ -70,8 +70,8 @@ function MergeQueueRow({
     try {
       await approveMerge(entry.id);
       onRefresh();
-    } catch {
-      toast.error("Failed to approve merge entry");
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to approve merge entry");
     }
   }
 
@@ -79,8 +79,8 @@ function MergeQueueRow({
     try {
       await rejectMerge(entry.id);
       onRefresh();
-    } catch {
-      toast.error("Failed to reject merge entry");
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to reject merge entry");
     }
   }
 
@@ -292,8 +292,8 @@ export function MergeQueuePage() {
     try {
       await flushMergeQueue();
       await refreshSnapshot();
-    } catch {
-      toast.error("Failed to flush merge queue");
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to flush merge queue");
     } finally {
       setFlushing(false);
     }

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -22,7 +22,8 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
 import { useAppState } from "@/hooks/use-app-state";
-import { cancelTask, fetchTaskEvents, sendChat, subscribeEvents } from "@/lib/api";
+import { ApiError, cancelTask, fetchTaskEvents, sendChat, subscribeEvents } from "@/lib/api";
+import { allowedTransitions, isTerminalState } from "@/lib/task-states";
 import { cn, formatRelativeTime, projectLabel } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -476,9 +477,13 @@ function SessionView({ taskId, chatEnabled }: { taskId: string; chatEnabled: boo
     setChatInput("");
     try {
       await sendChat(taskId, text);
-    } catch {
+    } catch (err) {
       setChatInput(text);
-      toast.error("Failed to send message to agent");
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : "Failed to send message to agent";
+      toast.error(message);
     } finally {
       setSending(false);
     }
@@ -740,12 +745,50 @@ function PropertyRow({ label, children }: { label: string; children: React.React
   );
 }
 
+function AllowedTransitions({ state }: { state: TaskState }) {
+  const transitions = allowedTransitions(state);
+  if (transitions.length === 0) {
+    return (
+      <span className="text-xs text-muted-foreground italic">
+        Terminal state
+      </span>
+    );
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {transitions.map((s) => {
+        const meta = taskStateMeta[s];
+        if (!meta) return null;
+        const Icon = meta.icon;
+        return (
+          <Badge
+            key={s}
+            variant="outline"
+            className={cn("gap-1 text-[10px] px-1.5 py-0", meta.className)}
+          >
+            <Icon className="h-2.5 w-2.5" />
+            {meta.label}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}
+
 function PropertiesSidebar({ task, projectName }: { task: Task; projectName: string }) {
   return (
     <div className="space-y-1">
       <PropertyRow label="Status">
         <StateBadge state={task.state} />
       </PropertyRow>
+
+      {/* Show allowed next states */}
+      <div className="py-2">
+        <span className="text-sm text-muted-foreground block mb-1.5">
+          {isTerminalState(task.state) ? "Transitions" : "Next states"}
+        </span>
+        <AllowedTransitions state={task.state} />
+      </div>
 
       <PropertyRow label="Priority">
         <span className="text-sm">
@@ -869,8 +912,12 @@ export function TaskDetailPage() {
     setCancelling(true);
     try {
       await cancelTask(id);
-    } catch {
-      toast.error("Failed to cancel task");
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : "Failed to cancel task";
+      toast.error(message);
     } finally {
       setCancelling(false);
     }


### PR DESCRIPTION
## Summary

- Adds a client-side state transition map (`web/src/lib/task-states.ts`) mirroring the server's `TaskState::can_transition_to()` from PR #551
- Shows allowed next states in the task detail sidebar so users can see what transitions are possible from the current state
- Extracts server error messages from JSON error responses (`{ "error": "..." }`) and displays them in toast notifications instead of generic fallback messages
- Applies improved error handling across task cancel, chat send, merge approve/reject, and merge queue flush

## Changes

- **`web/src/lib/task-states.ts`** (new) — State transition map with `allowedTransitions()`, `canTransitionTo()`, and `isTerminalState()` helpers
- **`web/src/lib/api.ts`** — `ApiError` class that parses server error responses; `extractErrorMessage()` reads the JSON `error` field
- **`web/src/pages/task-detail.tsx`** — "Next states" section in properties sidebar showing allowed transitions as mini badges; error-aware cancel and chat handlers
- **`web/src/pages/merge-queue/page.tsx`** — Error-aware approve, reject, and flush handlers

## Test plan

- [ ] Open a task in Running state — verify "Next states" shows expected badges (Question, Testing, Awaiting Merge, etc.)
- [ ] Open a task in Completed state — verify it shows "Terminal state" instead of transition badges
- [ ] Cancel a task that's already completed/cancelled — verify the toast shows the server's error message, not a generic "Failed to cancel task"
- [ ] Approve/reject merge queue entries — verify server errors surface in toasts

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)