### PR TITLE
Add HTTP timeouts to prevent poll failures from stalling server

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -33,6 +33,14 @@ use crate::problem_tracker::ProblemTracker;
 use crate::scheduler::AutomationScheduler;
 use crate::update::{self, UpdateState};
 
+/// Timeout for a single GitHub poll operation.
+///
+/// Prevents a slow or unresponsive GitHub API from blocking the entire
+/// poll loop. If a poll exceeds this duration, it is cancelled and the
+/// next tick will retry. This is a safety net on top of the per-request
+/// timeouts configured on the HTTP client.
+const POLL_TIMEOUT: Duration = Duration::from_secs(60);
+
 /// Default cooldown duration for rejected PRs (10 minutes).
 ///
 /// After a PR is rejected, the poll loop will skip creating new merge queue
@@ -573,15 +581,24 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                 let token = github_token.clone();
                 let pid = project_id.clone();
 
-                let result = poll_config_watcher
-                    .refresh(&pid, || async {
+                let result = match tokio::time::timeout(
+                    POLL_TIMEOUT,
+                    poll_config_watcher.refresh(&pid, || async {
                         let client = GitHubClient::new(&token);
                         client
                             .get_file_content(&owner, &repo_name, "workflow.toml")
                             .await
                             .map_err(|e| e.to_string())
-                    })
-                    .await;
+                    }),
+                )
+                .await
+                {
+                    Ok(r) => r,
+                    Err(_elapsed) => {
+                        warn!(project = %pid, "workflow config refresh timed out");
+                        continue;
+                    }
+                };
 
                 // Emit event if config changed
                 if let RefreshResult::Changed(config) = result {
@@ -626,7 +643,16 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                     }
                 }
 
-                match poller.poll().await {
+                // Wrap poll in timeout to prevent stalls (issue #574)
+                let poll_result = tokio::time::timeout(POLL_TIMEOUT, poller.poll()).await;
+                let poll_result = match poll_result {
+                    Ok(inner) => inner,
+                    Err(_elapsed) => {
+                        error!(project = %project_id, "poll timed out after {}s", POLL_TIMEOUT.as_secs());
+                        continue;
+                    }
+                };
+                match poll_result {
                     Ok(result) => {
                         // Reset backoff on success (issue #510)
                         if poll_failures.remove(project_id.as_str()).is_some() {

--- a/crates/github/src/client.rs
+++ b/crates/github/src/client.rs
@@ -1,6 +1,7 @@
 //! GitHub GraphQL client — spec github.md §4.
 
 use std::sync::RwLock;
+use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, USER_AGENT};
@@ -136,6 +137,8 @@ impl GitHubClientBuilder {
 
         let http = reqwest::Client::builder()
             .default_headers(headers)
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
             .build()
             .expect("failed to build HTTP client");
 


### PR DESCRIPTION
## Summary

- Add connect timeout (10s) and request timeout (30s) to the GitHub HTTP client — previously no timeouts were configured, so network errors could hang for OS-level TCP timeouts (minutes)
- Wrap each `poller.poll()` and workflow config refresh call with a 60s `tokio::time::timeout` — on timeout, log an error and `continue` to the next project instead of blocking the entire poll loop
- Together these ensure a single unresponsive GitHub API call cannot stall the server's poll loop

## Root cause

The `reqwest::Client` was built without any timeout configuration. When the GitHub API became unreachable (network errors in the logs), each poll call would hang until the OS TCP timeout (typically 2-8 minutes). Since projects are polled sequentially in the loop, this blocked all GitHub data ingestion, merge queue reconciliation, and workflow config refreshes — effectively halting the server.

## Test plan

- [x] `cargo test --package tasks-github` passes (9 tests)
- [x] `cargo check --package tasks-github` compiles cleanly
- [ ] Manual: simulate network timeout (e.g., block `api.github.com`) and verify poll loop continues with error logs instead of stalling

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)