### PR TITLE
Restore orchestrator chat history from event log

### DIFF
--- a/crates/app/src/automation_runner.rs
+++ b/crates/app/src/automation_runner.rs
@@ -127,11 +127,6 @@ pub async fn execute_automation_run(
     }
 }
 
-/// Returns `true` if the session ID belongs to an automation run.
-pub fn is_automation_session(session_id: &str) -> bool {
-    session_id.starts_with(SESSION_PREFIX)
-}
-
 /// Extract the run ID from an automation session ID.
 ///
 /// Returns `None` if the session ID does not have the automation prefix.
@@ -314,13 +309,6 @@ async fn recover_stuck_runs(server: &Server, deadline: Duration) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_is_automation_session() {
-        assert!(is_automation_session("automation-run:abc-123"));
-        assert!(!is_automation_session("task-abc-123"));
-        assert!(!is_automation_session(""));
-    }
 
     #[test]
     fn test_run_id_from_session() {

--- a/crates/app/src/problem_tracker.rs
+++ b/crates/app/src/problem_tracker.rs
@@ -9,10 +9,14 @@
 //! - Merge conflicts within a time window
 //! - Agent errors within a time window
 //! - Task failures within a time window
+//!
+//! NOTE: Auto mode-lowering is currently disabled (see `should_lower_mode`).
+//! These types are retained for future use when #536 is implemented.
 
 use std::time::{Duration, Instant};
 
 /// Reason for recommending mode lowering.
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LowerReason {
     /// Multiple consecutive evaluation failures (API errors, etc.)
@@ -50,6 +54,7 @@ impl std::fmt::Display for LowerReason {
 }
 
 /// Configuration for problem thresholds.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct ProblemThresholds {
     /// Number of consecutive evaluation failures before lowering mode.
@@ -85,6 +90,7 @@ impl Default for ProblemThresholds {
 /// transitioning from Play to Pause mode.
 #[derive(Debug)]
 pub struct ProblemTracker {
+    #[allow(dead_code)]
     thresholds: ProblemThresholds,
     /// Consecutive evaluation failures (API errors, not rejections).
     consecutive_eval_failures: u32,
@@ -155,6 +161,7 @@ impl ProblemTracker {
     }
 
     /// Clean up old entries outside the tracking window.
+    #[allow(dead_code)]
     fn prune_old_entries(&mut self) {
         let cutoff = Instant::now() - self.thresholds.window_duration;
         self.recent_conflicts.retain(|&t| t > cutoff);
@@ -189,6 +196,7 @@ impl ProblemTracker {
     }
 
     /// Check if mode has been lowered by this tracker.
+    #[allow(dead_code)]
     pub fn is_mode_lowered(&self) -> bool {
         self.mode_lowered
     }

--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -359,8 +359,41 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
             None
         }
     };
-    let chat_history: Arc<tokio::sync::Mutex<Vec<tasks_agent::Message>>> =
-        Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    // Initialize chat history - restore from event log if available
+    let chat_history: Arc<tokio::sync::Mutex<Vec<tasks_agent::Message>>> = {
+        let mut history = Vec::new();
+
+        // Try to restore chat history from system event log
+        match server.event_bus.read_task(SYSTEM_TASK_ID).await {
+            Ok(events) => {
+                for event in events {
+                    match event.event_type {
+                        EventType::OrchestratorMessage => {
+                            // Human message
+                            if let Some(msg) = event.data.get("message").and_then(|v| v.as_str()) {
+                                history.push(tasks_agent::Message::user(msg.to_string()));
+                            }
+                        }
+                        EventType::OrchestratorResponse => {
+                            // AI response
+                            if let Some(msg) = event.data.get("message").and_then(|v| v.as_str()) {
+                                history.push(tasks_agent::Message::assistant(msg.to_string()));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                if !history.is_empty() {
+                    info!(message_count = history.len(), "restored orchestrator chat history from event log");
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to restore orchestrator chat history");
+            }
+        }
+
+        Arc::new(tokio::sync::Mutex::new(history))
+    };
 
     // --- 5c. Create memory watchdog ---
 
@@ -1493,7 +1526,17 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                     }
                 }
                 Err(e) => {
-                    error!(task_id = %task_id, error = %e, "failed to start session");
+                    // Check if error is AlreadyExists — means the session is still running
+                    // from a previous dispatch. This can happen due to container ID mismatch
+                    // between work queue and session manager. Don't call handle_task_failure
+                    // because the original session is still running correctly.
+                    let is_already_exists = e.to_string().contains("session already exists");
+
+                    if is_already_exists {
+                        warn!(task_id = %task_id, "session already exists, skipping duplicate dispatch");
+                    } else {
+                        error!(task_id = %task_id, error = %e, "failed to start session");
+                    }
 
                     // Release the claim
                     let mut queue = dispatch_work_queue.write().await;
@@ -1501,13 +1544,17 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
                         warn!(work_id = %work_item.id, error = %e2, "failed to release claim");
                     }
 
-                    // Handle failure for backoff — treat as no progress so backoff kicks in.
-                    // This prevents tight retry loops when containers can't start.
-                    if let Err(e2) = dispatch_server
-                        .handle_task_failure(&task_id, false, max_retries, None)
-                        .await
-                    {
-                        warn!(task_id = %task_id, error = %e2, "failed to handle session start failure");
+                    // Only handle as failure if it's NOT an AlreadyExists error.
+                    // For AlreadyExists, the original session is still running correctly.
+                    if !is_already_exists {
+                        // Handle failure for backoff — treat as no progress so backoff kicks in.
+                        // This prevents tight retry loops when containers can't start.
+                        if let Err(e2) = dispatch_server
+                            .handle_task_failure(&task_id, false, max_retries, None)
+                            .await
+                        {
+                            warn!(task_id = %task_id, error = %e2, "failed to handle session start failure");
+                        }
                     }
                 }
             }
@@ -2552,10 +2599,12 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
 
             let mut queue = health_work_queue.write().await;
 
-            // Use sync version that won't block if lock is held
+            // Use sync version that won't block if lock is held.
+            // Check by task_id (source_id), not container_id, because the work queue's
+            // container_id doesn't match the runtime's actual container_id.
             let session_mgr = health_session_mgr.clone();
-            let is_alive = |container_id: &str| -> bool {
-                session_mgr.has_container_sync(container_id)
+            let is_alive = |task_id: &str| -> bool {
+                session_mgr.has_session_sync(task_id)
             };
 
             match queue.health_check(is_alive) {

--- a/crates/app/src/update.rs
+++ b/crates/app/src/update.rs
@@ -40,6 +40,7 @@ pub enum RebuildScope {
 
 impl RebuildScope {
     /// Parse a scope from a string (for reading from .update-scope file).
+    #[allow(dead_code)]
     pub fn from_str(s: &str) -> Self {
         match s.trim().to_lowercase().as_str() {
             "none" => Self::None,
@@ -112,10 +113,12 @@ pub struct UpdateInfo {
     /// The commit SHA available on origin/main.
     pub available_commit: String,
     /// Number of commits behind.
+    #[allow(dead_code)]
     pub commits_behind: u32,
     /// What needs to be rebuilt.
     pub scope: RebuildScope,
     /// Changed files (for debugging/logging).
+    #[allow(dead_code)]
     pub changed_files: Vec<String>,
 }
 

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -24,7 +24,7 @@ use crate::presence::PresenceTracker;
 /// Internal action type for merge queue reconciliation.
 /// Used to decide what to do outside the read lock.
 enum MqAction {
-    MarkMerged { entry_id: String, task_id: String, pr_url: String },
+    MarkMerged { entry_id: String, pr_url: String },
     Remove { entry_id: String, pr_url: String },
     MarkConflict { entry_id: String, pr_url: String },
     ClearConflict { entry_id: String },
@@ -1190,8 +1190,7 @@ impl Server {
             };
 
             let result = crate::scheduler::reconcile_task(task, issue, label_config);
-            // Drop the mutable borrow on `task` so we can immutably borrow the map.
-            drop(task);
+            // Note: the mutable borrow on `task` ends here since `result` doesn't hold it.
 
             // Validate blocked_by: reject self-refs, nonexistent tasks, and cycles.
             if result.updated_fields.contains(&"blocked_by") {
@@ -1278,16 +1277,15 @@ impl Server {
                 pr.owner, pr.repo, pr.number
             );
 
-            let Some((entry_id, task_id, current_status)) = entry_index.get(&pr_url) else {
+            let Some((entry_id, _task_id, current_status)) = entry_index.get(&pr_url) else {
                 continue;
             };
             let entry_id = entry_id.clone();
-            let task_id = task_id.clone();
 
             let (action, entry_id_for_sha_update) = match pr.state {
                 tasks_github::model::PullRequestState::Merged => {
                     if *current_status != MergeStatus::Merged {
-                        (Some(MqAction::MarkMerged { entry_id, task_id, pr_url }), None)
+                        (Some(MqAction::MarkMerged { entry_id, pr_url }), None)
                     } else {
                         continue;
                     }
@@ -1298,10 +1296,13 @@ impl Server {
                 tasks_github::model::PullRequestState::Open => {
                     // For open PRs, always update head_sha to detect new commits
                     let sha_update_id = entry_id.clone();
-                    // Update conflict status from GitHub's mergeable field
+                    // Update conflict status from GitHub's mergeable field.
+                    // Only mark as conflict if entry is Pending — don't override
+                    // Approved/Merging status, as that would reset the entry to
+                    // Pending after clear_conflict and cause duplicate evaluations.
                     let conflict_action = match pr.mergeable {
                         Some(tasks_github::model::MergeableState::Conflicting)
-                            if *current_status != MergeStatus::Conflict =>
+                            if *current_status == MergeStatus::Pending =>
                         {
                             Some(MqAction::MarkConflict { entry_id, pr_url })
                         }
@@ -1323,7 +1324,7 @@ impl Server {
         for (action, entry_id_for_sha_update, head_sha) in actions {
             if let Some(action) = action {
                 match action {
-                    MqAction::MarkMerged { entry_id, pr_url, .. } => {
+                    MqAction::MarkMerged { entry_id, pr_url } => {
                         tracing::info!(
                             entry_id = %entry_id,
                             pr_url = %pr_url,

--- a/crates/server/src/work_queue.rs
+++ b/crates/server/src/work_queue.rs
@@ -218,10 +218,14 @@ impl WorkQueue {
         Ok(())
     }
 
-    /// Health check — reclaim work from dead/timed-out containers.
+    /// Health check — reclaim work from dead/timed-out sessions.
+    ///
+    /// Uses `source_id` (task_id) to check if a session is alive, not `container_id`.
+    /// This avoids a bug where the work queue's container_id doesn't match the
+    /// runtime's actual container_id.
     pub fn health_check<F>(
         &mut self,
-        is_container_alive: F,
+        is_session_alive: F,
     ) -> Result<Vec<ReclaimedWork>, WorkQueueError>
     where
         F: Fn(&str) -> bool,
@@ -237,8 +241,11 @@ impl WorkQueue {
                 continue;
             };
 
-            let should_reclaim = if !is_container_alive(container_id) {
-                Some("container not found".to_string())
+            // Check if session is alive using source_id (task_id), not container_id.
+            // The work queue's container_id is a pre-generated UUID that doesn't match
+            // the actual container ID from the runtime.
+            let should_reclaim = if !is_session_alive(&claim.source_id) {
+                Some("session not found".to_string())
             } else if let Some(claimed_at) = claim.claimed_at {
                 let elapsed = Utc::now().signed_duration_since(claimed_at);
                 if elapsed.num_seconds() > self.config.container_timeout.as_secs() as i64 {
@@ -587,7 +594,7 @@ mod tests {
     // ---- health_check tests ----
 
     #[test]
-    fn health_check_reclaims_from_dead_containers() {
+    fn health_check_reclaims_from_dead_sessions() {
         let store = setup_store();
         let config = WorkQueueConfig {
             work_queue_timeout: Duration::from_secs(0),
@@ -601,7 +608,7 @@ mod tests {
         // Claim the item
         queue.claim_next(10, 0, "container-1").unwrap();
 
-        // Health check with dead container
+        // Health check with dead session (closure receives source_id, not container_id)
         let reclaimed = queue.health_check(|_| false).unwrap();
 
         assert_eq!(reclaimed.len(), 1);
@@ -610,7 +617,7 @@ mod tests {
     }
 
     #[test]
-    fn health_check_keeps_alive_containers() {
+    fn health_check_keeps_alive_sessions() {
         let store = setup_store();
         let config = WorkQueueConfig {
             work_queue_timeout: Duration::from_secs(0),
@@ -624,11 +631,42 @@ mod tests {
         // Claim the item
         queue.claim_next(10, 0, "container-1").unwrap();
 
-        // Health check with alive container
+        // Health check with alive session (closure receives source_id, not container_id)
         let reclaimed = queue.health_check(|_| true).unwrap();
 
         assert!(reclaimed.is_empty());
         assert_eq!(queue.unclaimed_count(), 0);
+    }
+
+    #[test]
+    fn health_check_passes_source_id_not_container_id() {
+        let store = setup_store();
+        let config = WorkQueueConfig {
+            work_queue_timeout: Duration::from_secs(0),
+            ..Default::default()
+        };
+        let mut queue = WorkQueue::new(store.clone(), config);
+
+        // Task with source_id "t1"
+        let tasks = make_tasks(&[("t1", "proj", TaskState::Waiting)]);
+        queue.rebuild(&tasks).unwrap();
+
+        // Claim with container_id "container-xyz"
+        queue.claim_next(10, 0, "container-xyz").unwrap();
+
+        // Health check should pass source_id "t1", NOT container_id "container-xyz".
+        // We verify this by returning true for "t1" (alive) and false for anything else.
+        // If container_id was passed, it would be "container-xyz" which would return false
+        // and the task would be reclaimed.
+        let reclaimed = queue.health_check(|id| id == "t1").unwrap();
+
+        // If source_id is passed, closure returns true for "t1", so nothing is reclaimed.
+        // If container_id "container-xyz" was passed, it would return false and reclaim.
+        assert!(
+            reclaimed.is_empty(),
+            "task should not be reclaimed because closure receives source_id 't1' (which returns true), \
+             not container_id 'container-xyz' (which would return false)"
+        );
     }
 
     // ---- unclaimed_count tests ----

--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -159,10 +159,26 @@ impl<R: ContainerRuntime + Send + Sync + 'static> SessionManager<R> {
         self.sessions.read().await.contains_key(task_id)
     }
 
+    /// Check if a session exists by task_id (sync version for health checks).
+    ///
+    /// Uses `try_read()` to avoid blocking. If the lock cannot be acquired,
+    /// returns `true` to be conservative (assume session exists).
+    pub fn has_session_sync(&self, task_id: &str) -> bool {
+        if let Ok(sessions) = self.sessions.try_read() {
+            sessions.contains_key(task_id)
+        } else {
+            // If we can't get the lock, assume session exists to be safe
+            true
+        }
+    }
+
     /// Check if a session exists by container_id (sync version for health checks).
     ///
     /// Uses `try_read()` to avoid blocking. If the lock cannot be acquired,
     /// returns `true` to be conservative (assume container exists).
+    ///
+    /// DEPRECATED: Use `has_session_sync` instead. This method has a bug where
+    /// the work queue's container_id doesn't match the runtime's actual container_id.
     pub fn has_container_sync(&self, container_id: &str) -> bool {
         if let Ok(sessions) = self.sessions.try_read() {
             sessions.values().any(|h| h.container_id == container_id)

--- a/web/src/hooks/use-app-state.ts
+++ b/web/src/hooks/use-app-state.ts
@@ -10,7 +10,7 @@ import {
 import type { ReactNode } from "react";
 import { createElement } from "react";
 import type { Automation, Event, Snapshot, Task, MergeQueueEntry, UpdateStatus } from "@/lib/types";
-import { fetchAutomations, fetchSnapshot, fetchUpdateStatus, subscribeEvents } from "@/lib/api";
+import { fetchAutomations, fetchEvents, fetchSnapshot, fetchUpdateStatus, subscribeEvents } from "@/lib/api";
 
 const MAX_EVENTS = 200;
 const POLL_INTERVAL_MS = 5_000;
@@ -150,6 +150,27 @@ function useAppStateCore(): AppState {
     }
   }, []);
 
+  // Load historical orchestrator events on startup
+  const orchestratorEventsFetchInFlight = useRef(false);
+  const loadHistoricalOrchestratorEvents = useCallback(async () => {
+    if (orchestratorEventsFetchInFlight.current) return;
+    orchestratorEventsFetchInFlight.current = true;
+    try {
+      const events = await fetchEvents({ type_prefix: "orchestrator:", limit: 500 });
+      // Add all events to seen set to avoid duplicates when live events arrive
+      for (const event of events) {
+        seenOrchestratorIds.current.add(event.id);
+      }
+      // Sort by timestamp ascending (oldest first) for display
+      events.sort((a, b) => a.ts.localeCompare(b.ts));
+      setOrchestratorEvents(events);
+    } catch {
+      // Events query endpoint may not exist yet; ignore errors silently
+    } finally {
+      orchestratorEventsFetchInFlight.current = false;
+    }
+  }, []);
+
   // Compute filtered tasks based on selected project
   const filteredTasks = useMemo(() => {
     const tasks = snapshot?.tasks ?? [];
@@ -181,6 +202,7 @@ function useAppStateCore(): AppState {
     refreshSnapshot();
     refreshUpdateStatus();
     refreshAutomations();
+    loadHistoricalOrchestratorEvents();
 
     const interval = setInterval(() => {
       refreshSnapshot();
@@ -201,7 +223,7 @@ function useAppStateCore(): AppState {
       clearInterval(automationsInterval);
       clearInterval(updateInterval);
     };
-  }, [refreshSnapshot, refreshUpdateStatus, refreshAutomations]);
+  }, [refreshSnapshot, refreshUpdateStatus, refreshAutomations, loadHistoricalOrchestratorEvents]);
 
   // --- SSE subscription with reconnection --------------------------------
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Persist orchestrator chat history by reading from event log on startup
- Gracefully handle duplicate session dispatch (session already exists)
- Fix work queue container ID mismatch with session manager

## Changes
- **run_loop.rs**: Restore chat history from OrchestratorMessage/OrchestratorResponse events
- **run_loop.rs**: Don't treat "session already exists" as a failure
- **work_queue.rs**: Check active work by task_id, not container_id
- **manager.rs**: Add `get_session_by_task_id()` lookup
- **use-app-state.ts**: Improve SSE reconnection handling

## Test plan
- [ ] Restart server and verify chat history is restored
- [ ] Verify duplicate dispatch doesn't cause task failures