### PR TITLE
Add retry with backoff for initial snapshot fetch failure

### DIFF
--- a/crates/desktop/src/state.rs
+++ b/crates/desktop/src/state.rs
@@ -26,6 +26,12 @@ const MAX_EVENTS: usize = 200;
 /// Polling interval for snapshot refresh (milliseconds).
 const POLL_INTERVAL_MS: u64 = 5_000;
 
+/// Initial retry delay for snapshot fetch (milliseconds).
+const INITIAL_RETRY_DELAY_MS: u64 = 1_000;
+
+/// Maximum retry delay for snapshot fetch (milliseconds).
+const MAX_RETRY_DELAY_MS: u64 = 30_000;
+
 /// Check whether an event type string should trigger a snapshot refresh.
 /// Matches: task:*, merge:*, system:mode*
 fn is_state_changing_event(event_type: &str) -> bool {
@@ -118,6 +124,8 @@ pub struct AppState {
     stop_polling: Option<Arc<AtomicBool>>,
     /// Whether a fetch is currently in flight.
     fetch_in_flight: Arc<AtomicBool>,
+    /// Number of consecutive snapshot fetch failures (for backoff).
+    snapshot_retry_count: u32,
 }
 
 impl AppState {
@@ -158,6 +166,7 @@ impl AppState {
             sse_client: Some(sse_client),
             stop_polling: None,
             fetch_in_flight: Arc::new(AtomicBool::new(false)),
+            snapshot_retry_count: 0,
         };
 
         // Start polling loop
@@ -325,7 +334,23 @@ impl AppState {
         }
     }
 
+    /// Get the current snapshot retry count.
+    pub fn snapshot_retry_count(&self) -> u32 {
+        self.snapshot_retry_count
+    }
+
     // --- Actions ---
+
+    /// Manually retry connecting to the server (resets backoff).
+    pub fn retry_connection(&mut self, cx: &mut Context<Self>) {
+        self.snapshot_retry_count = 0;
+        self.connection_status = ConnectionStatus::Connecting;
+        cx.emit(AppStateEvent::ConnectionStatusChanged(
+            self.connection_status,
+        ));
+        cx.notify();
+        self.refresh_snapshot(cx);
+    }
 
     /// Refresh the snapshot from the server.
     pub fn refresh_snapshot(&mut self, cx: &mut Context<Self>) {
@@ -360,9 +385,12 @@ impl AppState {
             Ok(snapshot) => {
                 self.snapshot = Some(snapshot);
                 self.last_error = None;
+                self.snapshot_retry_count = 0;
                 // Update connection status if we were previously disconnected
                 if self.connection_status == ConnectionStatus::Disconnected
                     || self.connection_status == ConnectionStatus::Failed
+                    || self.connection_status == ConnectionStatus::Connecting
+                    || self.connection_status == ConnectionStatus::Reconnecting
                 {
                     self.connection_status = ConnectionStatus::Connected;
                     cx.emit(AppStateEvent::ConnectionStatusChanged(
@@ -373,7 +401,41 @@ impl AppState {
                 cx.notify();
             }
             Err(e) => {
+                let had_snapshot = self.snapshot.is_some();
                 self.set_error(e.to_string(), cx);
+
+                // If we've never had a snapshot, schedule a retry with backoff
+                if !had_snapshot {
+                    self.snapshot_retry_count += 1;
+                    let delay_ms = INITIAL_RETRY_DELAY_MS
+                        .saturating_mul(1 << self.snapshot_retry_count.min(5))
+                        .min(MAX_RETRY_DELAY_MS);
+
+                    // Show reconnecting status during retries
+                    if self.connection_status != ConnectionStatus::Reconnecting {
+                        self.connection_status = ConnectionStatus::Reconnecting;
+                        cx.emit(AppStateEvent::ConnectionStatusChanged(
+                            self.connection_status,
+                        ));
+                        cx.notify();
+                    }
+
+                    info!(
+                        retry_count = self.snapshot_retry_count,
+                        delay_ms, "Initial snapshot fetch failed, retrying"
+                    );
+
+                    let delay = Duration::from_millis(delay_ms);
+                    cx.spawn(async move |this, cx| {
+                        smol::Timer::after(delay).await;
+                        if let Err(e) = this.update(cx, |state, cx| {
+                            state.refresh_snapshot(cx);
+                        }) {
+                            warn!(error = %e, "Failed to trigger snapshot retry");
+                        }
+                    })
+                    .detach();
+                }
             }
         }
     }

--- a/crates/desktop/src/views/dashboard.rs
+++ b/crates/desktop/src/views/dashboard.rs
@@ -9,8 +9,8 @@ use chrono::{DateTime, Utc};
 use gpui::{div, prelude::*, Entity, FontWeight, Styled, Window};
 
 use crate::api::{self, TaskState};
-use crate::components::{Badge, BadgeVariant, Card, CardContent, CardHeader};
-use crate::state::AppState;
+use crate::components::{Badge, BadgeVariant, Button, ButtonVariant, Card, CardContent, CardHeader};
+use crate::state::{AppState, ConnectionStatus};
 use crate::theme::{colors, radius, rgb, spacing, style_helpers::StyledExt, typography, ComponentTheme};
 
 /// Maximum number of recent events to display.
@@ -37,18 +37,58 @@ impl Render for Dashboard {
 
         // Check if we have data
         let Some(snapshot) = state.snapshot() else {
-            return div()
+            let connection_status = state.connection_status();
+            let last_error = state.last_error().map(|s| s.to_string());
+            let state_entity = self.state.clone();
+
+            let (status_text, show_retry) = match connection_status {
+                ConnectionStatus::Connecting => ("Connecting to server...", false),
+                ConnectionStatus::Reconnecting => ("Reconnecting to server...", true),
+                ConnectionStatus::Failed => ("Failed to connect to server", true),
+                ConnectionStatus::Disconnected => ("Disconnected from server", true),
+                ConnectionStatus::Connected => ("Waiting for data...", false),
+            };
+
+            let mut container = div()
                 .size_full()
                 .flex()
+                .flex_col()
                 .items_center()
                 .justify_center()
-                .child(
+                .gap(spacing::SPACE_3);
+
+            container = container.child(
+                div()
+                    .text_muted()
+                    .text_size(typography::TEXT_SM)
+                    .child(status_text.to_string()),
+            );
+
+            if let Some(err) = last_error {
+                container = container.child(
                     div()
-                        .text_muted()
-                        .text_size(typography::TEXT_SM)
-                        .child("No data yet"),
-                )
-                .into_any_element();
+                        .text_size(typography::TEXT_XS)
+                        .text_color(rgb(colors::DESTRUCTIVE))
+                        .max_w(gpui::px(400.0))
+                        .text_ellipsis()
+                        .overflow_hidden()
+                        .child(err),
+                );
+            }
+
+            if show_retry {
+                container = container.child(
+                    Button::new("retry-connection", "Retry")
+                        .variant(ButtonVariant::Outline)
+                        .on_click(move |_event, _window, cx| {
+                            state_entity.update(cx, |state, cx| {
+                                state.retry_connection(cx);
+                            });
+                        }),
+                );
+            }
+
+            return container.into_any_element();
         };
 
         // Calculate stats


### PR DESCRIPTION
## Summary

- When the initial snapshot fetch fails (server not yet running), the desktop app now automatically retries with exponential backoff (1s → 2s → 4s → 8s → 16s → 30s cap) instead of showing an empty state forever
- Dashboard shows connection-aware UI: "Connecting to server...", "Reconnecting to server..." with error details, instead of the unhelpful "No data yet" message
- Added a manual "Retry" button visible during reconnecting/failed/disconnected states that resets the backoff and immediately retries

## Test plan

- [ ] Start the desktop app without the server running — should show "Connecting to server..." then "Reconnecting to server..." with error details and a Retry button
- [ ] Click the Retry button — should reset to "Connecting to server..." and attempt a fresh connection
- [ ] Start the server while the app is retrying — should connect and show the dashboard
- [ ] Verify normal startup (server already running) still works as before

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)