### PR TITLE
Add specialized agent types with tool restrictions

### DIFF
--- a/crates/orchestrator/src/agents.rs
+++ b/crates/orchestrator/src/agents.rs
@@ -1,0 +1,300 @@
+//! Agent type definitions for specialized container agents.
+//!
+//! Each agent type has specific tool restrictions, model preferences, and
+//! behavioral limits. This allows the orchestrator to dispatch the right
+//! kind of agent for each task — implementers for coding, reviewers for
+//! read-only quality checks, explorers for codebase research.
+//!
+//! Inspired by Claude Code's AgentDefinition system (tools/AgentTool).
+
+use serde::{Deserialize, Serialize};
+
+/// Definition of a specialized agent type.
+///
+/// Agent types control what tools an agent can use, which model it runs on,
+/// and how many turns it gets. Tool restrictions are enforced by the
+/// container supervisor when starting the agent process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentDefinition {
+    /// Unique identifier for this agent type (e.g., "implementer", "reviewer").
+    pub agent_type: String,
+
+    /// Human-readable description of when to use this agent type.
+    /// Used by the orchestrator to select the right agent for a task.
+    pub when_to_use: String,
+
+    /// Tool allowlist. If `Some`, only these tools are available.
+    /// If `None`, all tools are available.
+    pub allowed_tools: Option<Vec<String>>,
+
+    /// Tool denylist. These tools are explicitly blocked.
+    /// Applied after the allowlist (if both are set, denylist wins).
+    pub disallowed_tools: Option<Vec<String>>,
+
+    /// Model override. If `None`, uses the system default.
+    pub model: Option<String>,
+
+    /// Maximum number of conversation turns before the agent is stopped.
+    /// Prevents runaway agents.
+    pub max_turns: Option<u32>,
+
+    /// System prompt template for this agent type.
+    /// Can reference `{task}`, `{repo}`, `{branch}` placeholders.
+    pub system_prompt_template: Option<String>,
+}
+
+impl AgentDefinition {
+    /// Create a new agent definition with required fields.
+    pub fn new(agent_type: impl Into<String>, when_to_use: impl Into<String>) -> Self {
+        Self {
+            agent_type: agent_type.into(),
+            when_to_use: when_to_use.into(),
+            allowed_tools: None,
+            disallowed_tools: None,
+            model: None,
+            max_turns: None,
+            system_prompt_template: None,
+        }
+    }
+
+    /// Set the tool allowlist.
+    pub fn with_allowed_tools(mut self, tools: Vec<String>) -> Self {
+        self.allowed_tools = Some(tools);
+        self
+    }
+
+    /// Set the tool denylist.
+    pub fn with_disallowed_tools(mut self, tools: Vec<String>) -> Self {
+        self.disallowed_tools = Some(tools);
+        self
+    }
+
+    /// Set the model override.
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the maximum number of turns.
+    pub fn with_max_turns(mut self, max_turns: u32) -> Self {
+        self.max_turns = Some(max_turns);
+        self
+    }
+
+    /// Set the system prompt template.
+    pub fn with_system_prompt_template(mut self, template: impl Into<String>) -> Self {
+        self.system_prompt_template = Some(template.into());
+        self
+    }
+
+    /// Check whether a tool is allowed for this agent type.
+    pub fn is_tool_allowed(&self, tool_name: &str) -> bool {
+        // Denylist takes precedence
+        if let Some(ref denied) = self.disallowed_tools {
+            if denied.iter().any(|t| t == tool_name) {
+                return false;
+            }
+        }
+
+        // If allowlist is set, tool must be in it
+        if let Some(ref allowed) = self.allowed_tools {
+            return allowed.iter().any(|t| t == tool_name);
+        }
+
+        true
+    }
+}
+
+/// Configuration passed to a container when starting an agent.
+///
+/// Extracted from an `AgentDefinition` and sent as part of the `StartCommand`
+/// protocol message. The supervisor uses this to configure the agent process.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AgentConfig {
+    /// Agent type identifier (e.g., "implementer", "reviewer").
+    pub agent_type: Option<String>,
+
+    /// Tool allowlist — only these tools are available.
+    pub allowed_tools: Option<Vec<String>>,
+
+    /// Tool denylist — these tools are blocked.
+    pub disallowed_tools: Option<Vec<String>>,
+
+    /// Model to use for this agent.
+    pub model: Option<String>,
+
+    /// Maximum conversation turns.
+    pub max_turns: Option<u32>,
+}
+
+impl AgentConfig {
+    /// Create an `AgentConfig` from an `AgentDefinition`.
+    pub fn from_definition(def: &AgentDefinition) -> Self {
+        Self {
+            agent_type: Some(def.agent_type.clone()),
+            allowed_tools: def.allowed_tools.clone(),
+            disallowed_tools: def.disallowed_tools.clone(),
+            model: def.model.clone(),
+            max_turns: def.max_turns,
+        }
+    }
+}
+
+/// Returns the built-in agent type definitions.
+///
+/// These are the default agent types available in the system. Custom agent
+/// types can be defined through project configuration in the future.
+pub fn built_in_agents() -> Vec<AgentDefinition> {
+    vec![
+        // Full-capability implementation agent
+        AgentDefinition::new(
+            "implementer",
+            "Implement features, fix bugs, write code, and make changes to the codebase",
+        )
+        .with_model("claude-sonnet-4-6".to_string())
+        .with_max_turns(200),
+
+        // Read-only code reviewer
+        AgentDefinition::new(
+            "reviewer",
+            "Review code changes for quality, correctness, and adherence to conventions",
+        )
+        .with_allowed_tools(vec![
+            "Read".to_string(),
+            "Grep".to_string(),
+            "Glob".to_string(),
+            "Bash".to_string(),
+        ])
+        .with_disallowed_tools(vec![
+            "Edit".to_string(),
+            "Write".to_string(),
+            "NotebookEdit".to_string(),
+        ])
+        .with_model("claude-opus-4-6".to_string())
+        .with_max_turns(30),
+
+        // Lightweight codebase explorer
+        AgentDefinition::new(
+            "explorer",
+            "Research codebase structure, find patterns, answer questions about the code",
+        )
+        .with_allowed_tools(vec![
+            "Read".to_string(),
+            "Grep".to_string(),
+            "Glob".to_string(),
+        ])
+        .with_model("claude-sonnet-4-6".to_string())
+        .with_max_turns(20),
+    ]
+}
+
+/// Look up a built-in agent definition by type name.
+pub fn get_agent_definition(agent_type: &str) -> Option<AgentDefinition> {
+    built_in_agents()
+        .into_iter()
+        .find(|a| a.agent_type == agent_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn built_in_agents_are_valid() {
+        let agents = built_in_agents();
+        assert_eq!(agents.len(), 3);
+
+        let types: Vec<&str> = agents.iter().map(|a| a.agent_type.as_str()).collect();
+        assert!(types.contains(&"implementer"));
+        assert!(types.contains(&"reviewer"));
+        assert!(types.contains(&"explorer"));
+    }
+
+    #[test]
+    fn get_agent_definition_found() {
+        let def = get_agent_definition("reviewer").unwrap();
+        assert_eq!(def.agent_type, "reviewer");
+        assert_eq!(def.model.as_deref(), Some("claude-opus-4-6"));
+    }
+
+    #[test]
+    fn get_agent_definition_not_found() {
+        assert!(get_agent_definition("nonexistent").is_none());
+    }
+
+    #[test]
+    fn tool_restrictions_implementer() {
+        let def = get_agent_definition("implementer").unwrap();
+        // Implementer has no restrictions
+        assert!(def.is_tool_allowed("Edit"));
+        assert!(def.is_tool_allowed("Write"));
+        assert!(def.is_tool_allowed("Read"));
+        assert!(def.is_tool_allowed("Bash"));
+    }
+
+    #[test]
+    fn tool_restrictions_reviewer() {
+        let def = get_agent_definition("reviewer").unwrap();
+        // Reviewer can read but not write
+        assert!(def.is_tool_allowed("Read"));
+        assert!(def.is_tool_allowed("Grep"));
+        assert!(def.is_tool_allowed("Glob"));
+        assert!(def.is_tool_allowed("Bash"));
+        assert!(!def.is_tool_allowed("Edit"));
+        assert!(!def.is_tool_allowed("Write"));
+        assert!(!def.is_tool_allowed("NotebookEdit"));
+    }
+
+    #[test]
+    fn tool_restrictions_explorer() {
+        let def = get_agent_definition("explorer").unwrap();
+        // Explorer is strictly read-only
+        assert!(def.is_tool_allowed("Read"));
+        assert!(def.is_tool_allowed("Grep"));
+        assert!(def.is_tool_allowed("Glob"));
+        assert!(!def.is_tool_allowed("Bash"));
+        assert!(!def.is_tool_allowed("Edit"));
+        assert!(!def.is_tool_allowed("Write"));
+    }
+
+    #[test]
+    fn denylist_overrides_allowlist() {
+        let def = AgentDefinition::new("test", "test")
+            .with_allowed_tools(vec!["Edit".to_string(), "Read".to_string()])
+            .with_disallowed_tools(vec!["Edit".to_string()]);
+        assert!(!def.is_tool_allowed("Edit")); // denied
+        assert!(def.is_tool_allowed("Read")); // allowed
+        assert!(!def.is_tool_allowed("Write")); // not in allowlist
+    }
+
+    #[test]
+    fn agent_config_from_definition() {
+        let def = get_agent_definition("reviewer").unwrap();
+        let config = AgentConfig::from_definition(&def);
+        assert_eq!(config.agent_type.as_deref(), Some("reviewer"));
+        assert_eq!(config.model.as_deref(), Some("claude-opus-4-6"));
+        assert_eq!(config.max_turns, Some(30));
+        assert!(config.allowed_tools.is_some());
+        assert!(config.disallowed_tools.is_some());
+    }
+
+    #[test]
+    fn agent_config_default_is_empty() {
+        let config = AgentConfig::default();
+        assert!(config.agent_type.is_none());
+        assert!(config.allowed_tools.is_none());
+        assert!(config.disallowed_tools.is_none());
+        assert!(config.model.is_none());
+        assert!(config.max_turns.is_none());
+    }
+
+    #[test]
+    fn agent_definition_serialization_roundtrip() {
+        let def = get_agent_definition("implementer").unwrap();
+        let json = serde_json::to_string(&def).unwrap();
+        let parsed: AgentDefinition = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.agent_type, "implementer");
+        assert_eq!(parsed.model, def.model);
+        assert_eq!(parsed.max_turns, def.max_turns);
+    }
+}

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! Also provides a chat interface for user interaction (orchestrator chat).
 
+pub mod agents;
 pub mod chat;
 pub mod error;
 mod claude;
@@ -14,6 +15,7 @@ mod orchestrator;
 mod prompt;
 pub mod types;
 
+pub use agents::{AgentConfig, AgentDefinition, built_in_agents, get_agent_definition};
 pub use chat::{ChatContext, ChatEvent, ChatResponse, OrchestratorChat, event_to_chat_event};
 pub use claude::ClaudeOrchestrator;
 pub use error::OrchestratorError;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -9,5 +9,6 @@ mod transport;
 mod session;
 
 pub use container::{ContainerConfig, ContainerError, ContainerRuntime, AppleContainerRuntime};
+pub use protocol::AgentStartConfig;
 pub use transport::{StdioTransport, TransportError};
 pub use session::{Session, SessionError, SessionState};

--- a/crates/runtime/src/protocol/commands.rs
+++ b/crates/runtime/src/protocol/commands.rs
@@ -2,12 +2,43 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Agent configuration passed to the container supervisor.
+///
+/// Controls which tools the agent can use, which model it runs on,
+/// and how many conversation turns it gets. Extracted from an
+/// `AgentDefinition` by the orchestrator before dispatch.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AgentStartConfig {
+    /// Agent type identifier (e.g., "implementer", "reviewer").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_type: Option<String>,
+
+    /// Tool allowlist — only these tools are available to the agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+
+    /// Tool denylist — these tools are blocked for the agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disallowed_tools: Option<Vec<String>>,
+
+    /// Model override for the agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    /// Maximum conversation turns before the agent is stopped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_turns: Option<u32>,
+}
+
 /// Start the agent with repo setup and initial prompt.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StartCommand {
     pub repo: String,
     pub branch: String,
     pub prompt: String,
+    /// Optional agent configuration for tool restrictions, model, and limits.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_config: Option<AgentStartConfig>,
 }
 
 /// Send a chat message to the running agent.
@@ -39,6 +70,21 @@ impl Command {
             repo: repo.into(),
             branch: branch.into(),
             prompt: prompt.into(),
+            agent_config: None,
+        })
+    }
+
+    pub fn start_with_config(
+        repo: impl Into<String>,
+        branch: impl Into<String>,
+        prompt: impl Into<String>,
+        agent_config: AgentStartConfig,
+    ) -> Self {
+        Self::Start(StartCommand {
+            repo: repo.into(),
+            branch: branch.into(),
+            prompt: prompt.into(),
+            agent_config: Some(agent_config),
         })
     }
 

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -117,6 +117,24 @@ impl<R: ContainerRuntime> Session<R> {
         Ok(())
     }
 
+    /// Start the agent with a repo, branch, prompt, and agent configuration.
+    ///
+    /// The `agent_config` controls tool restrictions, model selection, and
+    /// turn limits for this agent session.
+    pub fn start_agent_with_config(
+        &mut self,
+        repo: impl Into<String>,
+        branch: impl Into<String>,
+        prompt: impl Into<String>,
+        agent_config: crate::protocol::AgentStartConfig,
+    ) -> Result<(), SessionError> {
+        let transport = self.transport.as_mut().ok_or(SessionError::NotStarted)?;
+        let cmd = Command::start_with_config(repo, branch, prompt, agent_config);
+        transport.send(&cmd)?;
+        self.state = SessionState::Running;
+        Ok(())
+    }
+
     /// Send a chat message to the agent.
     pub fn send_chat(&mut self, text: impl Into<String>) -> Result<(), SessionError> {
         let transport = self.transport.as_mut().ok_or(SessionError::NotStarted)?;

--- a/crates/supervisor/src/main.rs
+++ b/crates/supervisor/src/main.rs
@@ -15,6 +15,21 @@ use tokio::sync::mpsc;
 // Protocol types (matching spec/session-runtime.md §4)
 // ---------------------------------------------------------------------------
 
+/// Agent configuration received from the host.
+#[derive(serde::Deserialize, Default)]
+struct AgentConfig {
+    #[serde(default)]
+    agent_type: Option<String>,
+    #[serde(default)]
+    allowed_tools: Option<Vec<String>>,
+    #[serde(default)]
+    disallowed_tools: Option<Vec<String>>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    max_turns: Option<u32>,
+}
+
 /// Commands from host → supervisor (§4.1).
 #[derive(serde::Deserialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
@@ -23,6 +38,8 @@ enum Cmd {
         repo: String,
         branch: String,
         prompt: String,
+        #[serde(default)]
+        agent_config: Option<AgentConfig>,
     },
     Chat {
         text: String,
@@ -161,22 +178,59 @@ struct AgentHandle {
 
 /// Start the agent process. Returns the handle and spawns tasks that
 /// forward stdout/stderr as protocol events via the provided channel.
+///
+/// If `agent_config` is provided, it overrides the default model and
+/// adds tool restriction flags (--allowed-tools / --disallowed-tools)
+/// and a max-turns limit to the agent command.
 async fn start_agent(
     prompt: &str,
+    agent_config: Option<&AgentConfig>,
     event_tx: &mpsc::UnboundedSender<Ev>,
 ) -> Result<AgentHandle, String> {
     let agent_cmd = std::env::var("AGENT_CMD").unwrap_or_else(|_| "claude".to_string());
+
+    // Determine model: agent_config overrides env/default
+    let model = agent_config
+        .and_then(|c| c.model.clone())
+        .unwrap_or_else(|| "claude-opus-4-6".to_string());
+
     let agent_args: Vec<String> = std::env::var("AGENT_ARGS")
         .map(|s| s.split_whitespace().map(String::from).collect())
-        .unwrap_or_else(|_| vec![
-            "--print".to_string(),
-            "--verbose".to_string(),
-            "--model".to_string(),
-            "claude-opus-4-6".to_string(),
-            "--output-format".to_string(),
-            "stream-json".to_string(),
-            "--dangerously-skip-permissions".to_string(),
-        ]);
+        .unwrap_or_else(|_| {
+            let mut args = vec![
+                "--print".to_string(),
+                "--verbose".to_string(),
+                "--model".to_string(),
+                model,
+                "--output-format".to_string(),
+                "stream-json".to_string(),
+                "--dangerously-skip-permissions".to_string(),
+            ];
+
+            // Add max-turns if configured
+            if let Some(max_turns) = agent_config.and_then(|c| c.max_turns) {
+                args.push("--max-turns".to_string());
+                args.push(max_turns.to_string());
+            }
+
+            // Add allowed-tools if configured
+            if let Some(allowed) = agent_config.and_then(|c| c.allowed_tools.as_ref()) {
+                if !allowed.is_empty() {
+                    args.push("--allowed-tools".to_string());
+                    args.push(allowed.join(","));
+                }
+            }
+
+            // Add disallowed-tools if configured
+            if let Some(disallowed) = agent_config.and_then(|c| c.disallowed_tools.as_ref()) {
+                if !disallowed.is_empty() {
+                    args.push("--disallowed-tools".to_string());
+                    args.push(disallowed.join(","));
+                }
+            }
+
+            args
+        });
 
     // Run the agent as the non-root "agent" user (Claude Code refuses
     // --dangerously-skip-permissions as root). The supervisor stays root (PID 1).
@@ -426,10 +480,14 @@ async fn main() {
             // Commands from host.
             Some(cmd) = cmd_rx.recv() => {
                 match cmd {
-                    Cmd::Start { repo, branch, prompt } => {
+                    Cmd::Start { repo, branch, prompt, agent_config } => {
                         if agent.is_some() {
                             log!("start received while agent already running — ignoring");
                             continue;
+                        }
+                        if let Some(ref config) = agent_config {
+                            log!("agent config: type={:?} model={:?} max_turns={:?}",
+                                config.agent_type, config.model, config.max_turns);
                         }
                         // Clone repo if needed (§3).
                         if !repo_exists() {
@@ -440,7 +498,7 @@ async fn main() {
                             }
                         }
                         // Start agent.
-                        match start_agent(&prompt, &event_tx).await {
+                        match start_agent(&prompt, agent_config.as_ref(), &event_tx).await {
                             Ok(mut handle) => {
                                 // Flush pending chat messages.
                                 for text in pending_chat.drain(..) {


### PR DESCRIPTION
## Summary

- Define `AgentDefinition` and `AgentConfig` types in `crates/orchestrator/src/agents.rs` with three built-in agent types: **implementer** (full tools, sonnet), **reviewer** (read-only, opus), and **explorer** (read-only, sonnet)
- Extend `StartCommand` protocol with optional `AgentStartConfig` for tool restrictions, model override, and max-turns limit
- Update supervisor to configure agent CLI flags (`--model`, `--max-turns`, `--allowed-tools`, `--disallowed-tools`) from agent config
- Add `Session::start_agent_with_config()` and `Command::start_with_config()` for typed agent dispatch

## Test plan

- [x] All 53 existing tests pass (orchestrator + runtime)
- [x] New unit tests for agent definitions, tool restriction logic, serialization roundtrip
- [x] Backward compatible: `agent_config` is optional, existing `start_agent()` still works
- [ ] Integration test: start a container with reviewer config and verify write tools are blocked

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)