### PR TITLE
Allow tool results to attach supplementary notes (#689)

### DIFF
--- a/crates/agent/src/message.rs
+++ b/crates/agent/src/message.rs
@@ -195,15 +195,38 @@ pub struct ToolResult {
     pub tool_call_id: String,
     pub content: String,
     pub is_error: bool,
+    /// Supplementary context appended after the tool result in the same user message.
+    ///
+    /// Each note becomes an additional text content block following the tool_result block,
+    /// so the model sees it as context right after the tool output. Useful for warnings,
+    /// suggestions, or hints that shouldn't clutter the primary `content` field.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notes: Vec<String>,
 }
 
 impl ToolResult {
     pub fn success(tool_call_id: impl Into<String>, content: impl Into<String>) -> Self {
-        Self { tool_call_id: tool_call_id.into(), content: content.into(), is_error: false }
+        Self {
+            tool_call_id: tool_call_id.into(),
+            content: content.into(),
+            is_error: false,
+            notes: Vec::new(),
+        }
     }
 
     pub fn error(tool_call_id: impl Into<String>, error: impl Into<String>) -> Self {
-        Self { tool_call_id: tool_call_id.into(), content: error.into(), is_error: true }
+        Self {
+            tool_call_id: tool_call_id.into(),
+            content: error.into(),
+            is_error: true,
+            notes: Vec::new(),
+        }
+    }
+
+    /// Append a supplementary note that the model will see after the tool result.
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
+        self.notes.push(note.into());
+        self
     }
 }
 

--- a/crates/agent/src/session.rs
+++ b/crates/agent/src/session.rs
@@ -124,11 +124,17 @@ impl Session {
     /// messages for continuity). A warning is logged when truncation occurs.
     pub fn build_request(&mut self) -> CompletionRequest {
         if !self.pending_tool_results.is_empty() {
-            let tool_result_content: Vec<Content> = std::mem::take(&mut self.pending_tool_results)
-                .into_iter()
-                .map(|r| Content::tool_result(r.tool_call_id, r.content, r.is_error))
-                .collect();
-            self.messages.push(Message::new(Role::User, tool_result_content));
+            let results = std::mem::take(&mut self.pending_tool_results);
+            let mut content: Vec<Content> = Vec::with_capacity(results.len());
+            let mut trailing_notes: Vec<String> = Vec::new();
+            for r in results {
+                content.push(Content::tool_result(r.tool_call_id, r.content, r.is_error));
+                trailing_notes.extend(r.notes);
+            }
+            for note in trailing_notes {
+                content.push(Content::text(note));
+            }
+            self.messages.push(Message::new(Role::User, content));
         }
 
         let messages = self.truncate_to_budget();
@@ -700,6 +706,49 @@ mod tests {
         let last_msg = request.messages.last().unwrap();
         assert_eq!(last_msg.role, Role::User);
         assert!(matches!(&last_msg.content[0], Content::ToolResult { tool_use_id, .. } if tool_use_id == "tc-1"));
+    }
+
+    #[test]
+    fn test_tool_result_notes_appended_after_tool_result() {
+        let mut session = Session::new(CompletionConfig::new("test-model"));
+        session.add_user_message("go");
+
+        let response = Response {
+            content: vec![],
+            tool_calls: vec![
+                ToolCall {
+                    id: "tc-1".into(),
+                    name: "read_file".into(),
+                    arguments: serde_json::json!({}),
+                },
+                ToolCall {
+                    id: "tc-2".into(),
+                    name: "grep".into(),
+                    arguments: serde_json::json!({}),
+                },
+            ],
+            stop_reason: Some(StopReason::ToolUse),
+            usage: None,
+        };
+        session.apply_response(&response);
+
+        session.apply_tool_results(vec![
+            ToolResult::success("tc-1", "file contents")
+                .with_note("Note: this is a test file; implementation is in src/lib.rs"),
+            ToolResult::success("tc-2", "47 matches")
+                .with_note("Tip: narrow the pattern to reduce noise."),
+        ]);
+
+        let request = session.build_request();
+        let last_msg = request.messages.last().unwrap();
+        assert_eq!(last_msg.role, Role::User);
+
+        // First two content blocks are tool results (in order), then the two notes as text.
+        assert_eq!(last_msg.content.len(), 4);
+        assert!(matches!(&last_msg.content[0], Content::ToolResult { tool_use_id, .. } if tool_use_id == "tc-1"));
+        assert!(matches!(&last_msg.content[1], Content::ToolResult { tool_use_id, .. } if tool_use_id == "tc-2"));
+        assert!(matches!(&last_msg.content[2], Content::Text { text } if text.starts_with("Note:")));
+        assert!(matches!(&last_msg.content[3], Content::Text { text } if text.starts_with("Tip:")));
     }
 
     #[test]

--- a/crates/agent/src/tool_result_budget.rs
+++ b/crates/agent/src/tool_result_budget.rs
@@ -106,6 +106,7 @@ pub fn budget_tool_results(
                 tool_call_id: result.tool_call_id,
                 content: budgeted_content,
                 is_error: result.is_error,
+                notes: result.notes,
             }
         })
         .collect()


### PR DESCRIPTION
## Summary

Adds a `notes: Vec<String>` field to `ToolResult` so tool authors can attach supplementary context (warnings, hints, suggestions) that the model sees right after the tool's primary output. Each note becomes an additional text content block emitted after the `tool_result` block in the same user message — Anthropic-API compliant and API-shape neutral.

### Why a Vec<String>, not Vec<Message>

The issue sketched a `new_messages: Vec<Message>` field, but the Anthropic provider filters/coerces `Role::System` out of the conversation array (`providers/anthropic.rs:233, :452, :576`). Full-`Message` injection wouldn't survive round-trip. The documented use cases (test-file note, search-result hint, .env warning, build-warnings note) are all supplementary text, so a `Vec<String>` captures the intent without fighting the API shape. See issue #689 for the full reasoning.

### Usage

```rust
ToolResult::success(tool_call_id, file_contents)
    .with_note("Note: this is a test file; implementation is in src/lib.rs")
```

## Test plan

- [x] New unit test `test_tool_result_notes_appended_after_tool_result` verifies content-block ordering (tool_results first, then notes as text)
- [x] Existing `test_apply_tool_results_emits_structured_content` still passes
- [x] `cargo test --workspace` — all 969 tests pass
- [x] `cargo check --workspace` clean

Closes #689