### PR TITLE
Remove stale .lock() calls after r2d2 pool migration

### DIFF
--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1510,10 +1510,8 @@ impl Server {
                 state.merge_queue.get(entry_id).cloned()
             };
             if let Some(entry) = entry_clone {
-                if let Ok(store) = store.lock() {
-                    if let Err(e) = store.save_merge_entry(&entry) {
-                        tracing::error!(entry_id = %entry_id, error = %e, "failed to persist revert-to-approved");
-                    }
+                if let Err(e) = store.save_merge_entry(&entry) {
+                    tracing::error!(entry_id = %entry_id, error = %e, "failed to persist revert-to-approved");
                 }
             }
         }
@@ -1690,10 +1688,8 @@ impl Server {
                 .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
             // Persist rejected status to SQLite (issue #463)
             if let Some(ref store) = self.store {
-                if let Ok(store) = store.lock() {
-                    if let Err(e) = store.save_merge_entry(entry) {
-                        tracing::error!(entry_id = %entry_id, error = %e, "failed to persist rejected merge queue entry");
-                    }
+                if let Err(e) = store.save_merge_entry(entry) {
+                    tracing::error!(entry_id = %entry_id, error = %e, "failed to persist rejected merge queue entry");
                 }
             }
             entry.task_id.clone()
@@ -1748,10 +1744,8 @@ impl Server {
                 .ok_or_else(|| ServerError::StoreError(format!("entry not found: {}", entry_id)))?;
             // Persist rejected status to SQLite (issue #463)
             if let Some(ref store) = self.store {
-                if let Ok(store) = store.lock() {
-                    if let Err(e) = store.save_merge_entry(entry) {
-                        tracing::error!(entry_id = %entry_id, error = %e, "failed to persist rejected merge queue entry");
-                    }
+                if let Err(e) = store.save_merge_entry(entry) {
+                    tracing::error!(entry_id = %entry_id, error = %e, "failed to persist rejected merge queue entry");
                 }
             }
             entry.task_id.clone()


### PR DESCRIPTION
## Summary

- Removes 3 leftover `.lock()` calls in `server.rs` that cause compilation errors
- These were missed during conflict resolution when merging PR #576 (r2d2 pool) with PR #572 (rejection persistence)

## Details

PR #576 replaced `Mutex<Store>` with an r2d2 connection pool that handles thread safety internally. The Store no longer needs external locking, but three call sites in `server.rs` still had the old `store.lock()` pattern:

- `revert_entry_to_approved()` (line 1513)
- `reject_merge_entry()` (line 1693)  
- `reject_merge_entry_closed()` (line 1751)

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --package server` passes