### PR TITLE
Show rejected-PR cooldown status in web UI

### DIFF
--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -77,6 +77,8 @@ export interface MergeQueueEntry {
   changes_requested_feedback?: string;
   /** Position in merge queue (1-indexed). Only set for approved/merging entries. */
   queue_position?: number;
+  /** Timestamp when entry reached terminal state (merged/rejected). Used for cooldown display. */
+  completed_at?: string;
 }
 
 export type Actor = "human" | "orchestrator" | "scheduler" | "agent" | "system";

--- a/web/src/pages/merge-queue/columns.tsx
+++ b/web/src/pages/merge-queue/columns.tsx
@@ -1,11 +1,33 @@
 import { type ColumnDef } from "@tanstack/react-table";
 import { Link } from "react-router-dom";
-import { ExternalLink, Check, X } from "lucide-react";
+import { ExternalLink, Check, X, Timer } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatRelativeTime, projectLabel } from "@/lib/utils";
 import { approveMerge, rejectMerge } from "@/lib/api";
 import type { MergeQueueEntry, MergeStatus, Project, Task } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Cooldown helpers
+// ---------------------------------------------------------------------------
+
+/** Cooldown duration in milliseconds (matches backend REJECTED_PR_COOLDOWN = 10 min). */
+const COOLDOWN_DURATION_MS = 10 * 60 * 1000;
+
+/** Get remaining cooldown time for a rejected entry. Returns null if not in cooldown. */
+export function getCooldownRemaining(entry: MergeQueueEntry): { remainingMs: number; cooldownUntil: Date } | null {
+  if (entry.status !== "rejected" || !entry.completed_at) return null;
+  const completedAt = new Date(entry.completed_at).getTime();
+  const cooldownUntil = new Date(completedAt + COOLDOWN_DURATION_MS);
+  const remainingMs = cooldownUntil.getTime() - Date.now();
+  if (remainingMs <= 0) return null;
+  return { remainingMs, cooldownUntil };
+}
+
+/** Format a cooldown time as "HH:MM". */
+function formatCooldownTime(date: Date): string {
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
 
 // ---------------------------------------------------------------------------
 // Status badge
@@ -30,6 +52,21 @@ export function statusBadge(status: MergeStatus) {
     default:
       return <Badge variant="outline">{status}</Badge>;
   }
+}
+
+/** Cooldown badge shown next to rejected entries that are still in cooldown. */
+export function CooldownBadge({ entry }: { entry: MergeQueueEntry }) {
+  const cooldown = getCooldownRemaining(entry);
+  if (!cooldown) return null;
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-xs text-red-400/70"
+      title="This PR is in a 10-minute cooldown period and won't be re-evaluated until the timer expires. Pushing new commits will bypass the cooldown."
+    >
+      <Timer className="h-3 w-3" />
+      until {formatCooldownTime(cooldown.cooldownUntil)}
+    </span>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -192,7 +229,12 @@ export const columns: ColumnDef<MergeQueueEntry>[] = [
   {
     accessorKey: "status",
     header: "Status",
-    cell: ({ row }) => statusBadge(row.original.status),
+    cell: ({ row }) => (
+      <span className="inline-flex items-center gap-1.5">
+        {statusBadge(row.original.status)}
+        <CooldownBadge entry={row.original} />
+      </span>
+    ),
     sortingFn: (rowA, rowB) => {
       const a = statusSortOrder[rowA.original.status] ?? 99;
       const b = statusSortOrder[rowB.original.status] ?? 99;

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -22,6 +22,7 @@ import {
   lifecyclePhases,
   type LifecyclePhase,
   statusBadge,
+  CooldownBadge,
   prNumber,
   prRepo,
   prRepoShort,
@@ -127,7 +128,12 @@ function MergeQueueRow({
       {showProject && <ProjectCell>{shortProject}</ProjectCell>}
 
       {/* Status */}
-      <BadgeCell>{statusBadge(entry.status)}</BadgeCell>
+      <BadgeCell>
+        <span className="inline-flex items-center gap-1.5">
+          {statusBadge(entry.status)}
+          <CooldownBadge entry={entry} />
+        </span>
+      </BadgeCell>
 
       {/* Queue position */}
       <IdCell width="w-12">


### PR DESCRIPTION
## Summary

- Adds `completed_at` field to the frontend `MergeQueueEntry` TypeScript type (already serialized by the backend)
- Displays a cooldown timer badge ("until HH:MM") next to rejected merge queue entries still within the 10-minute cooldown window
- Includes a tooltip explaining that pushing new commits bypasses the cooldown

The backend (`RejectedPrCooldown` in `run_loop.rs`) already tracks and enforces the 10-minute cooldown for rejected PRs. The `completed_at` timestamp was already being serialized in the API response but not consumed by the frontend.

Closes #565

## Test plan

- [ ] Verify rejected merge queue entries show "until HH:MM" timer when within the 10-minute cooldown window
- [ ] Verify the cooldown badge disappears after the cooldown expires (page refresh or next snapshot poll)
- [ ] Verify the tooltip on the cooldown badge mentions pushing new commits to bypass
- [ ] Verify non-rejected entries are unaffected
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify `npx vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)