### PR TITLE
Stop active sessions when their GitHub issue is closed externally

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -494,6 +494,7 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
     let github_token = config.github_token.clone();
     let poll_config_watcher = workflow_config_watcher.clone();
     let poll_rejected_cooldown = rejected_pr_cooldown.clone();
+    let poll_session_mgr = session_manager.clone();
     let mut poll_shutdown_rx = shutdown_tx.subscribe();
 
     let poll_handle = tokio::spawn(async move {
@@ -684,6 +685,24 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                                                 updated_fields = ?result.updated_fields,
                                                 "reconciled task from GitHub"
                                             );
+
+                                            // Stop the running session when the issue
+                                            // is closed externally (issue #499).
+                                            if new_state.is_terminal() {
+                                                match poll_session_mgr.stop_session(&task_id).await {
+                                                    Ok(()) => {
+                                                        info!(
+                                                            task_id = %task_id,
+                                                            new_state = ?new_state,
+                                                            "stopped session for externally closed issue"
+                                                        );
+                                                    }
+                                                    Err(_) => {
+                                                        // No active session — task was
+                                                        // waiting/blocked, not running.
+                                                    }
+                                                }
+                                            }
                                         } else if !result.updated_fields.is_empty() {
                                             debug!(
                                                 project = %project_id,

--- a/crates/server/src/scheduler.rs
+++ b/crates/server/src/scheduler.rs
@@ -968,6 +968,28 @@ mod tests {
     }
 
     #[test]
+    fn reconcile_closure_stops_active_task() {
+        // Issue #499: When an issue is closed externally while a task is Running,
+        // reconcile should still transition the task to a terminal state.
+        let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
+        let cfg = default_label_config();
+        let mut task = make_task_from_issue(&issue, &cfg);
+        task.set_state(TaskState::Running);
+
+        let mut closed_issue = issue.clone();
+        closed_issue.state = GhIssueState::Closed;
+        closed_issue.state_reason = Some(tasks_github::model::IssueStateReason::NotPlanned);
+
+        let result = reconcile_task(&mut task, &closed_issue, &cfg);
+        assert_eq!(result.new_state, Some(TaskState::Cancelled));
+        assert_eq!(task.state, TaskState::Cancelled);
+        assert_eq!(
+            result.closure_reason,
+            Some(tasks_github::model::ClosureReason::NotPlanned)
+        );
+    }
+
+    #[test]
     fn reconcile_updates_priority() {
         let issue = make_issue(42, vec![make_label("bug")], GhIssueState::Open);
         let cfg = default_label_config();


### PR DESCRIPTION
## Summary

- When a GitHub issue is closed while its task has an active session (Running/Question/Testing/etc.), the poll loop now calls `session_manager.stop_session()` to signal the session to stop
- Previously, `reconcile_task` correctly transitioned the task state to terminal but no one told the session to stop — it would keep running until it exited on its own
- Added a test confirming `reconcile_task` transitions Running tasks to terminal on external closure

## Details

The fix is two parts:

1. **`crates/app/src/run_loop.rs`**: Clone `session_manager` into the poll task and, after reconciliation detects a terminal state transition, call `stop_session()`. Errors are silently ignored (task may not have an active session).

2. **`crates/server/src/scheduler.rs`**: Added `reconcile_closure_stops_active_task` test confirming that a Running task whose issue is closed as NotPlanned transitions to Cancelled.

Note: `reconcile_task` already handled closure detection for active tasks correctly (the `is_active` guard only protects blocked-label logic). The missing piece was the run_loop not acting on the terminal state by stopping the session.

## Test plan

- [x] `cargo test --package server --lib scheduler` — all 36 tests pass
- [x] `cargo check --package tasks-app` — compiles cleanly
- [ ] Manual: close an issue while its task is Running, verify session stops promptly

Fixes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)