### PR TITLE
Add missing_context to QualityEvaluation for incomplete data tracking

### DIFF
--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -172,6 +172,9 @@ impl Orchestrator for ClaudeOrchestrator {
             "Fetched PR details"
         );
 
+        // Track data sources that were unavailable
+        let mut missing_context: Vec<String> = Vec::new();
+
         // Fetch the actual diff
         let diff = match self.github.get_pr_diff(&owner, &repo, pr_number).await {
             Ok(d) => {
@@ -180,6 +183,7 @@ impl Orchestrator for ClaudeOrchestrator {
             }
             Err(e) => {
                 warn!(error = %e, "Failed to fetch PR diff, continuing without it");
+                missing_context.push("pr_diff".to_string());
                 None
             }
         };
@@ -202,6 +206,7 @@ impl Orchestrator for ClaudeOrchestrator {
                     }
                     Err(e) => {
                         warn!(error = %e, "Failed to fetch associated issue, continuing without it");
+                        missing_context.push("associated_issue".to_string());
                         None
                     }
                 }
@@ -240,15 +245,20 @@ impl Orchestrator for ClaudeOrchestrator {
             || pass1.files_to_review.is_none()
             || pass1.files_to_review.as_ref().is_some_and(|f| f.is_empty())
         {
+            if !missing_context.is_empty() {
+                warn!(missing = ?missing_context, "Evaluation completed with incomplete data");
+            }
             info!(
                 approved = pass1.approved,
                 has_feedback = pass1.feedback.is_some(),
+                incomplete = !missing_context.is_empty(),
                 "Evaluation complete (pass 1 — no deeper review needed)"
             );
             return Ok(QualityEvaluation {
                 approved: pass1.approved,
                 reasoning: pass1.reasoning,
                 feedback: pass1.feedback,
+                missing_context: missing_context.clone(),
             });
         }
 
@@ -308,9 +318,13 @@ impl Orchestrator for ClaudeOrchestrator {
 
         let pass2 = self.parse_evaluation_response(&response_text)?;
 
+        if !missing_context.is_empty() {
+            warn!(missing = ?missing_context, "Evaluation completed with incomplete data");
+        }
         info!(
             approved = pass2.approved,
             has_feedback = pass2.feedback.is_some(),
+            incomplete = !missing_context.is_empty(),
             "Evaluation complete (pass 2 — deep review)"
         );
 
@@ -318,6 +332,7 @@ impl Orchestrator for ClaudeOrchestrator {
             approved: pass2.approved,
             reasoning: pass2.reasoning,
             feedback: pass2.feedback,
+            missing_context,
         })
     }
 

--- a/crates/orchestrator/src/mock.rs
+++ b/crates/orchestrator/src/mock.rs
@@ -39,6 +39,7 @@ impl MockOrchestrator {
                 approved: true,
                 reasoning: "Mock: approved".to_string(),
                 feedback: None,
+                missing_context: Vec::new(),
             }),
             conflict_triage: Mutex::new(None),
             evaluate_count: Mutex::new(0),
@@ -57,6 +58,7 @@ impl MockOrchestrator {
                 approved: false,
                 reasoning: "Mock: rejected".to_string(),
                 feedback: Some(feedback),
+                missing_context: Vec::new(),
             }),
             conflict_triage: Mutex::new(None),
             evaluate_count: Mutex::new(0),
@@ -176,6 +178,7 @@ mod tests {
             approved: false,
             reasoning: "changed my mind".to_string(),
             feedback: Some("redo everything".to_string()),
+            missing_context: Vec::new(),
         });
         let ctx = test_context();
         let result = mock.evaluate(&ctx).await.unwrap();

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -86,6 +86,13 @@ pub struct QualityEvaluation {
     /// Specific feedback for the implementor, if the PR needs work.
     /// Used to re-engage the task's agent session.
     pub feedback: Option<String>,
+    /// Data sources that were unavailable during evaluation.
+    ///
+    /// When non-empty, this evaluation was made with incomplete context.
+    /// Each entry describes what was missing (e.g. "pr_diff", "associated_issue").
+    /// Humans reviewing orchestrator decisions can use this to gauge confidence.
+    #[serde(default)]
+    pub missing_context: Vec<String>,
 }
 
 /// Context for conflict triage — spec §7.4.


### PR DESCRIPTION
## Summary
- Adds `missing_context: Vec<String>` field to `QualityEvaluation` so humans can distinguish evaluations made with full context from those made with partial data
- Tracks `"pr_diff"` and `"associated_issue"` as missing context when their respective fetches fail
- Logs a warning when evaluation completes with incomplete data

Closes #509

## Test plan
- [x] All 43 existing orchestrator tests pass
- [ ] Verify `missing_context` is empty when all data fetches succeed
- [ ] Verify `missing_context` contains `"pr_diff"` when diff fetch fails
- [ ] Verify `missing_context` contains `"associated_issue"` when issue fetch fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)