### PR TITLE
Proactively fetch file context during review

### DIFF
--- a/crates/orchestrator/src/claude.rs
+++ b/crates/orchestrator/src/claude.rs
@@ -7,8 +7,15 @@ use serde::Deserialize;
 use tracing::{info, warn};
 
 use crate::error::OrchestratorError;
+use crate::diff::{
+    extract_context_window, parse_diff_files, CONTEXT_WINDOW_LINES, MAX_CONTEXT_FILES,
+    MAX_CONTEXT_LINES_PER_FILE,
+};
 use crate::orchestrator::Orchestrator;
-use crate::prompt::{build_evaluation_prompt, build_deep_review_prompt, parse_pr_url, system_prompt};
+use crate::prompt::{
+    build_evaluation_prompt_with_context, build_deep_review_prompt, parse_pr_url, system_prompt,
+    FileContext,
+};
 use crate::types::{
     default_triage, ConflictContext, ConflictTriage, EvaluationContext, OrchestratorAction,
     QualityEvaluation, QuestionContext, SystemContext,
@@ -214,15 +221,72 @@ impl Orchestrator for ClaudeOrchestrator {
             _ => None,
         };
 
-        // --- Pass 1: Triage with diff ---
+        // --- Proactive context fetching ---
+        // Parse the diff to find the most-changed files and fetch surrounding
+        // code context so the reviewer sees how changes fit into the codebase.
+        let file_contexts = if let Some(ref diff_text) = diff {
+            let changed_files = parse_diff_files(diff_text);
+            let mut contexts = Vec::new();
+
+            for file in changed_files.iter().take(MAX_CONTEXT_FILES) {
+                // Skip files that are likely non-code (binary, generated, etc.)
+                if is_likely_non_code(&file.path) {
+                    continue;
+                }
+
+                match self
+                    .github
+                    .get_file_content_at_ref(&owner, &repo, &file.path, &pr.head_ref)
+                    .await
+                {
+                    Ok(Some(content)) => {
+                        let windowed = extract_context_window(
+                            &content,
+                            &file.changed_lines,
+                            CONTEXT_WINDOW_LINES,
+                            MAX_CONTEXT_LINES_PER_FILE,
+                        );
+                        info!(
+                            path = %file.path,
+                            changed_lines = file.changed_lines.len(),
+                            context_len = windowed.len(),
+                            "Fetched proactive file context"
+                        );
+                        contexts.push(FileContext {
+                            path: file.path.clone(),
+                            content: windowed,
+                        });
+                    }
+                    Ok(None) => {
+                        info!(path = %file.path, "File not found for proactive context (may be deleted)");
+                    }
+                    Err(e) => {
+                        warn!(path = %file.path, error = %e, "Failed to fetch proactive file context");
+                    }
+                }
+            }
+            contexts
+        } else {
+            Vec::new()
+        };
+
+        if !file_contexts.is_empty() {
+            info!(
+                file_count = file_contexts.len(),
+                "Proactive context fetched for pass 1"
+            );
+        }
+
+        // --- Pass 1: Triage with diff + proactive context ---
         let system = system_prompt();
-        let user_prompt = build_evaluation_prompt(
+        let user_prompt = build_evaluation_prompt_with_context(
             &pr,
             issue.as_ref(),
             &context.task.title,
             context.task.description.as_deref(),
             diff.as_deref(),
             &context.queue_context,
+            &file_contexts,
         );
 
         let config = CompletionConfig::new(&self.model).with_max_tokens(self.max_tokens);
@@ -578,6 +642,26 @@ fn build_question_answer_prompt(
     ));
 
     prompt
+}
+
+/// Check if a file path is likely non-code (binary, generated, lock files, etc.)
+/// that wouldn't benefit from context fetching.
+fn is_likely_non_code(path: &str) -> bool {
+    let non_code_extensions = [
+        ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".woff", ".woff2", ".ttf", ".eot",
+        ".mp3", ".mp4", ".wav", ".pdf", ".zip", ".tar", ".gz", ".lock", ".sum",
+    ];
+    let non_code_files = [
+        "package-lock.json",
+        "yarn.lock",
+        "Cargo.lock",
+        "bun.lockb",
+        "pnpm-lock.yaml",
+    ];
+
+    let lower = path.to_lowercase();
+    non_code_extensions.iter().any(|ext| lower.ends_with(ext))
+        || non_code_files.iter().any(|f| path.ends_with(f))
 }
 
 /// Extract JSON from a text response.

--- a/crates/orchestrator/src/diff.rs
+++ b/crates/orchestrator/src/diff.rs
@@ -1,0 +1,264 @@
+//! Unified diff parser for extracting file paths and changed line numbers.
+//!
+//! Used to proactively fetch context around changed code during review.
+
+use std::collections::HashSet;
+
+/// A file that was changed in a diff, with the line numbers that were modified.
+#[derive(Debug, Clone)]
+pub struct DiffFile {
+    /// Path of the changed file (e.g., "src/main.rs").
+    pub path: String,
+    /// Line numbers that were added or modified in the new version.
+    pub changed_lines: Vec<usize>,
+    /// Total number of changed lines (additions + deletions).
+    pub change_count: usize,
+}
+
+/// Parse a unified diff to extract changed files and their modified line numbers.
+///
+/// Returns files sorted by change count (most changed first).
+pub fn parse_diff_files(diff: &str) -> Vec<DiffFile> {
+    let mut files: Vec<DiffFile> = Vec::new();
+    let mut current_path: Option<String> = None;
+    let mut current_lines: Vec<usize> = Vec::new();
+    let mut current_change_count: usize = 0;
+    let mut new_line_num: usize = 0;
+
+    for line in diff.lines() {
+        if line.starts_with("diff --git ") {
+            // Flush previous file
+            if let Some(path) = current_path.take() {
+                files.push(DiffFile {
+                    path,
+                    changed_lines: current_lines.clone(),
+                    change_count: current_change_count,
+                });
+            }
+            current_lines.clear();
+            current_change_count = 0;
+            new_line_num = 0;
+
+            // Extract path from "diff --git a/path b/path"
+            if let Some(b_path) = line.split(" b/").last() {
+                current_path = Some(b_path.to_string());
+            }
+        } else if line.starts_with("+++ b/") {
+            // More reliable path from the +++ line
+            if let Some(path) = line.strip_prefix("+++ b/") {
+                current_path = Some(path.to_string());
+            }
+        } else if line.starts_with("@@ ") {
+            // Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
+            if let Some(new_range) = parse_hunk_header(line) {
+                new_line_num = new_range;
+            }
+        } else if new_line_num > 0 {
+            if line.starts_with('+') && !line.starts_with("+++") {
+                current_lines.push(new_line_num);
+                current_change_count += 1;
+                new_line_num += 1;
+            } else if line.starts_with('-') && !line.starts_with("---") {
+                current_change_count += 1;
+                // Deletion — don't advance new_line_num
+            } else {
+                // Context line
+                new_line_num += 1;
+            }
+        }
+    }
+
+    // Flush last file
+    if let Some(path) = current_path {
+        files.push(DiffFile {
+            path,
+            changed_lines: current_lines,
+            change_count: current_change_count,
+        });
+    }
+
+    // Sort by change count descending
+    files.sort_by(|a, b| b.change_count.cmp(&a.change_count));
+    files
+}
+
+/// Parse a hunk header to get the new file start line number.
+///
+/// Format: `@@ -old_start[,old_count] +new_start[,new_count] @@`
+fn parse_hunk_header(line: &str) -> Option<usize> {
+    let plus_idx = line.find('+')?;
+    let rest = &line[plus_idx + 1..];
+    let end = rest.find(|c: char| !c.is_ascii_digit())?;
+    rest[..end].parse().ok()
+}
+
+/// Extract context windows around changed lines from file content.
+///
+/// Returns line-numbered content with ±`context_lines` around each change,
+/// collapsing overlapping windows. Limits total output to `max_lines`.
+pub fn extract_context_window(
+    content: &str,
+    changed_lines: &[usize],
+    context_lines: usize,
+    max_lines: usize,
+) -> String {
+    if changed_lines.is_empty() {
+        // No specific lines — return the head of the file
+        return content
+            .lines()
+            .take(max_lines)
+            .enumerate()
+            .map(|(i, line)| format!("{}: {}", i + 1, line))
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    let total_lines = lines.len();
+
+    // Build set of lines to include
+    let target_lines: HashSet<usize> = changed_lines
+        .iter()
+        .flat_map(|&line| {
+            let start = line.saturating_sub(context_lines);
+            let end = (line + context_lines).min(total_lines);
+            (start.max(1))..=end
+        })
+        .collect();
+
+    let mut sorted_lines: Vec<usize> = target_lines.into_iter().collect();
+    sorted_lines.sort_unstable();
+
+    let mut result = Vec::new();
+    let mut prev_line: Option<usize> = None;
+
+    for &line_num in sorted_lines.iter().take(max_lines) {
+        if line_num == 0 || line_num > total_lines {
+            continue;
+        }
+        // Insert separator for gaps
+        if let Some(prev) = prev_line {
+            if line_num > prev + 1 {
+                result.push("...".to_string());
+            }
+        }
+        result.push(format!("{}: {}", line_num, lines[line_num - 1]));
+        prev_line = Some(line_num);
+    }
+
+    result.join("\n")
+}
+
+/// Maximum number of files to proactively fetch context for.
+pub const MAX_CONTEXT_FILES: usize = 3;
+
+/// Number of context lines to include around each change.
+pub const CONTEXT_WINDOW_LINES: usize = 50;
+
+/// Maximum lines of context per file.
+pub const MAX_CONTEXT_LINES_PER_FILE: usize = 300;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_diff_files_basic() {
+        let diff = r#"diff --git a/src/main.rs b/src/main.rs
+index 1234567..abcdefg 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -10,6 +10,7 @@ fn main() {
+     let x = 1;
+     let y = 2;
++    let z = 3;
+     println!("hello");
+ }
+"#;
+        let files = parse_diff_files(diff);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "src/main.rs");
+        assert_eq!(files[0].changed_lines, vec![12]);
+        assert_eq!(files[0].change_count, 1);
+    }
+
+    #[test]
+    fn test_parse_diff_files_multiple() {
+        let diff = r#"diff --git a/src/a.rs b/src/a.rs
+--- a/src/a.rs
++++ b/src/a.rs
+@@ -1,3 +1,4 @@
+ line1
++added
+ line2
+ line3
+diff --git a/src/b.rs b/src/b.rs
+--- a/src/b.rs
++++ b/src/b.rs
+@@ -1,5 +1,7 @@
+ line1
++added1
++added2
+ line2
+-removed
++replaced
+ line4
+"#;
+        let files = parse_diff_files(diff);
+        assert_eq!(files.len(), 2);
+        // b.rs has more changes (3 additions + 1 deletion = 4) vs a.rs (1)
+        assert_eq!(files[0].path, "src/b.rs");
+        assert_eq!(files[0].change_count, 4);
+        assert_eq!(files[1].path, "src/a.rs");
+        assert_eq!(files[1].change_count, 1);
+    }
+
+    #[test]
+    fn test_parse_diff_files_empty() {
+        assert!(parse_diff_files("").is_empty());
+        assert!(parse_diff_files("no diff here").is_empty());
+    }
+
+    #[test]
+    fn test_parse_hunk_header() {
+        assert_eq!(parse_hunk_header("@@ -10,6 +10,7 @@ fn main() {"), Some(10));
+        assert_eq!(parse_hunk_header("@@ -1,3 +1,4 @@"), Some(1));
+        assert_eq!(parse_hunk_header("@@ -0,0 +1,5 @@"), Some(1));
+    }
+
+    #[test]
+    fn test_extract_context_window_basic() {
+        let content = (1..=20)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let result = extract_context_window(&content, &[10], 3, 100);
+        assert!(result.contains("7: line 7"));
+        assert!(result.contains("10: line 10"));
+        assert!(result.contains("13: line 13"));
+        // Should not contain lines far from the change
+        assert!(!result.starts_with("1: "));
+        assert!(!result.contains("\n1: "));
+        assert!(!result.contains("20: line 20"));
+    }
+
+    #[test]
+    fn test_extract_context_window_gap_separator() {
+        let content = (1..=100)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Two distant changes should produce a gap
+        let result = extract_context_window(&content, &[10, 90], 2, 200);
+        assert!(result.contains("..."));
+    }
+
+    #[test]
+    fn test_extract_context_window_empty_lines() {
+        let content = "line1\nline2\nline3";
+        let result = extract_context_window(&content, &[], 3, 100);
+        assert!(result.contains("1: line1"));
+    }
+}

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod agents;
 pub mod chat;
+pub mod diff;
 pub mod error;
 mod claude;
 pub mod mock;

--- a/crates/orchestrator/src/prompt.rs
+++ b/crates/orchestrator/src/prompt.rs
@@ -18,7 +18,7 @@ You review the ACTUAL CODE DIFF, not just PR metadata. Do not trust the PR descr
 ## Review process
 
 **Pass 1 — Diff triage:**
-Read the diff carefully. Evaluate:
+Read the diff carefully. You may also receive auto-fetched file context showing surrounding code for the most-changed files — use this to understand how changes fit into the broader codebase. Evaluate:
 
 1. **Issue alignment**: Does the diff actually address the issue? Not "does the PR description say it does" — do the actual code changes solve the problem?
 2. **Correctness**: Are there obvious bugs, missing error handling, or incomplete changes? For removals: is anything left that depends on the removed code? For additions: does the new code handle edge cases?
@@ -213,6 +213,48 @@ pub fn build_evaluation_prompt(
     prompt.push_str("Review the diff above against the issue requirements. ");
     prompt.push_str("Evaluate correctness, completeness, and whether this actually solves the issue. ");
     prompt.push_str("Respond with your evaluation in the JSON format specified in your instructions.");
+
+    prompt
+}
+
+/// File context fetched proactively from the diff.
+pub struct FileContext {
+    /// File path.
+    pub path: String,
+    /// Context-windowed content (line-numbered, with gaps).
+    pub content: String,
+}
+
+/// Build the evaluation prompt with proactively-fetched file context.
+///
+/// This enhances pass 1 by including surrounding code context for the
+/// most-changed files in the diff, so the reviewer can see how changes
+/// fit into the broader codebase.
+pub fn build_evaluation_prompt_with_context(
+    pr: &PullRequest,
+    issue: Option<&Issue>,
+    task_title: &str,
+    task_description: Option<&str>,
+    diff: Option<&str>,
+    queue_context: &[QueueEntrySummary],
+    file_contexts: &[FileContext],
+) -> String {
+    let mut prompt = build_evaluation_prompt(pr, issue, task_title, task_description, diff, queue_context);
+
+    if !file_contexts.is_empty() {
+        prompt.push_str("\n## File Context (auto-fetched)\n\n");
+        prompt.push_str("The following shows surrounding code context for the most-changed files, ");
+        prompt.push_str("so you can see how the diff fits into the broader codebase.\n\n");
+        for ctx in file_contexts {
+            prompt.push_str(&format!("### `{}`\n\n", ctx.path));
+            prompt.push_str("```\n");
+            prompt.push_str(&ctx.content);
+            if !ctx.content.ends_with('\n') {
+                prompt.push('\n');
+            }
+            prompt.push_str("```\n\n");
+        }
+    }
 
     prompt
 }
@@ -585,5 +627,61 @@ mod tests {
         let prompt = system_prompt();
         assert!(prompt.contains("Queue context"));
         assert!(prompt.contains("queue ordering"));
+    }
+
+    #[test]
+    fn test_build_evaluation_prompt_with_file_context() {
+        let pr = test_pr();
+        let file_contexts = vec![
+            FileContext {
+                path: "src/auth.rs".to_string(),
+                content: "10: fn login() {\n11:     validate();\n12: }".to_string(),
+            },
+            FileContext {
+                path: "src/session.rs".to_string(),
+                content: "5: fn create_session() {\n6:     // ...\n7: }".to_string(),
+            },
+        ];
+
+        let prompt = build_evaluation_prompt_with_context(
+            &pr,
+            None,
+            "Fix auth bug",
+            None,
+            Some("diff content"),
+            &[],
+            &file_contexts,
+        );
+
+        // Should contain file context section
+        assert!(prompt.contains("## File Context (auto-fetched)"));
+        assert!(prompt.contains("src/auth.rs"));
+        assert!(prompt.contains("fn login()"));
+        assert!(prompt.contains("src/session.rs"));
+        assert!(prompt.contains("fn create_session()"));
+        assert!(prompt.contains("surrounding code context"));
+    }
+
+    #[test]
+    fn test_build_evaluation_prompt_with_empty_file_context() {
+        let pr = test_pr();
+        let prompt = build_evaluation_prompt_with_context(
+            &pr,
+            None,
+            "Fix auth bug",
+            None,
+            Some("diff content"),
+            &[],
+            &[],
+        );
+
+        // Should NOT contain file context section when empty
+        assert!(!prompt.contains("## File Context"));
+    }
+
+    #[test]
+    fn test_system_prompt_mentions_file_context() {
+        let prompt = system_prompt();
+        assert!(prompt.contains("auto-fetched file context"));
     }
 }


### PR DESCRIPTION
## Summary

- Adds a unified diff parser (`crates/orchestrator/src/diff.rs`) that extracts changed file paths and line numbers from PR diffs
- During pass 1 evaluation, proactively fetches surrounding code context (±50 lines) for the top 3 most-changed files
- Includes this context in the evaluation prompt so the reviewer can see how changes fit into the broader codebase
- Skips non-code files (binaries, lock files, images) to avoid wasting tokens

## How it works

1. **Diff parsing**: `parse_diff_files()` extracts file paths, changed line numbers, and change counts from unified diffs, sorted by most changed
2. **Context windowing**: `extract_context_window()` fetches ±50 lines around each changed line, collapsing overlapping windows and inserting `...` separators for gaps
3. **Prompt enhancement**: `build_evaluation_prompt_with_context()` appends an "auto-fetched file context" section to the pass 1 prompt
4. **Smart limits**: Max 3 files, 300 lines per file, non-code files filtered out

## Benefits

- Better reviews: Reviewer sees surrounding code, not just isolated diff hunks
- Fewer false negatives: Can catch issues like "function changed but callers weren't updated"
- Reduced pass-2 needs: More context upfront means fewer deep review requests

## Test plan

- [x] All 63 orchestrator tests pass (7 new tests added)
- [x] Full workspace builds cleanly
- [ ] Integration test with real PR evaluation (requires API keys)

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)