### PR TITLE
Display orchestrator rejection feedback on tasks in web UI

### DIFF
--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -47,6 +47,7 @@ export interface Task {
   retry_count: number;
   last_failure_at: string | null;
   last_failure: FailureInfo | null;
+  rejection_feedback: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/web/src/pages/task-detail.tsx
+++ b/web/src/pages/task-detail.tsx
@@ -832,6 +832,17 @@ function PropertiesSidebar({ task, projectName }: { task: Task; projectName: str
         </PropertyRow>
       )}
 
+      {/* Rejection feedback */}
+      {task.rejection_feedback && (
+        <>
+          <Separator className="my-3" />
+          <div className="text-xs font-medium text-amber-400 mb-2">Rejection Feedback</div>
+          <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+            <p className="text-xs text-amber-300/90 whitespace-pre-wrap">{task.rejection_feedback}</p>
+          </div>
+        </>
+      )}
+
       {/* Failure info */}
       {task.last_failure && (
         <>

--- a/web/src/pages/tasks/page.tsx
+++ b/web/src/pages/tasks/page.tsx
@@ -6,6 +6,7 @@ import {
   ArrowUp,
   ChevronRight,
   ExternalLink,
+  MessageSquareWarning,
   Minus,
   Plus,
 } from "lucide-react";
@@ -212,6 +213,13 @@ function TaskRow({
         </IconCell>
       )}
       <TextCell>{task.title}</TextCell>
+      {task.rejection_feedback && (
+        <IconCell>
+          <span title="Has rejection feedback">
+            <MessageSquareWarning className="h-3.5 w-3.5 text-amber-500" />
+          </span>
+        </IconCell>
+      )}
       {task.labels.map((label) => (
         <BadgeCell key={label}>
           <Badge variant="outline" className="text-xs">

--- a/web/src/pages/tasks/sortable-task-list.tsx
+++ b/web/src/pages/tasks/sortable-task-list.tsx
@@ -22,6 +22,7 @@ import {
   ArrowRight,
   ArrowUp,
   GripVertical,
+  MessageSquareWarning,
   Minus,
 } from "lucide-react";
 import { cn, formatRelativeTime } from "@/lib/utils";
@@ -130,6 +131,13 @@ function SortableTaskItem({ task, projectName }: SortableTaskItemProps) {
 
         {/* Title */}
         <span className="flex-1 truncate text-sm">{task.title}</span>
+
+        {/* Rejection feedback indicator */}
+        {task.rejection_feedback && (
+          <span title="Has rejection feedback">
+            <MessageSquareWarning className="h-3.5 w-3.5 text-amber-500 shrink-0" />
+          </span>
+        )}
 
         {/* Labels */}
         {task.labels.map((label) => (


### PR DESCRIPTION
## Summary

- Added `rejection_feedback` field to the TypeScript `Task` interface (already serialized by the backend since #453)
- Show a "Rejection Feedback" section in the task detail sidebar when the field is populated, styled with amber/warning colors matching the existing orchestrator answer styling
- Added an amber `MessageSquareWarning` icon indicator on task rows (both grouped list and sortable queue views) when a task has active rejection feedback

## Test plan

- [ ] Verify task detail sidebar shows rejection feedback section when a task has `rejection_feedback` set
- [ ] Verify the feedback section is hidden when `rejection_feedback` is null
- [ ] Verify amber icon appears on task list rows for tasks with rejection feedback
- [ ] Verify icon appears in the sortable queue view as well
- [ ] Verify merge queue still shows `changes_requested_feedback` inline (no regression)

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)