### PR TITLE
Show rejected-PR cooldown status in web UI

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -38,7 +38,7 @@ use crate::update::{self, UpdateState};
 /// entries for the same PR URL + head SHA combination until this duration
 /// has elapsed. This prevents the race condition where cleanup removes the
 /// Rejected entry and the poll loop immediately re-queues the same PR.
-const REJECTED_PR_COOLDOWN: Duration = Duration::from_secs(10 * 60);
+pub const REJECTED_PR_COOLDOWN: Duration = Duration::from_secs(10 * 60);
 
 /// Tracks recently rejected PRs to prevent immediate re-queuing (issue #439).
 ///
@@ -52,7 +52,7 @@ const REJECTED_PR_COOLDOWN: Duration = Duration::from_secs(10 * 60);
 /// 2. Cleanup removes Rejected entry
 /// 3. Poll loop finds open PR, creates new Pending entry
 /// 4. Orchestrator re-evaluates (non-deterministically may approve)
-struct RejectedPrCooldown {
+pub struct RejectedPrCooldown {
     /// Map of pr_url -> (head_sha, rejection_time)
     entries: HashMap<String, (String, Instant)>,
 }
@@ -86,6 +86,31 @@ impl RejectedPrCooldown {
     fn cleanup(&mut self, cooldown: Duration) {
         self.entries
             .retain(|_, (_, rejected_at)| rejected_at.elapsed() < cooldown);
+    }
+
+    /// Export active cooldown entries as wall-clock expiry times.
+    ///
+    /// Returns a list of `(pr_url, head_sha, expires_at)` for entries
+    /// still within the cooldown window.
+    fn active_cooldowns(
+        &self,
+        cooldown: Duration,
+    ) -> Vec<(String, String, chrono::DateTime<chrono::Utc>)> {
+        let now_instant = Instant::now();
+        let now_utc = chrono::Utc::now();
+        self.entries
+            .iter()
+            .filter_map(|(pr_url, (head_sha, rejected_at))| {
+                let elapsed = rejected_at.elapsed();
+                if elapsed < cooldown {
+                    let remaining = cooldown - elapsed;
+                    let expires_at = now_utc + chrono::Duration::from_std(remaining).ok()?;
+                    Some((pr_url.clone(), head_sha.clone(), expires_at))
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 }
 
@@ -2641,6 +2666,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
             blocked_orgs: config.blocked_orgs.clone(),
             automation_soft_limit: config.automation_soft_limit,
             automation_hard_limit: config.automation_hard_limit,
+            rejected_pr_cooldown: Some(rejected_pr_cooldown.clone()),
         };
         let web_port = config.web_port;
 

--- a/crates/app/src/web.rs
+++ b/crates/app/src/web.rs
@@ -6,7 +6,7 @@
 
 use std::convert::Infallible;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::task::{Context, Poll};
 
 use axum::{
@@ -31,6 +31,7 @@ use server::Server;
 use server::presence::OwnedConnectionGuard;
 use models::Mode;
 
+use crate::run_loop::RejectedPrCooldown;
 use crate::update::UpdateState;
 
 /// Shared state for API handlers.
@@ -49,6 +50,8 @@ pub struct ApiState {
     pub automation_soft_limit: std::time::Duration,
     /// Automation session hard time limit.
     pub automation_hard_limit: std::time::Duration,
+    /// Rejected PR cooldown tracker (shared with poll/orchestrator loops).
+    pub rejected_pr_cooldown: Option<Arc<StdMutex<RejectedPrCooldown>>>,
 }
 
 /// Build the API router.
@@ -119,6 +122,16 @@ struct SnapshotResponse {
     automations: Vec<models::automation::Automation>,
     slot_utilization: SlotUtilization,
     human_present: bool,
+    /// Active rejected-PR cooldowns: pr_url -> (head_sha, expires_at).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    rejected_cooldowns: Vec<RejectedCooldownEntry>,
+}
+
+#[derive(Serialize)]
+struct RejectedCooldownEntry {
+    pr_url: String,
+    head_sha: String,
+    expires_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Serialize)]
@@ -398,6 +411,23 @@ async fn snapshot(State(state): State<ApiState>) -> Json<SnapshotResponse> {
         })
         .count() as u32;
 
+    let rejected_cooldowns = state
+        .rejected_pr_cooldown
+        .as_ref()
+        .map(|cooldown| {
+            let cooldown = cooldown.lock().unwrap();
+            cooldown
+                .active_cooldowns(crate::run_loop::REJECTED_PR_COOLDOWN)
+                .into_iter()
+                .map(|(pr_url, head_sha, expires_at)| RejectedCooldownEntry {
+                    pr_url,
+                    head_sha,
+                    expires_at,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     Json(SnapshotResponse {
         mode: server_state.mode,
         projects: server_state.projects.values().cloned().collect(),
@@ -409,6 +439,7 @@ async fn snapshot(State(state): State<ApiState>) -> Json<SnapshotResponse> {
             max: state.max_sessions,
         },
         human_present: state.server.is_human_present(),
+        rejected_cooldowns,
     })
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -77,6 +77,15 @@ export interface MergeQueueEntry {
   changes_requested_feedback?: string;
   /** Position in merge queue (1-indexed). Only set for approved/merging entries. */
   queue_position?: number;
+  /** Current head commit SHA of the PR branch. */
+  head_sha?: string;
+}
+
+/** A rejected PR that is in cooldown (won't be re-evaluated until expiry or new commits). */
+export interface RejectedCooldown {
+  pr_url: string;
+  head_sha: string;
+  expires_at: string;
 }
 
 export type Actor = "human" | "orchestrator" | "scheduler" | "agent" | "system";
@@ -102,6 +111,8 @@ export interface Snapshot {
   merge_queue: MergeQueueEntry[];
   slot_utilization: SlotUtilization;
   human_present: boolean;
+  /** Active rejected-PR cooldowns. */
+  rejected_cooldowns?: RejectedCooldown[];
 }
 
 /** Rebuild scope for self-update mechanism */

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -27,11 +27,23 @@ import {
   prRepoShort,
   getTask,
 } from "./columns";
-import type { MergeQueueEntry, Project, Task } from "@/lib/types";
+import type { MergeQueueEntry, Project, Task, RejectedCooldown } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // Merge Queue Row
 // ---------------------------------------------------------------------------
+
+function formatCooldownTime(expiresAt: string): string {
+  const expires = new Date(expiresAt);
+  const now = new Date();
+  const remainMs = expires.getTime() - now.getTime();
+  if (remainMs <= 0) return "expiring...";
+  const mins = Math.ceil(remainMs / 60000);
+  if (mins >= 60) {
+    return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+  }
+  return `${mins}m`;
+}
 
 function MergeQueueRow({
   entry,
@@ -39,12 +51,14 @@ function MergeQueueRow({
   projects,
   showProject,
   onRefresh,
+  cooldown,
 }: {
   entry: MergeQueueEntry;
   tasks: Task[];
   projects: Project[];
   showProject: boolean;
   onRefresh: () => Promise<void>;
+  cooldown?: RejectedCooldown;
 }) {
   const task = getTask(entry.task_id, tasks);
   const num = prNumber(entry.pr_url);
@@ -127,7 +141,19 @@ function MergeQueueRow({
       {showProject && <ProjectCell>{shortProject}</ProjectCell>}
 
       {/* Status */}
-      <BadgeCell>{statusBadge(entry.status)}</BadgeCell>
+      <BadgeCell>
+        <div className="flex items-center gap-1.5">
+          {statusBadge(entry.status)}
+          {cooldown && (
+            <span
+              className="text-[10px] text-orange-400 whitespace-nowrap"
+              title="In cooldown — won't be re-evaluated until timer expires or new commits are pushed"
+            >
+              cooldown {formatCooldownTime(cooldown.expires_at)}
+            </span>
+          )}
+        </div>
+      </BadgeCell>
 
       {/* Queue position */}
       <IdCell width="w-12">
@@ -199,6 +225,15 @@ function MergeList({
   const projects = snapshot.projects ?? [];
   const showProject = !selectedProject;
 
+  // Build a lookup of active cooldowns by pr_url
+  const cooldownMap = useMemo(() => {
+    const map = new Map<string, RejectedCooldown>();
+    for (const c of snapshot.rejected_cooldowns ?? []) {
+      map.set(c.pr_url, c);
+    }
+    return map;
+  }, [snapshot.rejected_cooldowns]);
+
   // Simple pagination
   const totalPages = Math.ceil(entries.length / pageSize);
   const paginatedEntries = entries.slice(page * pageSize, (page + 1) * pageSize);
@@ -220,6 +255,7 @@ function MergeList({
             projects={projects}
             showProject={showProject}
             onRefresh={refreshSnapshot}
+            cooldown={entry.status === "rejected" ? cooldownMap.get(entry.pr_url) : undefined}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary

Closes #565

- Expose the in-memory rejected-PR cooldown state through the `/api/snapshot` endpoint as a `rejected_cooldowns` array containing `(pr_url, head_sha, expires_at)` entries
- Display a "cooldown Xm" indicator next to rejected merge queue entries in the web UI, with a tooltip explaining that new commits bypass the cooldown
- Thread the `RejectedPrCooldown` tracker from the run loop into `ApiState` so web handlers can read active cooldowns

## Changes

**Backend (`crates/app/`):**
- `run_loop.rs`: Add `active_cooldowns()` method that converts monotonic `Instant` timestamps to wall-clock `DateTime<Utc>` expiry times. Make `RejectedPrCooldown` and `REJECTED_PR_COOLDOWN` public.
- `web.rs`: Add `rejected_pr_cooldown` field to `ApiState`, `rejected_cooldowns` to `SnapshotResponse`, and populate it in the snapshot handler.

**Frontend (`web/`):**
- `types.ts`: Add `RejectedCooldown` interface and `rejected_cooldowns` to `Snapshot`.
- `page.tsx`: Build a cooldown lookup map and show remaining time next to rejected entries.

## Test plan

- [ ] Verify the snapshot API returns `rejected_cooldowns` when cooldowns are active
- [ ] Confirm rejected merge queue entries show the cooldown timer in the UI
- [ ] Verify the cooldown indicator disappears after expiry
- [ ] Verify no cooldown shown for entries without active cooldowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)