### PR TITLE
Fetch full file context during review, not just diffs

### DIFF
--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -6,6 +6,7 @@
 use serde::Deserialize;
 use tracing::{info, warn};
 
+use crate::diff::{parse_diff_files, extract_context_window, MAX_CONTEXT_FILES, MAX_CONTEXT_LINES, CONTEXT_WINDOW};
 use crate::error::OrchestratorError;
 use crate::orchestrator::Orchestrator;
 use crate::prompt::{build_evaluation_prompt, build_deep_review_prompt, parse_pr_url, system_prompt};
@@ -214,7 +215,55 @@ impl Orchestrator for ClaudeOrchestrator {
             _ => None,
         };
 
-        // --- Pass 1: Triage with diff ---
+        // --- Proactive context fetching ---
+        // Parse the diff to find the most-changed files and fetch surrounding code
+        let mut file_contexts: Vec<(String, String)> = Vec::new();
+        if let Some(ref diff_text) = diff {
+            let changed_files = parse_diff_files(diff_text);
+            let mut total_lines = 0usize;
+
+            for file in changed_files.iter().take(MAX_CONTEXT_FILES) {
+                if total_lines >= MAX_CONTEXT_LINES {
+                    break;
+                }
+                match self
+                    .github
+                    .get_file_content_at_ref(&owner, &repo, &file.path, &pr.head_ref)
+                    .await
+                {
+                    Ok(Some(content)) => {
+                        let context_window =
+                            extract_context_window(&content, &file.changed_lines, CONTEXT_WINDOW);
+                        let line_count = context_window.lines().count();
+                        if line_count > 0 {
+                            info!(
+                                path = %file.path,
+                                context_lines = line_count,
+                                "Fetched proactive context"
+                            );
+                            total_lines += line_count;
+                            file_contexts.push((file.path.clone(), context_window));
+                        }
+                    }
+                    Ok(None) => {
+                        info!(path = %file.path, "File not found for proactive context (may be new)");
+                    }
+                    Err(e) => {
+                        warn!(path = %file.path, error = %e, "Failed to fetch proactive context");
+                    }
+                }
+            }
+
+            if !file_contexts.is_empty() {
+                info!(
+                    files = file_contexts.len(),
+                    total_lines,
+                    "Proactive context fetched for evaluation"
+                );
+            }
+        }
+
+        // --- Pass 1: Triage with diff + proactive context ---
         let system = system_prompt();
         let user_prompt = build_evaluation_prompt(
             &pr,
@@ -222,6 +271,7 @@ impl Orchestrator for ClaudeOrchestrator {
             &context.task.title,
             context.task.description.as_deref(),
             diff.as_deref(),
+            &file_contexts,
             &context.queue_context,
         );
 

--- a/crates/orchestrator/src/diff.rs
+++ b/crates/orchestrator/src/diff.rs
@@ -1,0 +1,279 @@
+//! Unified diff parser for extracting file paths and changed line numbers.
+//!
+//! Used by the orchestrator to proactively fetch context around changed lines
+//! during PR review, so the reviewer sees surrounding code — not just isolated hunks.
+
+use std::collections::HashSet;
+
+/// A file that was changed in a diff, with the line numbers that were modified.
+#[derive(Debug, Clone)]
+pub struct DiffFile {
+    /// Path of the changed file (e.g. "src/auth.rs").
+    pub path: String,
+    /// Line numbers changed in the new (post-image) version of the file.
+    pub changed_lines: Vec<usize>,
+    /// Total number of added + removed lines (used for ranking "most changed").
+    pub change_count: usize,
+}
+
+/// Parse a unified diff to extract changed files and their changed line numbers.
+///
+/// Handles standard `diff --git a/path b/path` and `--- a/path` / `+++ b/path` headers.
+/// Extracts new-side line numbers from `@@ -old,count +new,count @@` hunk headers.
+pub fn parse_diff_files(diff: &str) -> Vec<DiffFile> {
+    let mut files: Vec<DiffFile> = Vec::new();
+    let mut current_path: Option<String> = None;
+    let mut changed_lines: Vec<usize> = Vec::new();
+    let mut change_count: usize = 0;
+    let mut new_line_num: usize = 0;
+
+    for line in diff.lines() {
+        if line.starts_with("diff --git ") {
+            // Flush previous file
+            if let Some(path) = current_path.take() {
+                if !changed_lines.is_empty() {
+                    files.push(DiffFile {
+                        path,
+                        changed_lines: std::mem::take(&mut changed_lines),
+                        change_count,
+                    });
+                }
+            }
+            change_count = 0;
+            new_line_num = 0;
+        } else if line.starts_with("+++ b/") {
+            current_path = Some(line[6..].to_string());
+        } else if line.starts_with("+++ /dev/null") {
+            // File was deleted — no new-side content to fetch
+            current_path = None;
+        } else if line.starts_with("@@ ") {
+            // Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
+            if let Some(new_start) = parse_hunk_new_start(line) {
+                new_line_num = new_start;
+            }
+        } else if current_path.is_some() && new_line_num > 0 {
+            if line.starts_with('+') && !line.starts_with("+++") {
+                // Added line
+                changed_lines.push(new_line_num);
+                change_count += 1;
+                new_line_num += 1;
+            } else if line.starts_with('-') && !line.starts_with("---") {
+                // Removed line — doesn't advance new line counter
+                change_count += 1;
+            } else if !line.starts_with('\\') {
+                // Context line (or empty)
+                new_line_num += 1;
+            }
+        }
+    }
+
+    // Flush last file
+    if let Some(path) = current_path {
+        if !changed_lines.is_empty() {
+            files.push(DiffFile {
+                path,
+                changed_lines,
+                change_count,
+            });
+        }
+    }
+
+    // Sort by change_count descending (most-changed first)
+    files.sort_by(|a, b| b.change_count.cmp(&a.change_count));
+    files
+}
+
+/// Parse the new-side start line from a hunk header.
+///
+/// Input: `@@ -10,5 +20,8 @@ fn example()`
+/// Returns: `Some(20)`
+fn parse_hunk_new_start(line: &str) -> Option<usize> {
+    let after_plus = line.find('+').map(|i| &line[i + 1..])?;
+    let end = after_plus.find(|c: char| c == ',' || c == ' ')?;
+    after_plus[..end].parse().ok()
+}
+
+/// Extract a context window around changed lines from file content.
+///
+/// Returns numbered lines (1-indexed) within ±`window` lines of any changed line.
+/// Discontinuous ranges are separated by `...` markers.
+pub fn extract_context_window(content: &str, changed_lines: &[usize], window: usize) -> String {
+    if changed_lines.is_empty() {
+        return String::new();
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    let total = lines.len();
+
+    // Build set of lines to include
+    let include: HashSet<usize> = changed_lines
+        .iter()
+        .flat_map(|&line| {
+            let start = line.saturating_sub(window).max(1);
+            let end = (line + window).min(total);
+            start..=end
+        })
+        .collect();
+
+    let mut result = String::new();
+    let mut prev_included = false;
+
+    for (i, line) in lines.iter().enumerate() {
+        let line_num = i + 1; // 1-indexed
+        if include.contains(&line_num) {
+            if !prev_included && !result.is_empty() {
+                result.push_str("...\n");
+            }
+            result.push_str(&format!("{}: {}\n", line_num, line));
+            prev_included = true;
+        } else {
+            prev_included = false;
+        }
+    }
+
+    result
+}
+
+/// Maximum number of files to proactively fetch context for.
+pub const MAX_CONTEXT_FILES: usize = 3;
+
+/// Maximum total lines of context to include (across all files).
+pub const MAX_CONTEXT_LINES: usize = 1000;
+
+/// Default context window size (lines before/after each change).
+pub const CONTEXT_WINDOW: usize = 50;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_diff_files_basic() {
+        let diff = "\
+diff --git a/src/auth.rs b/src/auth.rs
+index abc..def 100644
+--- a/src/auth.rs
++++ b/src/auth.rs
+@@ -10,3 +10,4 @@ fn login() {
+     let user = get_user();
++    validate(user);
+     Ok(user)
+ }
+";
+        let files = parse_diff_files(diff);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "src/auth.rs");
+        assert_eq!(files[0].changed_lines, vec![11]);
+        assert_eq!(files[0].change_count, 1);
+    }
+
+    #[test]
+    fn test_parse_diff_files_multiple() {
+        let diff = "\
+diff --git a/src/a.rs b/src/a.rs
+--- a/src/a.rs
++++ b/src/a.rs
+@@ -1,3 +1,4 @@
+ line1
++added_a1
++added_a2
+ line2
+diff --git a/src/b.rs b/src/b.rs
+--- a/src/b.rs
++++ b/src/b.rs
+@@ -5,2 +5,3 @@
+ old
++added_b
+ more
+";
+        let files = parse_diff_files(diff);
+        assert_eq!(files.len(), 2);
+        // Sorted by change_count desc: a has 2, b has 1
+        assert_eq!(files[0].path, "src/a.rs");
+        assert_eq!(files[0].change_count, 2);
+        assert_eq!(files[1].path, "src/b.rs");
+        assert_eq!(files[1].change_count, 1);
+    }
+
+    #[test]
+    fn test_parse_diff_files_deleted_file() {
+        let diff = "\
+diff --git a/src/old.rs b/src/old.rs
+--- a/src/old.rs
++++ /dev/null
+@@ -1,3 +0,0 @@
+-line1
+-line2
+-line3
+";
+        let files = parse_diff_files(diff);
+        assert!(files.is_empty(), "Deleted files should not be included");
+    }
+
+    #[test]
+    fn test_parse_diff_files_removals_and_additions() {
+        let diff = "\
+diff --git a/src/lib.rs b/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -10,4 +10,4 @@ fn example() {
+-    old_call();
++    new_call();
+     keep();
+ }
+";
+        let files = parse_diff_files(diff);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].changed_lines, vec![10]);
+        assert_eq!(files[0].change_count, 2); // 1 removal + 1 addition
+    }
+
+    #[test]
+    fn test_parse_hunk_new_start() {
+        assert_eq!(parse_hunk_new_start("@@ -10,5 +20,8 @@ fn example()"), Some(20));
+        assert_eq!(parse_hunk_new_start("@@ -1 +1 @@"), Some(1));
+        assert_eq!(parse_hunk_new_start("@@ -0,0 +1,5 @@"), Some(1));
+    }
+
+    #[test]
+    fn test_extract_context_window_basic() {
+        let content = (1..=20)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let result = extract_context_window(&content, &[10], 3);
+        // Should include lines 7-13
+        assert!(result.contains("7: line 7"));
+        assert!(result.contains("10: line 10"));
+        assert!(result.contains("13: line 13"));
+        assert!(!result.contains("6: line 6"));
+        assert!(!result.contains("14: line 14"));
+    }
+
+    #[test]
+    fn test_extract_context_window_discontinuous() {
+        let content = (1..=100)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let result = extract_context_window(&content, &[10, 90], 3);
+        assert!(result.contains("..."));
+        assert!(result.contains("10: line 10"));
+        assert!(result.contains("90: line 90"));
+    }
+
+    #[test]
+    fn test_extract_context_window_empty() {
+        assert_eq!(extract_context_window("some content", &[], 50), "");
+    }
+
+    #[test]
+    fn test_extract_context_window_clamps_to_bounds() {
+        let content = "line1\nline2\nline3";
+        let result = extract_context_window(content, &[1], 100);
+        assert!(result.contains("1: line1"));
+        assert!(result.contains("3: line3"));
+    }
+}

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod agents;
 pub mod chat;
+pub mod diff;
 pub mod error;
 mod claude;
 pub mod mock;

--- a/crates/orchestrator/src/prompt.rs
+++ b/crates/orchestrator/src/prompt.rs
@@ -18,10 +18,12 @@ You review the ACTUAL CODE DIFF, not just PR metadata. Do not trust the PR descr
 ## Review process
 
 **Pass 1 — Diff triage:**
-Read the diff carefully. Evaluate:
+Read the diff carefully. You will also receive **File Context** — surrounding code (±50 lines) for the most-changed files. Use this to understand how the changes fit into the broader codebase.
+
+Evaluate:
 
 1. **Issue alignment**: Does the diff actually address the issue? Not "does the PR description say it does" — do the actual code changes solve the problem?
-2. **Correctness**: Are there obvious bugs, missing error handling, or incomplete changes? For removals: is anything left that depends on the removed code? For additions: does the new code handle edge cases?
+2. **Correctness**: Are there obvious bugs, missing error handling, or incomplete changes? For removals: is anything left that depends on the removed code? For additions: does the new code handle edge cases? Use the file context to check callers/dependents.
 3. **Completeness**: Does the diff cover all aspects of the issue, or are there gaps?
 4. **Conflicts/CI**: Check mergeable state and review status from the metadata.
 5. **Queue context**: Consider other PRs in the merge queue. If this PR appears to depend on changes from another PR that hasn't merged yet, or if issues you see would be resolved by a PR ahead in the queue, factor that into your decision.
@@ -70,12 +72,16 @@ Response format for Pass 2 is the same, but `needs_deeper_review` must be false.
 }
 
 /// Build the user prompt with PR and issue context.
+///
+/// `file_contexts` contains `(path, context_window)` pairs for proactively
+/// fetched surrounding code. Pass `&[]` if no context was fetched.
 pub fn build_evaluation_prompt(
     pr: &PullRequest,
     issue: Option<&Issue>,
     task_title: &str,
     task_description: Option<&str>,
     diff: Option<&str>,
+    file_contexts: &[(String, String)],
     queue_context: &[QueueEntrySummary],
 ) -> String {
     let mut prompt = String::new();
@@ -195,6 +201,21 @@ pub fn build_evaluation_prompt(
         prompt.push_str("\nConsider whether this PR might depend on or conflict with any of the above.\n\n");
     }
 
+    // File context — proactively fetched surrounding code for key changed files
+    if !file_contexts.is_empty() {
+        prompt.push_str("## File Context\n\n");
+        prompt.push_str("Surrounding code for the most-changed files (line numbers shown, `...` indicates skipped lines):\n\n");
+        for (path, context) in file_contexts {
+            prompt.push_str(&format!("### `{}`\n\n", path));
+            prompt.push_str("```\n");
+            prompt.push_str(context);
+            if !context.ends_with('\n') {
+                prompt.push('\n');
+            }
+            prompt.push_str("```\n\n");
+        }
+    }
+
     // The diff — this is what the review is actually about
     if let Some(diff) = diff {
         prompt.push_str("## Diff\n\n");
@@ -230,8 +251,8 @@ pub fn build_deep_review_prompt(
     files: &[(String, String)],
     queue_context: &[QueueEntrySummary],
 ) -> String {
-    // Start with the same base prompt
-    let mut prompt = build_evaluation_prompt(pr, issue, task_title, task_description, Some(diff), queue_context);
+    // Start with the same base prompt (no file contexts in deep review — we include full files below)
+    let mut prompt = build_evaluation_prompt(pr, issue, task_title, task_description, Some(diff), &[], queue_context);
 
     // Add the reviewer's reasoning from pass 1
     prompt.push_str("\n## Previous Review Notes\n\n");
@@ -422,7 +443,7 @@ mod tests {
     #[test]
     fn test_build_evaluation_prompt_basic() {
         let pr = test_pr();
-        let prompt = build_evaluation_prompt(&pr, None, "Fix auth bug", None, None, &[]);
+        let prompt = build_evaluation_prompt(&pr, None, "Fix auth bug", None, None, &[], &[]);
 
         // Should contain task info
         assert!(prompt.contains("Fix auth bug"));
@@ -451,6 +472,7 @@ mod tests {
             Some("Fix the timeout issue"),
             None,
             &[],
+            &[],
         );
 
         // Should contain issue info
@@ -467,7 +489,7 @@ mod tests {
         let mut pr = test_pr();
         pr.mergeable = Some(MergeableState::Conflicting);
 
-        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[]);
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[], &[]);
         assert!(prompt.contains("has conflicts"));
     }
 
@@ -476,14 +498,14 @@ mod tests {
         let mut pr = test_pr();
         pr.review_decision = Some(ReviewDecision::ChangesRequested);
 
-        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[]);
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[], &[]);
         assert!(prompt.contains("Changes requested"));
     }
 
     #[test]
     fn test_build_evaluation_prompt_with_reviews() {
         let pr = test_pr();
-        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[]);
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[], &[]);
 
         // Should contain review info
         assert!(prompt.contains("@testuser"));
@@ -508,6 +530,7 @@ mod tests {
             None,
             Some("diff --git a/src/auth.rs b/src/auth.rs\n-old\n+new"),
             &[],
+            &[],
         );
         assert!(prompt.contains("## Diff"));
         assert!(prompt.contains("-old"));
@@ -517,7 +540,7 @@ mod tests {
     #[test]
     fn test_build_evaluation_prompt_no_diff_notes_absence() {
         let pr = test_pr();
-        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[]);
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[], &[]);
         assert!(prompt.contains("No diff available"));
     }
 
@@ -569,7 +592,7 @@ mod tests {
             },
         ];
 
-        let prompt = build_evaluation_prompt(&pr, None, "Test task", None, None, &queue_context);
+        let prompt = build_evaluation_prompt(&pr, None, "Test task", None, None, &[], &queue_context);
 
         // Should contain queue context section
         assert!(prompt.contains("## Merge Queue Context"));
@@ -585,5 +608,39 @@ mod tests {
         let prompt = system_prompt();
         assert!(prompt.contains("Queue context"));
         assert!(prompt.contains("queue ordering"));
+    }
+
+    #[test]
+    fn test_build_evaluation_prompt_with_file_context() {
+        let pr = test_pr();
+        let file_contexts = vec![
+            ("src/auth.rs".to_string(), "8: fn login() {\n9:     let user = get_user();\n10:     validate(user);\n11:     Ok(user)\n12: }\n".to_string()),
+        ];
+        let prompt = build_evaluation_prompt(
+            &pr,
+            None,
+            "Fix auth bug",
+            None,
+            Some("diff content"),
+            &file_contexts,
+            &[],
+        );
+        assert!(prompt.contains("## File Context"));
+        assert!(prompt.contains("src/auth.rs"));
+        assert!(prompt.contains("fn login()"));
+        assert!(prompt.contains("validate(user)"));
+    }
+
+    #[test]
+    fn test_build_evaluation_prompt_no_file_context() {
+        let pr = test_pr();
+        let prompt = build_evaluation_prompt(&pr, None, "Test", None, None, &[], &[]);
+        assert!(!prompt.contains("## File Context"));
+    }
+
+    #[test]
+    fn test_system_prompt_mentions_file_context() {
+        let prompt = system_prompt();
+        assert!(prompt.contains("File Context"));
     }
 }


### PR DESCRIPTION
## Summary

- Adds proactive context fetching to the orchestrator's PR evaluation flow: before pass 1, the diff is parsed to identify the most-changed files (up to 3), and surrounding code (±50 lines around each changed line) is fetched from the PR branch and included in the evaluation prompt
- Adds a new `diff` module with a unified diff parser (`parse_diff_files`) and context windowing (`extract_context_window`) with configurable limits (max 3 files, ~1000 lines total, ±50 line window)
- Updates the system prompt to instruct the reviewer to use the proactive file context for checking callers/dependents

## Test plan

- [x] All 65 orchestrator tests pass (including 7 new tests for diff parsing, context extraction, and prompt integration)
- [x] Full workspace compiles cleanly
- [ ] Verify proactive context appears in evaluation prompts during live review
- [ ] Confirm token budget stays reasonable with context included

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)