### PR TITLE
Communicate Pause mode behavior changes in web UI

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -52,10 +52,10 @@ import type { Mode } from "@/lib/types";
 // Mode indicator
 // ---------------------------------------------------------------------------
 
-const modeConfig: Record<Mode, { label: string; icon: typeof Square }> = {
-  stop: { label: "Stopped", icon: Square },
-  pause: { label: "Paused", icon: Pause },
-  play: { label: "Playing", icon: Play },
+const modeConfig: Record<Mode, { label: string; description: string; icon: typeof Square }> = {
+  stop: { label: "Stopped", description: "All activity halted. No new work will be started.", icon: Square },
+  pause: { label: "Paused", description: "Approved PRs are held for manual flush. Rejections, conflicts, and change requests continue automatically.", icon: Pause },
+  play: { label: "Playing", description: "Fully automatic. Work is dispatched and merged without intervention.", icon: Play },
 };
 
 const modeOrder: Mode[] = ["stop", "pause", "play"];
@@ -94,7 +94,10 @@ function ModeSelector() {
                 <Icon className="h-4 w-4" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top">{config.label}</TooltipContent>
+            <TooltipContent side="top" className="max-w-64">
+              <p className="font-medium">{config.label}</p>
+              <p className="text-muted-foreground font-normal">{config.description}</p>
+            </TooltipContent>
           </Tooltip>
         );
       })}

--- a/web/src/pages/dashboard/page.tsx
+++ b/web/src/pages/dashboard/page.tsx
@@ -244,14 +244,14 @@ function computeStatusMessages(
         type: "warning",
         message: `Paused: ${parts.join(", ")}`,
         detail: dispatchable > 0
-          ? `${dispatchable} ${dispatchable === 1 ? "task" : "tasks"} ready to dispatch. Approve entries or switch to Play.`
-          : "Review and approve entries, then use Flush or switch to Play.",
+          ? `${dispatchable} ${dispatchable === 1 ? "task" : "tasks"} ready to dispatch. Rejections, conflicts, and change requests still process automatically. Approve entries or switch to Play.`
+          : "Approved PRs are held for manual flush. Rejections, conflicts, and change requests still process automatically.",
       });
     } else if (activeWork === 0 && dispatchable === 0 && nonTerminalTasks > 0) {
       messages.push({
         type: "warning",
         message: "Paused with no dispatchable work",
-        detail: "All active tasks are awaiting merge decisions or blocked.",
+        detail: "All active tasks are awaiting merge decisions or blocked. Rejections, conflicts, and change requests still process automatically.",
       });
     }
   }

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { ExternalLink, Check, X } from "lucide-react";
+import { ExternalLink, Check, X, Info } from "lucide-react";
 import { toast } from "sonner";
 import { useAppState } from "@/hooks/use-app-state";
 import { flushMergeQueue, approveMerge, rejectMerge } from "@/lib/api";
@@ -344,6 +344,15 @@ export function MergeQueuePage() {
             countLabel="entries"
             actions={headerActions}
           />
+          {isPaused && (
+            <div className="mx-4 mb-2 flex items-start gap-2.5 rounded-md border border-blue-500/30 bg-blue-500/10 px-3 py-2">
+              <Info className="h-4 w-4 text-blue-400 mt-0.5 shrink-0" />
+              <p className="text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">Pause mode:</span>{" "}
+                Approved PRs are held for manual flush. Rejections, conflicts, and change requests continue to be processed automatically.
+              </p>
+            </div>
+          )}
           <div className="px-4 pb-1">
             {headerTabs}
           </div>


### PR DESCRIPTION
## Summary

- **Mode selector tooltips**: Each mode button (Stop/Pause/Play) now shows a descriptive tooltip explaining what the mode actually does, not just its name. The Pause tooltip explains that only approved merges are held while rejections, conflicts, and change requests continue automatically.
- **Merge queue info banner**: When in Pause mode, an info banner appears at the top of the merge queue page explaining the behavior.
- **Dashboard status messages**: Pause mode status messages in the system banner now mention that rejections, conflicts, and change requests still process automatically.

Closes #568

## Test plan

- [ ] Hover over each mode button (Stop, Pause, Play) in the sidebar footer — verify descriptive tooltips appear
- [ ] Switch to Pause mode — verify the merge queue page shows the blue info banner
- [ ] Switch to Play mode — verify the merge queue page does NOT show the info banner
- [ ] In Pause mode with pending/approved entries, check the dashboard status banner mentions automatic processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)