### PR TITLE
Fix container orphan leak when start_agent fails

### DIFF
--- a/crates/session/src/manager.rs
+++ b/crates/session/src/manager.rs
@@ -510,7 +510,23 @@ impl<R: ContainerRuntime + Clone + Send + Sync + 'static> SessionManager<R> {
         let container_id = session.container_id().unwrap().to_string();
         tracing::info!(task_id = %task_id, container_id = %container_id, "container ready");
 
-        session.start_agent(&repo_url, &branch, &prompt)?;
+        // Start agent - if this fails, destroy the container to prevent orphans
+        if let Err(e) = session.start_agent(&repo_url, &branch, &prompt) {
+            tracing::error!(
+                task_id = %task_id,
+                container_id = %container_id,
+                error = %e,
+                "failed to start agent, destroying orphaned container"
+            );
+            if let Err(destroy_err) = self.runtime.destroy(&container_id).await {
+                tracing::error!(
+                    container_id = %container_id,
+                    error = %destroy_err,
+                    "failed to destroy orphaned container"
+                );
+            }
+            return Err(e.into());
+        }
         tracing::info!(task_id = %task_id, "agent started");
 
         // Create command channel


### PR DESCRIPTION
## Summary
- Destroy container if `start_agent()` fails after container was started
- Prevents orphaned containers that accumulate when agent initialization fails

## Problem
If `start_agent()` failed after `session.start()` but before the session was registered in the sessions map, the container would be orphaned. These orphans were never cleaned up by `destroy_all()` because they weren't tracked.

This explains the 28 orphaned containers found after 1-2 days of the server being shut down.

## Test plan
- [x] All 35 session tests pass
- [x] Full workspace tests pass