### PR TITLE
Display orchestrator rejection feedback in web UI

### DIFF
--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -47,6 +47,7 @@ export interface Task {
   retry_count: number;
   last_failure_at: string | null;
   last_failure: FailureInfo | null;
+  rejection_feedback: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -121,6 +121,11 @@ function MergeQueueRow({
             {entry.changes_requested_feedback}
           </p>
         )}
+        {entry.status === "rejected" && task?.rejection_feedback && (
+          <p className="text-xs text-orange-400/80 truncate mt-0.5" title={task.rejection_feedback}>
+            {task.rejection_feedback}
+          </p>
+        )}
       </TextCell>
 
       {/* Project */}

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -832,6 +832,17 @@ function PropertiesSidebar({ task, projectName }: { task: Task; projectName: str
         </PropertyRow>
       )}
 
+      {/* Rejection feedback */}
+      {task.rejection_feedback && (
+        <>
+          <Separator className="my-3" />
+          <div className="text-xs font-medium text-orange-400 mb-2">Rejection Feedback</div>
+          <div className="rounded-md border border-orange-500/30 bg-orange-500/10 px-3 py-2">
+            <p className="text-xs text-orange-300/90 whitespace-pre-wrap">{task.rejection_feedback}</p>
+          </div>
+        </>
+      )}
+
       {/* Failure info */}
       {task.last_failure && (
         <>

--- a/web/src/pages/tasks/page.tsx
+++ b/web/src/pages/tasks/page.tsx
@@ -6,6 +6,7 @@ import {
   ArrowUp,
   ChevronRight,
   ExternalLink,
+  MessageSquareWarning,
   Minus,
   Plus,
 } from "lucide-react";
@@ -219,6 +220,14 @@ function TaskRow({
           </Badge>
         </BadgeCell>
       ))}
+      {task.rejection_feedback && (
+        <BadgeCell>
+          <Badge variant="outline" className="text-xs gap-1 bg-orange-500/15 text-orange-400 border-orange-500/30">
+            <MessageSquareWarning className="h-3 w-3" />
+            Rejection feedback
+          </Badge>
+        </BadgeCell>
+      )}
       {prUrl && prNumber(prUrl) && (
         <LinkCell href={prUrl} icon={<ExternalLink className="h-3 w-3" />}>
           #{prNumber(prUrl)}


### PR DESCRIPTION
## Summary

- Adds `rejection_feedback` field to the TypeScript `Task` type (already serialized by the Rust backend)
- Shows a "Rejection Feedback" section in the task detail sidebar when the orchestrator has provided rejection reasoning
- Adds an orange "Rejection feedback" badge indicator on tasks in the list view that are being retried with guidance
- Displays rejection feedback inline on rejected merge queue entries

## Test plan

- [ ] Verify `rejection_feedback` appears in `/api/tasks/:id` response when a task has been rejected
- [ ] Confirm the rejection feedback section renders in the task detail sidebar with orange styling
- [ ] Confirm the badge appears on task rows in the list when `rejection_feedback` is populated
- [ ] Verify rejected merge queue entries show the feedback text inline
- [ ] Confirm no UI changes when `rejection_feedback` is null

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)