### PR TITLE
Don't clear rejection feedback on dispatch success (#505)

### DIFF
--- a/crates/app/src/run_loop.rs
+++ b/crates/app/src/run_loop.rs
@@ -1542,14 +1542,16 @@ pub async fn run(config: AppConfig) -> Result<RunResult, Box<dyn std::error::Err
             {
                 Ok(_) => {
                     info!(task_id = %task_id, work_id = %work_item.id, "session started for claimed work");
-                    // Clear rejection feedback after successful dispatch (issue #423).
-                    // This prevents stale feedback from being repeated if the task
-                    // is rejected and re-dispatched again.
-                    if task.rejection_feedback.is_some() {
-                        if let Err(e) = dispatch_server.clear_task_rejection_feedback(&task_id).await {
-                            warn!(task_id = %task_id, error = %e, "failed to clear rejection feedback after dispatch");
-                        }
-                    }
+                    // Intentionally do NOT clear rejection_feedback here (issue #505).
+                    // start_session() returning Ok only means the container handoff
+                    // succeeded — not that the agent actually consumed the prompt.
+                    // Clearing at this point risks losing feedback if the session
+                    // crashes before the agent processes its first message.
+                    // Stale feedback is not a real concern because:
+                    //   - The next rejection overwrites via set_task_rejection_feedback.
+                    //   - Terminal tasks aren't re-dispatched.
+                    //   - A retry after transient failure legitimately needs to see
+                    //     the same feedback again.
                 }
                 Err(e) => {
                     // Check if error is AlreadyExists — means the session is still running

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -2954,6 +2954,36 @@ mod tests {
         assert!(task.rejection_feedback.is_none());
     }
 
+    #[tokio::test]
+    async fn new_rejection_feedback_overrides_old(/* issue #505 */) {
+        // Regression test for #505: the dispatch loop no longer clears feedback
+        // eagerly, so we need to confirm that setting new feedback cleanly
+        // overrides a previously-set value (the documented mechanism for
+        // invalidating stale feedback without risking data loss on dispatch
+        // failure).
+        let server = test_server().await;
+        let project = Project::new("proj-1", "owner/repo");
+        server.add_project(project).await;
+        let task = Task::new("task-1", TaskSource::Internal, "Test task", "proj-1");
+        server.add_task(task).await.unwrap();
+
+        server
+            .set_task_rejection_feedback("task-1", Some("first attempt was wrong".into()))
+            .await
+            .unwrap();
+        server
+            .set_task_rejection_feedback("task-1", Some("second attempt also wrong".into()))
+            .await
+            .unwrap();
+
+        let task = server.get_task("task-1").await.unwrap();
+        assert_eq!(
+            task.rejection_feedback.as_deref(),
+            Some("second attempt also wrong"),
+            "newer feedback must replace older"
+        );
+    }
+
     // --- Progress detection tests (spec §13.1, §13.2) ---
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes the P1 data-loss bug in #505: task rejection feedback was being cleared the moment \`start_session()\` returned \`Ok\`, but that return value only confirms the container handoff — it doesn't mean the agent actually consumed the prompt. If the session crashed between handoff and the agent's first response (OOM, container died, etc.), the feedback was lost before anyone saw it.

### Fix

Remove the eager clear at \`run_loop.rs:1548\`. Leave feedback in place and rely on the natural invalidation points:

- The next rejection overwrites via \`set_task_rejection_feedback\`.
- Terminal tasks aren't re-dispatched, so stale data can't reach a new agent.
- A retry after transient failure legitimately should re-see the same feedback — the PR it describes is still the one the agent is trying to fix.

The public \`clear_task_rejection_feedback\` API is kept for manual clearing (an endpoint could still use it); it's just no longer invoked automatically on dispatch.

### Scope

Issue #505 also mentions \`MergeQueueEntry.changes_requested_feedback\` as having the same structural shape. That field isn't currently wired into any prompt (has TODO comments about DB persistence), so there's no live data-loss path to fix there. Left for a follow-up once that feedback actually flows into prompts.

## Test plan

- [x] New regression test \`new_rejection_feedback_overrides_old\` confirms the documented invalidation mechanism (setting newer feedback replaces older) works, since that's now the only automatic clearing path.
- [x] Existing \`rejection_feedback_cleared_after_set\` still passes (manual clear API still works).
- [x] \`cargo check --workspace\` clean.
- [x] \`cargo test --workspace\` all pass.

Closes #505