### PR TITLE
Proactively fetch file context during PR review

### DIFF
--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -6,9 +6,10 @@
 use serde::Deserialize;
 use tracing::{info, warn};
 
+use crate::diff::{extract_context_window, parse_diff_files};
 use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
-use crate::prompt::{build_evaluation_prompt, build_deep_review_prompt, parse_pr_url, system_prompt};
+use crate::prompt::{build_evaluation_prompt_with_context, build_deep_review_prompt, parse_pr_url, system_prompt, FileContext};
 use crate::types::{
     default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
     QualityEvaluation, QuestionContext, SystemContext,
@@ -214,15 +215,66 @@ impl Orchestrator for ClaudeOrchestrator {
             _ => None,
         };
 
-        // --- Pass 1: Triage with diff ---
+        // --- Proactive context fetching ---
+        // Parse the diff to find the most-changed files and fetch context
+        // windows around their changed lines. This gives the reviewer
+        // surrounding code context without needing a pass-2 deep review.
+        let mut file_contexts: Vec<FileContext> = Vec::new();
+        if let Some(ref diff_text) = diff {
+            let changed_files = parse_diff_files(diff_text);
+            // Fetch up to 3 most-changed files
+            for diff_file in changed_files.iter().take(3) {
+                match self
+                    .github
+                    .get_file_content_at_ref(&owner, &repo, &diff_file.path, &pr.head_ref)
+                    .await
+                {
+                    Ok(Some(content)) => {
+                        let windowed = extract_context_window(
+                            &content,
+                            &diff_file.changed_lines,
+                            50,   // ±50 lines around each change
+                            1000, // max 1000 lines per file
+                        );
+                        if !windowed.is_empty() {
+                            info!(
+                                path = %diff_file.path,
+                                changed_lines = diff_file.changed_lines.len(),
+                                context_lines = windowed.lines().count(),
+                                "Fetched proactive file context"
+                            );
+                            file_contexts.push(FileContext {
+                                path: diff_file.path.clone(),
+                                content: windowed,
+                            });
+                        }
+                    }
+                    Ok(None) => {
+                        info!(path = %diff_file.path, "File not found on PR branch (may be deleted)");
+                    }
+                    Err(e) => {
+                        warn!(path = %diff_file.path, error = %e, "Failed to fetch file context, skipping");
+                    }
+                }
+            }
+            if !file_contexts.is_empty() {
+                info!(
+                    file_count = file_contexts.len(),
+                    "Proactive context fetched for evaluation"
+                );
+            }
+        }
+
+        // --- Pass 1: Triage with diff + proactive file context ---
         let system = system_prompt();
-        let user_prompt = build_evaluation_prompt(
+        let user_prompt = build_evaluation_prompt_with_context(
             &pr,
             issue.as_ref(),
             &context.task.title,
             context.task.description.as_deref(),
             diff.as_deref(),
             &context.queue_context,
+            &file_contexts,
         );
 
         let config = CompletionConfig::new(&self.model).with_max_tokens(self.max_tokens);

--- a/crates/orchestrator/src/diff.rs
+++ b/crates/orchestrator/src/diff.rs
@@ -1,0 +1,265 @@
+//! Unified diff parser for extracting file paths and changed line numbers.
+//!
+//! Used by the orchestrator to proactively fetch context around changed lines
+//! during PR evaluation, reducing the need for pass-2 deep reviews.
+
+/// A file that appears in a unified diff, with its changed line numbers.
+#[derive(Debug, Clone)]
+pub struct DiffFile {
+    /// Path of the changed file (e.g., "src/main.rs").
+    pub path: String,
+    /// Line numbers that were changed in the new version of the file.
+    /// These are line numbers from the `+` side of the diff (additions/modifications).
+    pub changed_lines: Vec<usize>,
+}
+
+/// Parse a unified diff to extract file paths and changed line numbers.
+///
+/// Returns files sorted by number of changed lines (most changed first).
+pub fn parse_diff_files(diff: &str) -> Vec<DiffFile> {
+    let mut files: Vec<DiffFile> = Vec::new();
+    let mut current_path: Option<String> = None;
+    let mut current_lines: Vec<usize> = Vec::new();
+    // Current line number in the new file (right side of hunk header)
+    let mut new_line: usize = 0;
+
+    for line in diff.lines() {
+        if line.starts_with("+++ b/") {
+            // Flush previous file
+            if let Some(path) = current_path.take() {
+                if !current_lines.is_empty() {
+                    files.push(DiffFile {
+                        path,
+                        changed_lines: std::mem::take(&mut current_lines),
+                    });
+                }
+            }
+            current_path = Some(line[6..].to_string());
+            current_lines.clear();
+        } else if line.starts_with("+++ /dev/null") {
+            // File was deleted — skip it
+            if let Some(path) = current_path.take() {
+                if !current_lines.is_empty() {
+                    files.push(DiffFile {
+                        path,
+                        changed_lines: std::mem::take(&mut current_lines),
+                    });
+                }
+            }
+            current_path = None;
+            current_lines.clear();
+        } else if line.starts_with("@@ ") {
+            // Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
+            if let Some(new_start) = parse_hunk_header_new_start(line) {
+                new_line = new_start;
+            }
+        } else if current_path.is_some() {
+            if let Some(stripped) = line.strip_prefix('+') {
+                // Added/modified line — not the +++ header
+                if !stripped.starts_with("++ ") {
+                    current_lines.push(new_line);
+                    new_line += 1;
+                }
+            } else if line.starts_with('-') {
+                // Removed line — doesn't advance new_line counter
+            } else {
+                // Context line — advances new_line counter
+                new_line += 1;
+            }
+        }
+    }
+
+    // Flush last file
+    if let Some(path) = current_path {
+        if !current_lines.is_empty() {
+            files.push(DiffFile {
+                path,
+                changed_lines: current_lines,
+            });
+        }
+    }
+
+    // Sort by most changed lines first
+    files.sort_by(|a, b| b.changed_lines.len().cmp(&a.changed_lines.len()));
+    files
+}
+
+/// Parse the new-file start line from a hunk header.
+///
+/// Format: `@@ -old_start[,old_count] +new_start[,new_count] @@`
+fn parse_hunk_header_new_start(line: &str) -> Option<usize> {
+    let plus_idx = line.find('+').filter(|&i| i > 0)?;
+    let rest = &line[plus_idx + 1..];
+    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
+    rest[..end].parse().ok()
+}
+
+/// Extract context windows around changed lines from file content.
+///
+/// Returns lines with line numbers, showing ±`window` lines around each change.
+/// Adjacent windows are merged. Total output is capped at `max_lines`.
+pub fn extract_context_window(
+    content: &str,
+    changed_lines: &[usize],
+    window: usize,
+    max_lines: usize,
+) -> String {
+    if changed_lines.is_empty() {
+        return String::new();
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    let total_lines = lines.len();
+
+    // Build a set of line numbers to include (1-indexed)
+    let mut include = vec![false; total_lines + 1];
+    for &line_num in changed_lines {
+        let start = line_num.saturating_sub(window).max(1);
+        let end = (line_num + window).min(total_lines);
+        for i in start..=end {
+            include[i] = true;
+        }
+    }
+
+    let mut result = Vec::new();
+    let mut in_window = false;
+
+    for (idx, line_text) in lines.iter().enumerate() {
+        let line_num = idx + 1;
+        if line_num >= include.len() {
+            break;
+        }
+        if include[line_num] {
+            if !in_window && !result.is_empty() {
+                result.push("...".to_string());
+            }
+            in_window = true;
+            result.push(format!("{}: {}", line_num, line_text));
+            if result.len() >= max_lines {
+                result.push("... (truncated)".to_string());
+                break;
+            }
+        } else {
+            in_window = false;
+        }
+    }
+
+    result.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_diff_files_basic() {
+        let diff = r#"diff --git a/src/main.rs b/src/main.rs
+index abc123..def456 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -10,6 +10,7 @@ fn main() {
+     let x = 1;
+     let y = 2;
++    let z = 3;
+     println!("hello");
+ }
+"#;
+        let files = parse_diff_files(diff);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "src/main.rs");
+        assert_eq!(files[0].changed_lines, vec![12]);
+    }
+
+    #[test]
+    fn test_parse_diff_files_multiple() {
+        let diff = r#"diff --git a/src/a.rs b/src/a.rs
+--- a/src/a.rs
++++ b/src/a.rs
+@@ -1,3 +1,4 @@
+ line1
++added1
++added2
+ line2
+diff --git a/src/b.rs b/src/b.rs
+--- a/src/b.rs
++++ b/src/b.rs
+@@ -5,3 +5,4 @@
+ line5
++added3
+ line6
+"#;
+        let files = parse_diff_files(diff);
+        assert_eq!(files.len(), 2);
+        // Most changed first
+        assert_eq!(files[0].path, "src/a.rs");
+        assert_eq!(files[0].changed_lines.len(), 2);
+        assert_eq!(files[1].path, "src/b.rs");
+        assert_eq!(files[1].changed_lines.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_diff_files_deleted_file() {
+        let diff = r#"diff --git a/src/old.rs b/src/old.rs
+--- a/src/old.rs
++++ /dev/null
+@@ -1,3 +0,0 @@
+-line1
+-line2
+-line3
+"#;
+        let files = parse_diff_files(diff);
+        // Deleted files have no added lines
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_parse_hunk_header() {
+        assert_eq!(parse_hunk_header_new_start("@@ -10,6 +10,7 @@ fn main()"), Some(10));
+        assert_eq!(parse_hunk_header_new_start("@@ -1 +1,4 @@"), Some(1));
+        assert_eq!(parse_hunk_header_new_start("@@ -0,0 +1,20 @@"), Some(1));
+    }
+
+    #[test]
+    fn test_extract_context_window() {
+        let content = (1..=20)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let result = extract_context_window(&content, &[10], 2, 100);
+        assert!(result.contains("8: line 8"));
+        assert!(result.contains("10: line 10"));
+        assert!(result.contains("12: line 12"));
+        assert!(!result.contains("7: line 7"));
+        assert!(!result.contains("13: line 13"));
+    }
+
+    #[test]
+    fn test_extract_context_window_merged_ranges() {
+        let content = (1..=20)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Two changes close together — windows should merge
+        let result = extract_context_window(&content, &[5, 7], 2, 100);
+        assert!(result.contains("3: line 3"));
+        assert!(result.contains("9: line 9"));
+        // No ellipsis between them since windows overlap
+        assert!(!result.contains("..."));
+    }
+
+    #[test]
+    fn test_extract_context_window_max_lines() {
+        let content = (1..=100)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let result = extract_context_window(&content, &[50], 50, 10);
+        let line_count = result.lines().count();
+        // Should be capped at max_lines + truncation message
+        assert!(line_count <= 11);
+        assert!(result.contains("truncated"));
+    }
+}

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod agents;
 pub mod chat;
+mod diff;
 pub mod error;
 mod claude;
 pub mod mock;

--- a/crates/orchestrator/src/prompt.rs
+++ b/crates/orchestrator/src/prompt.rs
@@ -18,10 +18,12 @@ You review the ACTUAL CODE DIFF, not just PR metadata. Do not trust the PR descr
 ## Review process
 
 **Pass 1 — Diff triage:**
-Read the diff carefully. Evaluate:
+Read the diff carefully. You may also receive **file context** showing code around the changed lines in the most-modified files. Use this context to understand how changes integrate with surrounding code — check for callers that weren't updated, broken invariants, or incomplete changes.
+
+Evaluate:
 
 1. **Issue alignment**: Does the diff actually address the issue? Not "does the PR description say it does" — do the actual code changes solve the problem?
-2. **Correctness**: Are there obvious bugs, missing error handling, or incomplete changes? For removals: is anything left that depends on the removed code? For additions: does the new code handle edge cases?
+2. **Correctness**: Are there obvious bugs, missing error handling, or incomplete changes? For removals: is anything left that depends on the removed code? For additions: does the new code handle edge cases? Use the file context to check surrounding code.
 3. **Completeness**: Does the diff cover all aspects of the issue, or are there gaps?
 4. **Conflicts/CI**: Check mergeable state and review status from the metadata.
 5. **Queue context**: Consider other PRs in the merge queue. If this PR appears to depend on changes from another PR that hasn't merged yet, or if issues you see would be resolved by a PR ahead in the queue, factor that into your decision.
@@ -67,6 +69,61 @@ Response format for Pass 2 is the same, but `needs_deeper_review` must be false.
 - For large diffs: if truncated, lean toward requesting deeper review rather than approving blind.
 - Be concise but specific. If rejecting, point to exact lines/hunks in the diff.
 - Consider queue ordering: if a "missing function" or "undefined reference" issue might be resolved by a PR ahead in the queue, mention this in your reasoning rather than rejecting outright."#.to_string()
+}
+
+/// A file context entry: path and windowed content around changed lines.
+pub struct FileContext {
+    /// File path (e.g., "src/main.rs").
+    pub path: String,
+    /// Windowed content with line numbers (context around changed lines).
+    pub content: String,
+}
+
+/// Build the user prompt with PR, issue, and proactive file context.
+///
+/// This is the enhanced version that includes context windows around changed
+/// files, allowing the reviewer to see surrounding code without a second pass.
+pub fn build_evaluation_prompt_with_context(
+    pr: &PullRequest,
+    issue: Option<&Issue>,
+    task_title: &str,
+    task_description: Option<&str>,
+    diff: Option<&str>,
+    queue_context: &[QueueEntrySummary],
+    file_contexts: &[FileContext],
+) -> String {
+    let mut prompt = build_evaluation_prompt(pr, issue, task_title, task_description, diff, queue_context);
+
+    if !file_contexts.is_empty() {
+        // Insert file context before the evaluation request
+        let eval_header = "## Evaluation Request";
+        if let Some(pos) = prompt.find(eval_header) {
+            let context_section = build_file_context_section(file_contexts);
+            prompt.insert_str(pos, &context_section);
+        }
+    }
+
+    prompt
+}
+
+/// Build the file context section for the prompt.
+fn build_file_context_section(file_contexts: &[FileContext]) -> String {
+    let mut section = String::new();
+    section.push_str("## File Context (around changed lines)\n\n");
+    section.push_str("The following shows code context (with line numbers) around the changed lines in the most-modified files. ");
+    section.push_str("Use this to understand how the changes fit into the surrounding code.\n\n");
+
+    for ctx in file_contexts {
+        section.push_str(&format!("### `{}`\n\n", ctx.path));
+        section.push_str("```\n");
+        section.push_str(&ctx.content);
+        if !ctx.content.ends_with('\n') {
+            section.push('\n');
+        }
+        section.push_str("```\n\n");
+    }
+
+    section
 }
 
 /// Build the user prompt with PR and issue context.
@@ -585,5 +642,60 @@ mod tests {
         let prompt = system_prompt();
         assert!(prompt.contains("Queue context"));
         assert!(prompt.contains("queue ordering"));
+    }
+
+    #[test]
+    fn test_system_prompt_mentions_file_context() {
+        let prompt = system_prompt();
+        assert!(prompt.contains("file context"));
+    }
+
+    #[test]
+    fn test_build_evaluation_prompt_with_file_context() {
+        let pr = test_pr();
+        let file_contexts = vec![
+            FileContext {
+                path: "src/auth.rs".to_string(),
+                content: "10: fn login() {\n11:     let timeout = 30;\n12: }".to_string(),
+            },
+        ];
+        let prompt = build_evaluation_prompt_with_context(
+            &pr,
+            None,
+            "Fix auth bug",
+            None,
+            Some("diff --git a/src/auth.rs b/src/auth.rs\n-old\n+new"),
+            &[],
+            &file_contexts,
+        );
+
+        // Should contain file context section
+        assert!(prompt.contains("## File Context (around changed lines)"));
+        assert!(prompt.contains("src/auth.rs"));
+        assert!(prompt.contains("fn login()"));
+        assert!(prompt.contains("let timeout = 30"));
+        // Should still contain the diff
+        assert!(prompt.contains("## Diff"));
+        // File context should appear before evaluation request
+        let ctx_pos = prompt.find("## File Context").unwrap();
+        let eval_pos = prompt.find("## Evaluation Request").unwrap();
+        assert!(ctx_pos < eval_pos);
+    }
+
+    #[test]
+    fn test_build_evaluation_prompt_with_empty_file_context() {
+        let pr = test_pr();
+        let prompt = build_evaluation_prompt_with_context(
+            &pr,
+            None,
+            "Fix auth bug",
+            None,
+            Some("diff content"),
+            &[],
+            &[], // no file contexts
+        );
+
+        // Should NOT contain file context section when empty
+        assert!(!prompt.contains("## File Context"));
     }
 }


### PR DESCRIPTION
## Summary

- **Adds diff parser** (`crates/orchestrator/src/diff.rs`): Parses unified diffs to extract file paths and changed line numbers, sorted by most-changed first
- **Proactive context fetching**: Before pass-1 evaluation, fetches the top 3 most-changed files from the PR branch and extracts ±50 line context windows around changed lines (capped at 1000 lines per file)
- **Enhanced evaluation prompt**: Includes file context section between the diff and evaluation request, giving the reviewer surrounding code context to catch issues like missing caller updates or broken invariants
- **Updated system prompt**: Instructs the reviewer to use the proactive file context for deeper analysis during pass-1

## Design

The implementation follows the two-phase approach from the issue:

**Phase 1 (this PR)**: Parse diff → identify most-changed files → fetch content at PR head ref → include in pass-1 prompt

**Phase 2 (this PR)**: Smart context windowing with `extract_context_window()` — instead of full files, shows ±50 lines around each changed line with line numbers. Adjacent windows are merged, and output is capped to avoid token bloat.

### Limits
- Max 3 files fetched proactively
- ±50 lines context window per change
- Max 1000 output lines per file
- Deleted files are skipped (no content to fetch)
- Fetch failures are logged and skipped gracefully

## Test plan

- [x] New unit tests for diff parsing (basic, multiple files, deleted files, hunk headers)
- [x] New unit tests for context windowing (basic, merged ranges, max lines cap)
- [x] New unit tests for prompt building with file context (with context, empty context)
- [x] All 63 orchestrator tests pass
- [x] Full workspace compiles clean

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)