### PR TITLE
Defer merge queue evaluation when GitHub mergeable is Unknown

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -1967,6 +1967,19 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                 let state = orch_server.state.read().await;
                 match state.merge_queue.get(&entry_id) {
                     Some(e) if e.status == server::model::merge_queue::MergeStatus::Pending => {
+                        // Defer evaluation when GitHub's mergeable is Unknown (issue #503).
+                        // The next poll cycle will re-check and clear the flag once resolved.
+                        if e.mergeable_unknown {
+                            tracing::debug!(
+                                entry_id = %entry_id,
+                                "deferring evaluation: GitHub mergeable=Unknown, will retry next cycle"
+                            );
+                            // Re-queue so it gets picked up on the next tick
+                            if eval_queued.insert(entry_id.clone()) {
+                                eval_queue.push_back(entry_id.clone());
+                            }
+                            continue;
+                        }
                         (e.task_id.clone(), e.pr_url.clone())
                     }
                     _ => continue, // Entry gone or no longer pending

--- a/crates/models/src/merge_queue.rs
+++ b/crates/models/src/merge_queue.rs
@@ -118,6 +118,10 @@ pub struct MergeQueueEntry {
     /// race conditions where GitHub's merged state hasn't propagated yet (issue #438).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<DateTime<Utc>>,
+    /// True when GitHub's mergeable field is Unknown (computation pending).
+    /// The orchestrator defers evaluation until this resolves (issue #503).
+    #[serde(default)]
+    pub mergeable_unknown: bool,
 }
 
 impl MergeQueueEntry {
@@ -133,6 +137,7 @@ impl MergeQueueEntry {
             head_sha: None,
             queue_position: None,
             completed_at: None,
+            mergeable_unknown: false,
         }
     }
 

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -28,6 +28,10 @@ enum MqAction {
     Remove { entry_id: String, pr_url: String },
     MarkConflict { entry_id: String, pr_url: String },
     ClearConflict { entry_id: String },
+    /// GitHub's mergeable field is Unknown — defer evaluation until resolved (issue #503).
+    SetMergeableUnknown { entry_id: String },
+    /// GitHub's mergeable field resolved — clear the unknown flag (issue #503).
+    ClearMergeableUnknown { entry_id: String },
 }
 
 #[derive(Debug, Error)]
@@ -1284,16 +1288,16 @@ impl Server {
             let entry_id = entry_id.clone();
             let task_id = task_id.clone();
 
-            let (action, entry_id_for_sha_update) = match pr.state {
+            let (action, entry_id_for_sha_update, unknown_action) = match pr.state {
                 tasks_github::model::PullRequestState::Merged => {
                     if *current_status != MergeStatus::Merged {
-                        (Some(MqAction::MarkMerged { entry_id, task_id, pr_url }), None)
+                        (Some(MqAction::MarkMerged { entry_id, task_id, pr_url }), None, None)
                     } else {
                         continue;
                     }
                 }
                 tasks_github::model::PullRequestState::Closed => {
-                    (Some(MqAction::Remove { entry_id, pr_url }), None)
+                    (Some(MqAction::Remove { entry_id, pr_url }), None, None)
                 }
                 tasks_github::model::PullRequestState::Open => {
                     // For open PRs, always update head_sha to detect new commits
@@ -1303,24 +1307,33 @@ impl Server {
                         Some(tasks_github::model::MergeableState::Conflicting)
                             if *current_status != MergeStatus::Conflict =>
                         {
-                            Some(MqAction::MarkConflict { entry_id, pr_url })
+                            Some(MqAction::MarkConflict { entry_id: entry_id.clone(), pr_url })
                         }
                         Some(tasks_github::model::MergeableState::Mergeable)
                             if *current_status == MergeStatus::Conflict =>
                         {
-                            Some(MqAction::ClearConflict { entry_id })
+                            Some(MqAction::ClearConflict { entry_id: entry_id.clone() })
                         }
                         _ => None,
                     };
-                    (conflict_action, Some(sha_update_id))
+                    // Track mergeable=Unknown so orchestrator defers evaluation (issue #503)
+                    let unknown_action = match pr.mergeable {
+                        Some(tasks_github::model::MergeableState::Unknown) | None => {
+                            Some(MqAction::SetMergeableUnknown { entry_id: entry_id.clone() })
+                        }
+                        _ => {
+                            Some(MqAction::ClearMergeableUnknown { entry_id: entry_id.clone() })
+                        }
+                    };
+                    (conflict_action, Some(sha_update_id), unknown_action)
                 }
             };
-            actions.push((action, entry_id_for_sha_update, pr.head_sha.clone()));
+            actions.push((action, entry_id_for_sha_update, pr.head_sha.clone(), unknown_action));
         }
 
         // Execute all actions
         let mut changes = 0u32;
-        for (action, entry_id_for_sha_update, head_sha) in actions {
+        for (action, entry_id_for_sha_update, head_sha, unknown_action) in actions {
             if let Some(action) = action {
                 match action {
                     MqAction::MarkMerged { entry_id, pr_url, .. } => {
@@ -1378,6 +1391,39 @@ impl Server {
                             changes += 1;
                         }
                     }
+                    MqAction::SetMergeableUnknown { .. } | MqAction::ClearMergeableUnknown { .. } => {
+                        // Handled below with unknown_action
+                    }
+                }
+            }
+
+            // Update mergeable_unknown flag on entries (issue #503)
+            if let Some(unknown_action) = unknown_action {
+                let mut state = self.state.write().await;
+                match unknown_action {
+                    MqAction::SetMergeableUnknown { ref entry_id } => {
+                        if let Some(entry) = state.merge_queue.get_mut(entry_id) {
+                            if !entry.mergeable_unknown {
+                                tracing::debug!(
+                                    entry_id = %entry_id,
+                                    "reconciliation: GitHub mergeable=Unknown, deferring evaluation"
+                                );
+                                entry.mergeable_unknown = true;
+                            }
+                        }
+                    }
+                    MqAction::ClearMergeableUnknown { ref entry_id } => {
+                        if let Some(entry) = state.merge_queue.get_mut(entry_id) {
+                            if entry.mergeable_unknown {
+                                tracing::debug!(
+                                    entry_id = %entry_id,
+                                    "reconciliation: GitHub mergeable resolved, clearing unknown flag"
+                                );
+                                entry.mergeable_unknown = false;
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
 

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -307,6 +307,7 @@ impl Store {
                     head_sha: None,      // Updated from GitHub on reconciliation
                     queue_position: None, // Computed lazily on API read
                     completed_at: None,  // Not persisted to DB yet
+                    mergeable_unknown: false, // Updated from GitHub on reconciliation
                 }))
             }
             None => Ok(None),
@@ -347,6 +348,7 @@ impl Store {
                 head_sha: None,      // Updated from GitHub on reconciliation
                 queue_position: None, // Computed lazily on API read
                 completed_at: None,  // Not persisted to DB yet
+                mergeable_unknown: false, // Updated from GitHub on reconciliation
             });
         }
         Ok(entries)


### PR DESCRIPTION
## Summary

- Fixes merge conflict detection being skipped when GitHub's `mergeable` field is `Unknown` (computation pending after a push)
- Adds `mergeable_unknown` flag to `MergeQueueEntry` that gets set/cleared during merge queue reconciliation
- Orchestrator eval loop defers evaluation of entries with the flag set, re-queuing them for the next poll cycle when GitHub has resolved the merge status

This prevents the orchestrator from approving and attempting to merge a conflicting PR during the window where GitHub hasn't computed mergeability yet.

## Test plan

- [ ] Verify build passes (`cargo check`)
- [ ] Verify existing tests pass (`cargo test`)
- [ ] Manual test: push a conflicting PR and verify the entry stays deferred while `mergeable=Unknown`, then transitions correctly once GitHub resolves the state

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)