### PR TITLE
Fix: retry with backoff on initial snapshot failure in desktop app

### DIFF
--- a/crates/desktop/src/state.rs
+++ b/crates/desktop/src/state.rs
@@ -26,6 +26,12 @@ const MAX_EVENTS: usize = 200;
 /// Polling interval for snapshot refresh (milliseconds).
 const POLL_INTERVAL_MS: u64 = 5_000;
 
+/// Initial retry delay for snapshot fetch (milliseconds).
+const INITIAL_RETRY_DELAY_MS: u64 = 1_000;
+
+/// Maximum retry delay (milliseconds).
+const MAX_RETRY_DELAY_MS: u64 = 30_000;
+
 /// Check whether an event type string should trigger a snapshot refresh.
 /// Matches: task:*, merge:*, system:mode*
 fn is_state_changing_event(event_type: &str) -> bool {
@@ -118,6 +124,8 @@ pub struct AppState {
     stop_polling: Option<Arc<AtomicBool>>,
     /// Whether a fetch is currently in flight.
     fetch_in_flight: Arc<AtomicBool>,
+    /// Current retry attempt for initial snapshot fetch (0 = no retries yet).
+    initial_retry_attempt: u32,
 }
 
 impl AppState {
@@ -158,6 +166,7 @@ impl AppState {
             sse_client: Some(sse_client),
             stop_polling: None,
             fetch_in_flight: Arc::new(AtomicBool::new(false)),
+            initial_retry_attempt: 0,
         };
 
         // Start polling loop
@@ -360,9 +369,12 @@ impl AppState {
             Ok(snapshot) => {
                 self.snapshot = Some(snapshot);
                 self.last_error = None;
+                self.initial_retry_attempt = 0;
                 // Update connection status if we were previously disconnected
                 if self.connection_status == ConnectionStatus::Disconnected
                     || self.connection_status == ConnectionStatus::Failed
+                    || self.connection_status == ConnectionStatus::Connecting
+                    || self.connection_status == ConnectionStatus::Reconnecting
                 {
                     self.connection_status = ConnectionStatus::Connected;
                     cx.emit(AppStateEvent::ConnectionStatusChanged(
@@ -373,9 +385,67 @@ impl AppState {
                 cx.notify();
             }
             Err(e) => {
+                let had_no_snapshot = self.snapshot.is_none();
                 self.set_error(e.to_string(), cx);
+
+                // If we've never loaded a snapshot, schedule retry with backoff
+                if had_no_snapshot {
+                    self.connection_status = ConnectionStatus::Reconnecting;
+                    cx.emit(AppStateEvent::ConnectionStatusChanged(
+                        self.connection_status,
+                    ));
+                    cx.notify();
+                    self.schedule_initial_retry(cx);
+                }
             }
         }
+    }
+
+    /// Schedule a retry for the initial snapshot fetch with exponential backoff.
+    fn schedule_initial_retry(&mut self, cx: &mut Context<Self>) {
+        let attempt = self.initial_retry_attempt;
+        self.initial_retry_attempt = attempt.saturating_add(1);
+
+        let delay_ms = INITIAL_RETRY_DELAY_MS.saturating_mul(1u64.saturating_shl(attempt.min(5)));
+        let delay_ms = delay_ms.min(MAX_RETRY_DELAY_MS);
+        let delay = Duration::from_millis(delay_ms);
+
+        info!(attempt = attempt + 1, delay_ms, "Scheduling initial snapshot retry");
+
+        let api_client = self.api_client.clone();
+        let fetch_in_flight = self.fetch_in_flight.clone();
+
+        cx.spawn(async move |this, cx| {
+            smol::Timer::after(delay).await;
+
+            // Skip if a fetch is already in flight
+            if fetch_in_flight
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err()
+            {
+                return;
+            }
+
+            let result = api_client.fetch_snapshot().await;
+            fetch_in_flight.store(false, Ordering::SeqCst);
+
+            if let Err(e) = this.update(cx, |state, cx| {
+                state.update_snapshot(result, cx);
+            }) {
+                warn!(error = %e, "Failed to update snapshot state during retry");
+            }
+        })
+        .detach();
+    }
+
+    /// Manually retry connecting to the server.
+    pub fn retry_connect(&mut self, cx: &mut Context<Self>) {
+        self.initial_retry_attempt = 0;
+        self.connection_status = ConnectionStatus::Connecting;
+        self.last_error = None;
+        cx.emit(AppStateEvent::ConnectionStatusChanged(self.connection_status));
+        cx.notify();
+        self.refresh_snapshot(cx);
     }
 
     /// Set an error state.

--- a/crates/desktop/src/views/dashboard.rs
+++ b/crates/desktop/src/views/dashboard.rs
@@ -6,11 +6,11 @@
 //! - Recent events list
 
 use chrono::{DateTime, Utc};
-use gpui::{div, prelude::*, Entity, FontWeight, Styled, Window};
+use gpui::{div, prelude::*, Entity, FontWeight, InteractiveElement, Styled, Window};
 
 use crate::api::{self, TaskState};
 use crate::components::{Badge, BadgeVariant, Card, CardContent, CardHeader};
-use crate::state::AppState;
+use crate::state::{AppState, ConnectionStatus};
 use crate::theme::{colors, radius, rgb, spacing, style_helpers::StyledExt, typography, ComponentTheme};
 
 /// Maximum number of recent events to display.
@@ -37,18 +37,75 @@ impl Render for Dashboard {
 
         // Check if we have data
         let Some(snapshot) = state.snapshot() else {
-            return div()
+            let connection_status = state.connection_status();
+            let last_error = state.last_error().map(|s| s.to_string());
+            let app_state = self.state.clone();
+
+            let status_text = match connection_status {
+                ConnectionStatus::Connecting => "Connecting to server...",
+                ConnectionStatus::Reconnecting => "Reconnecting to server...",
+                ConnectionStatus::Failed => "Connection failed",
+                ConnectionStatus::Disconnected => "Disconnected from server",
+                _ => "Connecting to server...",
+            };
+
+            let show_retry = matches!(
+                connection_status,
+                ConnectionStatus::Failed
+                    | ConnectionStatus::Disconnected
+                    | ConnectionStatus::Reconnecting
+            );
+
+            let mut container = div()
                 .size_full()
                 .flex()
+                .flex_col()
                 .items_center()
                 .justify_center()
+                .gap(spacing::SPACE_2)
                 .child(
                     div()
                         .text_muted()
                         .text_size(typography::TEXT_SM)
-                        .child("No data yet"),
-                )
-                .into_any_element();
+                        .child(status_text.to_string()),
+                );
+
+            if let Some(error) = last_error {
+                container = container.child(
+                    div()
+                        .text_size(typography::TEXT_XS)
+                        .text_color(rgb(colors::DESTRUCTIVE))
+                        .max_w(gpui::px(400.0))
+                        .text_ellipsis()
+                        .overflow_hidden()
+                        .child(error),
+                );
+            }
+
+            if show_retry {
+                container = container.child(
+                    div()
+                        .id("retry-button")
+                        .mt(spacing::SPACE_2)
+                        .px(spacing::SPACE_4)
+                        .py(spacing::SPACE_1)
+                        .rounded(radius::MD)
+                        .border_1()
+                        .border_color(rgb(colors::BORDER))
+                        .bg(rgb(colors::CARD))
+                        .text_size(typography::TEXT_SM)
+                        .text_primary()
+                        .cursor_pointer()
+                        .child("Retry")
+                        .on_click(move |_event, _window, cx| {
+                            app_state.update(cx, |state, cx| {
+                                state.retry_connect(cx);
+                            });
+                        }),
+                );
+            }
+
+            return container.into_any_element();
         };
 
         // Calculate stats


### PR DESCRIPTION
## Summary

- When the initial snapshot fetch fails (server not yet running), the desktop app now automatically retries with exponential backoff (1s, 2s, 4s, 8s, 16s, 32s, capped at 30s) instead of showing a blank "No data yet" state forever
- The dashboard shows connection status text ("Connecting to server...", "Reconnecting to server...") and the error message in red
- A "Retry" button is shown for manual reconnection, which resets the backoff timer

## Test plan

- [ ] Start desktop app without the server running — verify it shows "Connecting to server..." then transitions to "Reconnecting..." with error details and a Retry button
- [ ] Click Retry — verify it immediately attempts reconnection and resets status to "Connecting..."
- [ ] Start the server while app is retrying — verify it eventually connects and shows the dashboard
- [ ] Start app with server already running — verify normal startup is unaffected

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)