### PR TITLE
Reset approved merge entries to Pending on new commits

### DIFF
--- a/crates/server/src/merge_queue.rs
+++ b/crates/server/src/merge_queue.rs
@@ -693,6 +693,41 @@ mod tests {
     }
 
     #[test]
+    fn update_head_sha_returns_changed() {
+        let mut q = MergeQueue::new();
+        q.enqueue(entry("m1", "t1"));
+
+        // First update: no prior SHA, should report changed
+        assert_eq!(q.update_head_sha("m1", "abc123").unwrap(), true);
+        assert_eq!(q.get("m1").unwrap().head_sha.as_deref(), Some("abc123"));
+
+        // Same SHA: no change
+        assert_eq!(q.update_head_sha("m1", "abc123").unwrap(), false);
+
+        // Different SHA: changed
+        assert_eq!(q.update_head_sha("m1", "def456").unwrap(), true);
+        assert_eq!(q.get("m1").unwrap().head_sha.as_deref(), Some("def456"));
+    }
+
+    #[test]
+    fn approved_entry_can_be_reset_to_pending_on_sha_change() {
+        let mut q = MergeQueue::new();
+        q.enqueue(entry("m1", "t1"));
+        q.approve("m1").unwrap();
+        assert_eq!(q.get("m1").unwrap().status, MergeStatus::Approved);
+
+        // Simulate what reconcile_merge_queue does: update SHA and reset if changed
+        let changed = q.update_head_sha("m1", "new_sha").unwrap();
+        assert!(changed);
+        if let Some(e) = q.get_mut("m1") {
+            if e.status == MergeStatus::Approved {
+                e.status = MergeStatus::Pending;
+            }
+        }
+        assert_eq!(q.get("m1").unwrap().status, MergeStatus::Pending);
+    }
+
+    #[test]
     fn entries_with_positions_no_approved() {
         let mut q = MergeQueue::new();
         q.enqueue(entry("m1", "t1"));

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1359,11 +1359,24 @@ impl Server {
                 let mut state = self.state.write().await;
                 match state.merge_queue.update_head_sha(&entry_id, &head_sha) {
                     Ok(true) => {
-                        tracing::debug!(
+                        tracing::info!(
                             entry_id = %entry_id,
                             head_sha = %head_sha,
                             "reconciliation: updated head_sha for PR"
                         );
+                        // New commits detected — reset Approved entries to Pending
+                        // so the orchestrator re-evaluates the updated code.
+                        if let Some(entry) = state.merge_queue.get_mut(&entry_id) {
+                            if entry.status == MergeStatus::Approved {
+                                tracing::info!(
+                                    entry_id = %entry_id,
+                                    head_sha = %head_sha,
+                                    "reconciliation: new commits on approved PR, resetting to Pending for re-evaluation"
+                                );
+                                entry.status = MergeStatus::Pending;
+                                changes += 1;
+                            }
+                        }
                     }
                     Ok(false) => {} // No change
                     Err(e) => {


### PR DESCRIPTION
## Summary
- When reconciliation detects a `head_sha` change on an open PR, entries with `Approved` status are reset to `Pending` so the orchestrator re-evaluates the updated code
- Previously, a PR approved at commit A stayed approved even after the agent pushed commits B and C with potentially different code
- Added unit tests for `update_head_sha` behavior and the reset-to-pending pattern

## Test plan
- [x] Existing merge queue tests pass (20/20)
- [x] New `update_head_sha_returns_changed` test verifies SHA change detection
- [x] New `approved_entry_can_be_reset_to_pending_on_sha_change` test verifies the reset pattern
- [ ] Manual: verify that pushing a new commit to an approved PR triggers re-evaluation

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)