### PR TITLE
Add container runtime health check at startup

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -12,7 +12,7 @@ use tracing::{debug, error, info, warn};
 
 use events::{Actor, Event, EventBus, EventStore, EventType};
 use uuid::Uuid;
-use runtime::{AppleContainerRuntime, ContainerConfig};
+use runtime::{AppleContainerRuntime, ContainerConfig, ContainerRuntime};
 use server::Server;
 use server::model::merge_queue::{ConflictInfo, ConflictType, MergeQueueEntry};
 use server::model::task::{TaskSource, TaskState};
@@ -278,6 +278,9 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     // --- 3. Create container runtime ---
 
     let container_runtime = AppleContainerRuntime::new();
+    container_runtime.health_check().await.map_err(|e| {
+        format!("container runtime is not available: {e}")
+    })?;
 
     // --- 4. Restart recovery (spec §13.3) ---
     //

--- a/crates/runtime/src/container.rs
+++ b/crates/runtime/src/container.rs
@@ -58,6 +58,10 @@ impl ContainerConfig {
 /// Implementations can use different container runtimes (apple/container, Docker, etc.)
 #[trait_variant::make(Send)]
 pub trait ContainerRuntime {
+    /// Verify the container runtime is available and functional.
+    ///
+    /// Called at startup to fail fast if the runtime CLI is missing or broken.
+    async fn health_check(&self) -> Result<(), ContainerError>;
     /// Create a container from the given config. Returns the container ID.
     async fn create(&self, config: &ContainerConfig) -> Result<String, ContainerError>;
     /// Start a container and attach to its stdio. Returns the transport.
@@ -89,6 +93,23 @@ impl Default for AppleContainerRuntime {
 }
 
 impl ContainerRuntime for AppleContainerRuntime {
+    async fn health_check(&self) -> Result<(), ContainerError> {
+        let output = Command::new("container")
+            .arg("list")
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(ContainerError::CommandFailed(format!(
+                "container runtime check failed: {}",
+                stderr
+            )));
+        }
+
+        Ok(())
+    }
+
     async fn create(&self, config: &ContainerConfig) -> Result<String, ContainerError> {
         let mut cmd = Command::new("container");
         cmd.arg("create");

--- a/crates/server/src/recovery.rs
+++ b/crates/server/src/recovery.rs
@@ -159,6 +159,10 @@ mod tests {
     }
 
     impl ContainerRuntime for MockRuntime {
+        async fn health_check(&self) -> Result<(), ContainerError> {
+            Ok(())
+        }
+
         async fn create(
             &self,
             _config: &runtime::ContainerConfig,


### PR DESCRIPTION
## Summary

Closes #513

- Add `health_check()` method to `ContainerRuntime` trait that verifies the runtime is available
- Implement for `AppleContainerRuntime` by running `container list`
- Call at startup in `run_loop.rs` to fail fast with a clear error if the `container` CLI is missing or broken

## Test plan

- [ ] Start the platform without the `container` CLI installed — should get a clear error message
- [ ] Start the platform with the CLI installed — should proceed normally