### PR TITLE
Communicate Pause mode behavior changes in web UI

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -52,10 +52,10 @@ import type { Mode } from "@/lib/types";
 // Mode indicator
 // ---------------------------------------------------------------------------
 
-const modeConfig: Record<Mode, { label: string; icon: typeof Square }> = {
-  stop: { label: "Stopped", icon: Square },
-  pause: { label: "Paused", icon: Pause },
-  play: { label: "Playing", icon: Play },
+const modeConfig: Record<Mode, { label: string; description: string; icon: typeof Square }> = {
+  stop: { label: "Stopped", description: "All activity halted. No new work will be started.", icon: Square },
+  pause: { label: "Paused", description: "Approved PRs held for manual flush. Rejections, conflicts, and change requests still process automatically.", icon: Pause },
+  play: { label: "Playing", description: "Fully autonomous. All actions execute automatically.", icon: Play },
 };
 
 const modeOrder: Mode[] = ["stop", "pause", "play"];
@@ -94,7 +94,10 @@ function ModeSelector() {
                 <Icon className="h-4 w-4" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top">{config.label}</TooltipContent>
+            <TooltipContent side="top" className="max-w-64">
+              <p className="font-medium">{config.label}</p>
+              <p className="text-xs text-muted-foreground">{config.description}</p>
+            </TooltipContent>
           </Tooltip>
         );
       })}

--- a/web/src/pages/dashboard/page.tsx
+++ b/web/src/pages/dashboard/page.tsx
@@ -244,14 +244,14 @@ function computeStatusMessages(
         type: "warning",
         message: `Paused: ${parts.join(", ")}`,
         detail: dispatchable > 0
-          ? `${dispatchable} ${dispatchable === 1 ? "task" : "tasks"} ready to dispatch. Approve entries or switch to Play.`
-          : "Review and approve entries, then use Flush or switch to Play.",
+          ? `${dispatchable} ${dispatchable === 1 ? "task" : "tasks"} ready to dispatch. Rejections and conflicts still process automatically. Approve entries or switch to Play.`
+          : "Rejections and conflicts still process automatically. Review and approve entries, then use Flush or switch to Play.",
       });
     } else if (activeWork === 0 && dispatchable === 0 && nonTerminalTasks > 0) {
       messages.push({
         type: "warning",
         message: "Paused with no dispatchable work",
-        detail: "All active tasks are awaiting merge decisions or blocked.",
+        detail: "All active tasks are awaiting merge decisions or blocked. Rejections and conflicts still process automatically.",
       });
     }
   }

--- a/web/src/pages/merge-queue/page.tsx
+++ b/web/src/pages/merge-queue/page.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { ExternalLink, Check, X } from "lucide-react";
+import { ExternalLink, Check, X, Info } from "lucide-react";
 import { toast } from "sonner";
 import { useAppState } from "@/hooks/use-app-state";
 import { flushMergeQueue, approveMerge, rejectMerge } from "@/lib/api";
@@ -344,6 +344,15 @@ export function MergeQueuePage() {
             countLabel="entries"
             actions={headerActions}
           />
+          {isPaused && (
+            <div className="mx-4 mb-2 flex items-start gap-2 rounded-md bg-yellow-500/10 border border-yellow-500/20 px-3 py-2 text-xs text-yellow-200">
+              <Info className="h-3.5 w-3.5 shrink-0 mt-0.5 text-yellow-400" />
+              <span>
+                <strong>Pause mode:</strong> Approved PRs are held for manual flush.
+                Rejections, conflicts, and change requests continue to be processed automatically.
+              </span>
+            </div>
+          )}
           <div className="px-4 pb-1">
             {headerTabs}
           </div>


### PR DESCRIPTION
## Summary

- **Mode selector tooltips**: Each mode button now shows a descriptive tooltip explaining actual behavior. Pause tooltip clarifies that only approved PRs are held while rejections, conflicts, and change requests continue automatically.
- **Merge queue info banner**: When in Pause mode, an info banner appears on the merge queue page explaining which actions are held vs. auto-processed.
- **Dashboard status messages**: Pause-mode status messages now mention that rejections and conflicts still process automatically.

Closes #568

## Test plan

- [ ] Hover each mode button (Stop, Pause, Play) in the sidebar footer and verify descriptive tooltips appear
- [ ] Switch to Pause mode and navigate to the Merge Queue page — verify the yellow info banner is visible
- [ ] Switch to Play mode and verify the info banner is not shown on the Merge Queue page
- [ ] In Pause mode with queued entries, verify the dashboard status message mentions automatic processing of rejections/conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)