### PR TITLE
Add missing_context to QualityEvaluation for incomplete data tracking

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -2164,6 +2164,12 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                         "**Orchestrator Evaluation: {}**\n\n{}",
                         verdict, evaluation.reasoning
                     );
+                    if !evaluation.missing_context.is_empty() {
+                        comment_body.push_str(&format!(
+                            "\n\n> **Note:** This evaluation was made with incomplete data. Missing: {}",
+                            evaluation.missing_context.join(", ")
+                        ));
+                    }
                     if let Some(feedback) = &evaluation.feedback {
                         comment_body.push_str(&format!(
                             "\n\n---\n**Feedback for agent:**\n{}",


### PR DESCRIPTION
## Summary

- Adds `missing_context: Vec<String>` field to `QualityEvaluation` so humans can distinguish evaluations made with full context from those made with partial data
- Tracks `"pr_diff"` and `"linked_issue"` as missing context when GitHub fetches fail in `ClaudeOrchestrator::evaluate()`
- Surfaces missing context in PR evaluation comments (blockquote note)
- Uses `#[serde(default)]` for backward-compatible deserialization

## Test plan

- [x] All 53 orchestrator tests pass
- [x] Full `cargo check` succeeds
- [ ] Verify PR comments show missing context note when diff/issue fetch fails

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)