### PR TITLE
Add context compaction via LLM summarization

### DIFF
--- a/crates/agent/src/chain.rs
+++ b/crates/agent/src/chain.rs
@@ -199,6 +199,7 @@ impl<P: Provider> ChainBuilder<P> {
             ChainStep::Prompt { message, validator } => {
                 self.session.add_user_message(&message);
                 self.session.state = SessionState::Processing;
+                self.session.compact_if_needed(self.provider.as_ref()).await?;
                 let request = self.session.build_request();
                 let response = self.provider.complete(request).await?;
 

--- a/crates/agent/src/provider.rs
+++ b/crates/agent/src/provider.rs
@@ -32,6 +32,10 @@ pub struct CompletionConfig {
     /// Stop sequences
     #[serde(default)]
     pub stop_sequences: Vec<String>,
+    /// Fraction of context window at which to trigger compaction (0.0–1.0).
+    /// Defaults to 0.85 (85%). Set to 0.0 to disable compaction.
+    #[serde(default = "default_compact_threshold")]
+    pub compact_threshold: f32,
 }
 
 fn default_max_tokens() -> u32 {
@@ -42,6 +46,10 @@ fn default_context_window() -> u32 {
     // Conservative default for deserialization (non-Claude models).
     // CompletionConfig::new() overrides this via context_window_for_model().
     128_000
+}
+
+fn default_compact_threshold() -> f32 {
+    0.85
 }
 
 /// Infer context window size from model name.
@@ -64,6 +72,7 @@ impl Default for CompletionConfig {
             temperature: None,
             top_p: None,
             stop_sequences: Vec::new(),
+            compact_threshold: default_compact_threshold(),
         }
     }
 }
@@ -90,9 +99,23 @@ impl CompletionConfig {
         self
     }
 
+    pub fn with_compact_threshold(mut self, threshold: f32) -> Self {
+        self.compact_threshold = threshold;
+        self
+    }
+
     /// Maximum input tokens available after reserving space for the response.
     pub fn input_budget(&self) -> u32 {
         self.context_window.saturating_sub(self.max_tokens)
+    }
+
+    /// Token count at which context compaction should trigger.
+    /// Returns `None` if compaction is disabled (threshold == 0.0).
+    pub fn compact_budget(&self) -> Option<u32> {
+        if self.compact_threshold <= 0.0 {
+            return None;
+        }
+        Some((self.input_budget() as f32 * self.compact_threshold) as u32)
     }
 }
 

--- a/crates/agent/src/session.rs
+++ b/crates/agent/src/session.rs
@@ -38,6 +38,8 @@ pub struct Session {
     pub total_usage: Usage,
     pub metadata: HashMap<String, serde_json::Value>,
     pub created_at: DateTime<Utc>,
+    /// Number of times context compaction has been performed.
+    pub compaction_count: u32,
 }
 
 impl Session {
@@ -54,6 +56,7 @@ impl Session {
             total_usage: Usage::default(),
             metadata: HashMap::new(),
             created_at: Utc::now(),
+            compaction_count: 0,
         }
     }
 
@@ -223,6 +226,185 @@ impl Session {
         result
     }
 
+    /// Compact the conversation if token usage exceeds the configured threshold.
+    ///
+    /// Calls the LLM to summarize older messages, replacing them with a compact
+    /// summary while preserving the first message (task context) and recent
+    /// messages. Falls back to truncation if summarization fails.
+    ///
+    /// Returns `true` if compaction was performed.
+    pub async fn compact_if_needed(&mut self, provider: &impl Provider) -> Result<bool, AgentError> {
+        let compact_budget = match self.config.compact_budget() {
+            Some(budget) => budget,
+            None => return Ok(false), // compaction disabled
+        };
+
+        // Estimate overhead from system prompt + tools
+        let mut overhead: u32 = 0;
+        if let Some(ref system) = self.system_prompt {
+            overhead += (system.len() as u32) / 4 + 10;
+        }
+        for tool in &self.tools {
+            overhead += (tool.description.len() as u32 + tool.parameters.to_string().len() as u32) / 4 + 20;
+        }
+
+        let total_tokens: u32 = self.messages.iter().map(|m| m.estimate_tokens()).sum();
+        let available = self.config.input_budget().saturating_sub(overhead);
+
+        if total_tokens <= compact_budget.saturating_sub(overhead) {
+            return Ok(false); // under threshold
+        }
+
+        let total = self.messages.len();
+        if total <= 4 {
+            return Ok(false); // too few messages to compact
+        }
+
+        // Decide how many recent messages to keep.
+        // Walk backwards to fill ~40% of available budget with recent messages.
+        let recent_budget = available * 2 / 5;
+        let mut recent_tokens: u32 = 0;
+        let mut keep_recent_from = total;
+        for i in (1..total).rev() {
+            let msg_tokens = self.messages[i].estimate_tokens();
+            if recent_tokens + msg_tokens > recent_budget {
+                break;
+            }
+            recent_tokens += msg_tokens;
+            keep_recent_from = i;
+        }
+        // Keep at least the last 2 messages
+        keep_recent_from = keep_recent_from.min(total.saturating_sub(2));
+        // Must keep at least one message to summarize (index 1..keep_recent_from)
+        if keep_recent_from <= 1 {
+            return Ok(false);
+        }
+
+        // Build the conversation text to summarize (messages [1..keep_recent_from])
+        let messages_to_summarize = &self.messages[1..keep_recent_from];
+        let conversation_text = Self::format_messages_for_summary(messages_to_summarize);
+
+        // Summarize via the provider
+        let summary = self.summarize_conversation(provider, &conversation_text).await;
+
+        let summary_text = match summary {
+            Ok(text) => text,
+            Err(e) => {
+                tracing::warn!(
+                    session_id = %self.id,
+                    error = %e,
+                    "compaction summarization failed, will rely on truncation fallback"
+                );
+                return Ok(false);
+            }
+        };
+
+        // Replace old messages with: [first_msg, summary_msg, ...recent_msgs]
+        let first_message = self.messages[0].clone();
+        let recent_messages: Vec<Message> = self.messages[keep_recent_from..].to_vec();
+
+        let summary_message = Message::user(format!(
+            "[Conversation Summary — compaction #{}]\n\
+             The following summarizes the conversation history that was compacted \
+             to fit within the context window. Key facts, decisions, and context \
+             are preserved below.\n\n{}",
+            self.compaction_count + 1,
+            summary_text,
+        ));
+
+        let old_count = self.messages.len();
+        self.messages.clear();
+        self.messages.push(first_message);
+        self.messages.push(summary_message);
+        self.messages.extend(recent_messages);
+        self.compaction_count += 1;
+
+        let new_tokens: u32 = self.messages.iter().map(|m| m.estimate_tokens()).sum();
+        tracing::info!(
+            session_id = %self.id,
+            compaction_count = self.compaction_count,
+            old_message_count = old_count,
+            new_message_count = self.messages.len(),
+            summarized_messages = keep_recent_from - 1,
+            old_tokens = total_tokens,
+            new_tokens = new_tokens,
+            "compacted conversation via summarization"
+        );
+
+        Ok(true)
+    }
+
+    /// Format messages into a readable conversation transcript for summarization.
+    fn format_messages_for_summary(messages: &[Message]) -> String {
+        let mut lines = Vec::new();
+        for msg in messages {
+            let role_label = match msg.role {
+                Role::User => "User",
+                Role::Assistant => "Assistant",
+                Role::System => "System",
+            };
+            for content in &msg.content {
+                match content {
+                    Content::Text { text } => {
+                        lines.push(format!("[{}]: {}", role_label, text));
+                    }
+                    Content::Thinking { thinking } => {
+                        lines.push(format!("[{}/thinking]: {}", role_label, thinking));
+                    }
+                    Content::ToolUse { name, input, .. } => {
+                        lines.push(format!("[{}/tool_use]: {}({})", role_label, name, input));
+                    }
+                    Content::ToolResult { content, is_error, .. } => {
+                        let prefix = if *is_error { "error" } else { "result" };
+                        // Truncate large tool results to avoid blowing up the summary prompt
+                        let truncated = if content.len() > 500 {
+                            format!("{}... [truncated, {} chars total]", &content[..500], content.len())
+                        } else {
+                            content.clone()
+                        };
+                        lines.push(format!("[{}/tool_{}]: {}", role_label, prefix, truncated));
+                    }
+                    Content::Image { .. } => {
+                        lines.push(format!("[{}/image]: [image data]", role_label));
+                    }
+                }
+            }
+        }
+        lines.join("\n")
+    }
+
+    /// Call the LLM provider to summarize a conversation transcript.
+    async fn summarize_conversation(
+        &self,
+        provider: &impl Provider,
+        conversation_text: &str,
+    ) -> Result<String, AgentError> {
+        let system_prompt = "You are a conversation summarizer. Produce a concise summary of the \
+            conversation that preserves:\n\
+            - Key decisions and their reasoning\n\
+            - Important facts, file paths, and code references\n\
+            - Current task state and progress\n\
+            - Any errors encountered and how they were resolved\n\
+            - Outstanding work or next steps mentioned\n\n\
+            Write the summary in a structured format using short paragraphs or bullet points. \
+            Focus on information the assistant will need to continue working effectively. \
+            Omit pleasantries, redundant exchanges, and verbose tool outputs.";
+
+        let user_prompt = format!(
+            "Summarize the following conversation:\n\n{}", conversation_text
+        );
+
+        let config = CompletionConfig::new(self.config.model.clone())
+            .with_max_tokens(2048)
+            .with_compact_threshold(0.0); // no recursive compaction
+
+        let request = CompletionRequest::new(config, vec![Message::user(user_prompt)])
+            .with_system(system_prompt.to_string());
+
+        let response = provider.complete(request).await?;
+        Ok(response.text())
+    }
+
     /// Apply a response to the session, updating state.
     pub fn apply_response(&mut self, response: &Response) {
         if !response.content.is_empty() {
@@ -349,6 +531,7 @@ impl<P: Provider> Chain<P> {
         self.session.add_user_message(message);
         self.session.state = SessionState::Processing;
 
+        self.session.compact_if_needed(self.provider.as_ref()).await?;
         let request = self.session.build_request();
         let response = self.provider.complete(request).await?;
         self.session.apply_response(&response);
@@ -404,6 +587,7 @@ impl<P: Provider> Chain<P> {
         self.session.apply_tool_results(results);
         self.session.state = SessionState::Processing;
 
+        self.session.compact_if_needed(self.provider.as_ref()).await?;
         let request = self.session.build_request();
         let response = self.provider.complete(request).await?;
         self.session.apply_response(&response);
@@ -420,6 +604,46 @@ impl<P: Provider> Chain<P> {
 mod tests {
     use super::*;
     use crate::message::{Content, StopReason};
+    use crate::provider::StreamChunk;
+    use tokio::sync::mpsc;
+
+    /// A mock provider that returns a fixed response for testing compaction.
+    struct MockProvider {
+        response_text: String,
+    }
+
+    impl MockProvider {
+        fn new(text: impl Into<String>) -> Self {
+            Self { response_text: text.into() }
+        }
+    }
+
+    impl Provider for MockProvider {
+        fn name(&self) -> &str { "mock" }
+        fn models(&self) -> &[&str] { &[] }
+        async fn complete(&self, _request: CompletionRequest) -> std::result::Result<Response, AgentError> {
+            Ok(Response {
+                content: vec![Content::text(&self.response_text)],
+                tool_calls: vec![],
+                stop_reason: Some(StopReason::EndTurn),
+                usage: Some(Usage { input_tokens: 10, output_tokens: 20 }),
+            })
+        }
+        async fn complete_streaming(
+            &self,
+            _request: CompletionRequest,
+        ) -> std::result::Result<mpsc::UnboundedReceiver<StreamChunk>, AgentError> {
+            let (tx, rx) = mpsc::unbounded_channel();
+            let _ = tx.send(StreamChunk::Text(self.response_text.clone()));
+            let _ = tx.send(StreamChunk::Complete(Response {
+                content: vec![Content::text(&self.response_text)],
+                tool_calls: vec![],
+                stop_reason: Some(StopReason::EndTurn),
+                usage: Some(Usage { input_tokens: 10, output_tokens: 20 }),
+            }));
+            Ok(rx)
+        }
+    }
 
     #[test]
     fn test_session_new() {
@@ -661,5 +885,135 @@ mod tests {
         }
         // First message preserved
         assert_eq!(request.messages[0].text(), "implement feature X");
+    }
+
+    #[tokio::test]
+    async fn test_compact_under_threshold_is_noop() {
+        let config = CompletionConfig::new("test-model")
+            .with_context_window(10_000)
+            .with_max_tokens(1000);
+        let mut session = Session::new(config);
+        session.add_user_message("hello");
+        session.add_assistant_message("hi");
+
+        let provider = MockProvider::new("summary");
+        let compacted = session.compact_if_needed(&provider).await.unwrap();
+        assert!(!compacted);
+        assert_eq!(session.compaction_count, 0);
+        assert_eq!(session.messages.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_compact_disabled_when_threshold_zero() {
+        let config = CompletionConfig::new("test-model")
+            .with_context_window(100)
+            .with_max_tokens(20)
+            .with_compact_threshold(0.0);
+        let mut session = Session::new(config);
+
+        // Fill with many messages that exceed budget
+        session.add_user_message("task context");
+        for i in 0..20 {
+            session.add_assistant_message(&format!("working on step {} with lots of detail and explanation", i));
+            session.add_user_message(&format!("continue with step {} and add more detail", i + 1));
+        }
+
+        let provider = MockProvider::new("summary");
+        let compacted = session.compact_if_needed(&provider).await.unwrap();
+        assert!(!compacted);
+        assert_eq!(session.compaction_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_compact_over_threshold_summarizes() {
+        let config = CompletionConfig::new("test-model")
+            .with_context_window(200) // small window
+            .with_max_tokens(40)
+            .with_compact_threshold(0.5); // trigger at 50% to make test easier
+        let mut session = Session::new(config);
+
+        // First message (task context — always preserved)
+        session.add_user_message("task: implement feature X with detailed requirements and specifications");
+        // Add enough messages to exceed the compact threshold
+        for i in 0..10 {
+            session.add_assistant_message(&format!(
+                "working on step {} of the implementation with lots of detailed explanation and code", i
+            ));
+            session.add_user_message(&format!(
+                "continue with step {} and please add more detail about the approach", i + 1
+            ));
+        }
+
+        let original_count = session.messages.len();
+        let provider = MockProvider::new("Summary: implemented feature X through steps 0-9.");
+        let compacted = session.compact_if_needed(&provider).await.unwrap();
+
+        assert!(compacted);
+        assert_eq!(session.compaction_count, 1);
+        // Should have fewer messages now
+        assert!(session.messages.len() < original_count);
+        // First message is still the task context
+        assert!(session.messages[0].text().contains("task: implement feature X"));
+        // Second message is the summary
+        assert!(session.messages[1].text().contains("[Conversation Summary"));
+        assert!(session.messages[1].text().contains("Summary: implemented feature X"));
+    }
+
+    #[tokio::test]
+    async fn test_compact_too_few_messages_is_noop() {
+        let config = CompletionConfig::new("test-model")
+            .with_context_window(50)
+            .with_max_tokens(10)
+            .with_compact_threshold(0.5);
+        let mut session = Session::new(config);
+
+        // Only 3 messages — too few to compact meaningfully
+        session.add_user_message("task context here that is long enough");
+        session.add_assistant_message("response");
+        session.add_user_message("follow up");
+
+        let provider = MockProvider::new("summary");
+        let compacted = session.compact_if_needed(&provider).await.unwrap();
+        assert!(!compacted);
+    }
+
+    #[test]
+    fn test_format_messages_for_summary() {
+        let messages = vec![
+            Message::assistant("I'll read the file"),
+            Message::new(Role::Assistant, vec![
+                Content::ToolUse {
+                    id: "tc-1".into(),
+                    name: "read_file".into(),
+                    input: serde_json::json!({"path": "/tmp/foo.rs"}),
+                },
+            ]),
+            Message::new(Role::User, vec![
+                Content::tool_result("tc-1", "fn main() {}", false),
+            ]),
+            Message::assistant("The file contains a main function"),
+        ];
+
+        let summary = Session::format_messages_for_summary(&messages);
+        assert!(summary.contains("[Assistant]: I'll read the file"));
+        assert!(summary.contains("[Assistant/tool_use]: read_file"));
+        assert!(summary.contains("[User/tool_result]: fn main()"));
+        assert!(summary.contains("[Assistant]: The file contains a main function"));
+    }
+
+    #[test]
+    fn test_compact_budget_calculation() {
+        let config = CompletionConfig::new("test-model")
+            .with_context_window(200_000)
+            .with_max_tokens(4096)
+            .with_compact_threshold(0.85);
+
+        let input_budget = config.input_budget(); // 195_904
+        let compact_budget = config.compact_budget().unwrap();
+        assert_eq!(compact_budget, (input_budget as f32 * 0.85) as u32);
+
+        // Disabled
+        let config = config.with_compact_threshold(0.0);
+        assert!(config.compact_budget().is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Adds LLM-powered conversation summarization that triggers when token usage exceeds 85% of the context window, replacing the blunt middle-message truncation with a summary that preserves key facts, decisions, and context
- Keeps `truncate_to_budget()` as a safety fallback after compaction, so nothing breaks if summarization fails
- Integrates compaction into `Chain`, `ChainBuilder`, and `Session` with full test coverage (6 new tests, all 55 pass)

## Changes

**`crates/agent/src/provider.rs`**
- `compact_threshold` field on `CompletionConfig` (default 0.85, set to 0.0 to disable)
- `compact_budget()` method returns the token threshold for triggering compaction

**`crates/agent/src/session.rs`**
- `compact_if_needed(&mut self, provider)` — async method that summarizes older messages via the LLM when over threshold
- `format_messages_for_summary()` — formats conversation transcript for the summarization prompt
- `summarize_conversation()` — calls the provider with a structured summarization prompt
- `compaction_count` field for debugging/observability
- Compaction integrated into `Chain::user()`, `Chain::tool_results()`

**`crates/agent/src/chain.rs`**
- `ChainBuilder::execute_step()` calls `compact_if_needed` before each prompt step

## How it works

1. Before each LLM request, `compact_if_needed` estimates token usage
2. If over threshold: formats older messages into a transcript, calls the LLM to summarize
3. Replaces `[first_msg, ...old_msgs, ...recent_msgs]` with `[first_msg, summary_msg, ...recent_msgs]`
4. Recent messages get ~40% of the budget; the summary is concise
5. If summarization fails, falls back to the existing truncation strategy

## Test plan

- [x] `test_compact_under_threshold_is_noop` — no compaction when under budget
- [x] `test_compact_disabled_when_threshold_zero` — respects disabled config
- [x] `test_compact_over_threshold_summarizes` — verifies compaction occurs and message structure
- [x] `test_compact_too_few_messages_is_noop` — skips when ≤4 messages
- [x] `test_format_messages_for_summary` — transcript formatting correctness
- [x] `test_compact_budget_calculation` — threshold math
- [x] All 55 existing tests continue to pass

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)