### PR TITLE
Add version display and data-clear prompt to web UI

### DIFF
--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -119,6 +119,10 @@ struct SnapshotResponse {
     automations: Vec<models::automation::Automation>,
     slot_utilization: SlotUtilization,
     human_present: bool,
+    /// Cargo package version of the server binary.
+    server_version: &'static str,
+    /// Current data schema version (bumped on incompatible changes).
+    data_version: u32,
 }
 
 #[derive(Serialize)]
@@ -409,6 +413,8 @@ async fn snapshot(State(state): State<ApiState>) -> Json<SnapshotResponse> {
             max: state.max_sessions,
         },
         human_present: state.server.is_human_present(),
+        server_version: env!("CARGO_PKG_VERSION"),
+        data_version: tasks_store::DATA_VERSION,
     })
 }
 

--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import {
+  AlertTriangle,
   LayoutDashboard,
   ListTodo,
   GitMerge,
@@ -546,9 +547,42 @@ function ProjectSelector() {
 // Layout
 // ---------------------------------------------------------------------------
 
+const DATA_VERSION_KEY = "tasks:data_version";
+
 export function Layout() {
   const { connected, snapshot, updateStatus, updateDismissed, dismissUpdate, refreshUpdateStatus } = useAppState();
   const slotUtil = snapshot?.slot_utilization;
+  const [dataVersionMismatch, setDataVersionMismatch] = useState(false);
+  const initialVersionSet = useRef(false);
+
+  // Detect data version changes across page loads / server restarts.
+  // On first load, store the version. On subsequent snapshots, compare.
+  useEffect(() => {
+    if (snapshot?.data_version == null) return;
+    const currentVersion = String(snapshot.data_version);
+    const storedVersion = localStorage.getItem(DATA_VERSION_KEY);
+
+    if (storedVersion === null || !initialVersionSet.current) {
+      // First time seeing a version — store it
+      localStorage.setItem(DATA_VERSION_KEY, currentVersion);
+      initialVersionSet.current = true;
+      // If there was already a stored version and it differs, that means the
+      // server was upgraded between sessions.
+      if (storedVersion !== null && storedVersion !== currentVersion) {
+        setDataVersionMismatch(true);
+      }
+    } else if (storedVersion !== currentVersion) {
+      // Version changed while the app is running (server restarted with new version)
+      setDataVersionMismatch(true);
+    }
+  }, [snapshot?.data_version]);
+
+  function dismissDataVersionBanner() {
+    setDataVersionMismatch(false);
+    if (snapshot?.data_version != null) {
+      localStorage.setItem(DATA_VERSION_KEY, String(snapshot.data_version));
+    }
+  }
 
   // Show update banner if update is available (or applying) and not dismissed
   const showUpdateBanner = updateStatus && (updateStatus.available || updateStatus.applying) && !updateDismissed;
@@ -612,11 +646,43 @@ export function Layout() {
               </span>
             )}
           </div>
+          {snapshot?.server_version && (
+            <div className="text-[10px] text-muted-foreground/60">
+              v{snapshot.server_version}
+            </div>
+          )}
         </div>
       </aside>
 
       {/* Main content */}
       <main className="flex flex-1 flex-col overflow-hidden">
+        {dataVersionMismatch && (
+          <div className="flex items-center gap-2 bg-yellow-500/10 border-b border-yellow-500/30 px-4 py-2 text-sm text-yellow-200">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-yellow-500" />
+            <span>
+              Data schema updated to v{snapshot?.data_version}. The server has cleared
+              stale data automatically. You may want to reload the page.
+            </span>
+            <div className="ml-auto flex gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 text-xs"
+                onClick={() => window.location.reload()}
+              >
+                Reload
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 text-xs text-muted-foreground"
+                onClick={dismissDataVersionBanner}
+              >
+                Dismiss
+              </Button>
+            </div>
+          </div>
+        )}
         {showUpdateBanner && (
           <UpdateBanner
             status={updateStatus}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -102,6 +102,10 @@ export interface Snapshot {
   merge_queue: MergeQueueEntry[];
   slot_utilization: SlotUtilization;
   human_present: boolean;
+  /** Cargo package version of the server binary. */
+  server_version: string;
+  /** Current data schema version (bumped on incompatible changes). */
+  data_version: number;
 }
 
 /** Rebuild scope for self-update mechanism */


### PR DESCRIPTION
## Summary

Closes #563.

- Adds `server_version` (cargo package version) and `data_version` (schema version) fields to the `/api/snapshot` response
- Displays the server version in the sidebar footer (e.g. "v0.1.0")
- Detects data schema version changes across browser sessions using `localStorage` and shows a yellow banner prompting the user to reload when the server has been upgraded and data was cleared

## Changes

**Server (`crates/app/src/web.rs`):**
- Added `server_version` and `data_version` fields to `SnapshotResponse`
- Populated from `env!("CARGO_PKG_VERSION")` and `tasks_store::DATA_VERSION`

**Web (`web/src/lib/types.ts`):**
- Added `server_version` and `data_version` to the `Snapshot` TypeScript interface

**Web (`web/src/components/layout.tsx`):**
- Version displayed in sidebar footer below connection/slot status
- Data version mismatch detection via `localStorage` comparison
- Dismissable yellow banner with Reload/Dismiss actions when version changes

## Test plan

- [ ] Verify `/api/snapshot` response includes `server_version` and `data_version` fields
- [ ] Verify version appears in sidebar footer
- [ ] Simulate version change by modifying `localStorage` key `tasks:data_version` to a different value, then reload — banner should appear
- [ ] Verify Reload button reloads the page and Dismiss button hides the banner
- [ ] Verify TypeScript compiles cleanly (`bun x tsc --noEmit`)
- [ ] Verify frontend builds (`bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)