### PR TITLE
Startup reconciliation + persisted dispatch attempts

### DIFF
--- a/crates/tasks/migrations/0003_dispatch_attempts.sql
+++ b/crates/tasks/migrations/0003_dispatch_attempts.sql
@@ -1,0 +1,5 @@
+-- Consecutive failed scout dispatches for a task. Persisted rather than kept in
+-- the dispatcher's memory so a restart can't wipe the strike count and let a
+-- poison task retry forever. Reset to 0 when a scout produces a spec. Like
+-- manual_rank, the GitHub poller must never write it.
+ALTER TABLE tasks ADD COLUMN dispatch_attempts INTEGER NOT NULL DEFAULT 0;

--- a/crates/tasks/src/models.rs
+++ b/crates/tasks/src/models.rs
@@ -70,6 +70,11 @@ pub struct Task {
     /// sorts after every ranked task. Only ever written by explicit reorder
     /// requests — never by the GitHub poller.
     pub manual_rank: Option<i32>,
+    /// Consecutive failed scout dispatches. Persisted so restarts can't reset
+    /// the count: at `MAX_DISPATCH_ATTEMPTS` the dispatcher rejects the task
+    /// instead of retrying it forever. Cleared when a scout produces a spec.
+    /// Never written by the GitHub poller.
+    pub dispatch_attempts: u32,
     pub ingested_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -20,12 +20,17 @@
 //! [`crate::protocol::ScoutCommand`]) — cancelling means deallocating the VM,
 //! and that path is deferred.
 //!
+//! Crash consistency is the store's job, not memory's: startup calls
+//! [`reconcile_startup`] to clear work a dead process left mid-flight, and a
+//! task's failed dispatches are counted on its row, so restarts can't hand a
+//! task that can never be scouted three fresh attempts every time.
+//!
 //! Nothing here is required for the API to work. A missing `GITHUB_TOKEN`
 //! disables polling and an unreachable vm-pool socket disables dispatch (with
 //! periodic reconnect); the server stays up either way so manual flows over
 //! HTTP keep working.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -64,9 +69,10 @@ const SHUTDOWN_GRACE: Duration = Duration::from_secs(30);
 /// `source` on the breadcrumbs this module writes to the event log.
 const DISPATCHER: &str = "dispatcher";
 
-/// Consecutive failed dispatches after which the loop stops retrying a task
-/// for the lifetime of the process. Matches the re-explore cap the plan puts
-/// on the server rather than the orchestrator.
+/// Consecutive failed dispatches after which a task is rejected outright.
+/// Matches the re-explore cap the plan puts on the server rather than the
+/// orchestrator. The count lives in the store (`tasks.dispatch_attempts`), so
+/// restarts don't hand a poison task a fresh set of strikes.
 const MAX_DISPATCH_ATTEMPTS: u32 = 3;
 
 #[derive(Debug, Error)]
@@ -233,13 +239,18 @@ pub async fn open_store(data_dir: &Path) -> Result<Store, RunError> {
 
 /// Run the server until ctrl_c.
 ///
+/// Startup begins with [`reconcile_startup`], so work abandoned by a previous
+/// process is cleaned up before either loop looks at the queue.
+///
 /// Shutdown is best-effort: ctrl_c stops the HTTP listener and signals both
 /// loops. The poll loop exits at once; the dispatch loop starts nothing new
 /// and waits out its in-flight scouts, up to [`SHUTDOWN_GRACE`]. Past that we
 /// stop waiting — the abandoned VMs are reaped by vm-pool's health loop, and
-/// their sessions stay `running` in the store until a scout retries the task.
+/// their sessions stay `running` in the store until the next startup
+/// reconciles them.
 pub async fn run(config: Config) -> Result<(), RunError> {
     let store = Arc::new(open_store(&config.data_dir).await?);
+    reconcile_startup(&store).await?;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
     let poll = tokio::spawn(poll_loop(
@@ -268,6 +279,24 @@ pub async fn run(config: Config) -> Result<(), RunError> {
         warn!(
             grace_secs = SHUTDOWN_GRACE.as_secs(),
             "in-flight scouts did not finish within the grace period; exiting anyway"
+        );
+    }
+    Ok(())
+}
+
+/// Clean up work a previous process abandoned mid-flight.
+///
+/// Must run before any loop starts: this process owns all dispatch, so every
+/// `running` session it finds at startup is by definition orphaned, and every
+/// `scouting` task is stranded behind one. See
+/// [`Store::reconcile_orphaned_work`] for what that means row by row.
+pub async fn reconcile_startup(store: &Store) -> Result<(), StoreError> {
+    let report = store.reconcile_orphaned_work().await?;
+    if !report.is_empty() {
+        info!(
+            sessions = report.sessions,
+            tasks = report.tasks,
+            "reconciled work orphaned by a previous run"
         );
     }
     Ok(())
@@ -351,7 +380,6 @@ pub async fn poll_once(store: &Store, github: &GitHubClient) -> Result<usize, St
 /// drops, dispatch pauses and reconnects every [`VM_POOL_RETRY`] rather than
 /// taking the process down.
 pub async fn dispatch_loop(store: Arc<Store>, config: Config, mut shutdown: watch::Receiver<bool>) {
-    let mut attempts: HashMap<TaskId, u32> = HashMap::new();
     loop {
         if *shutdown.borrow() {
             return;
@@ -373,7 +401,7 @@ pub async fn dispatch_loop(store: Arc<Store>, config: Config, mut shutdown: watc
         };
         info!(socket = %config.vm_pool_socket.display(), "connected to vm-pool");
 
-        dispatch_connected(&store, &config, client, &mut attempts, &mut shutdown).await;
+        dispatch_connected(&store, &config, client, &mut shutdown).await;
     }
 }
 
@@ -384,7 +412,6 @@ async fn dispatch_connected(
     store: &Arc<Store>,
     config: &Config,
     client: Client<TasksProtocol>,
-    attempts: &mut HashMap<TaskId, u32>,
     shutdown: &mut watch::Receiver<bool>,
 ) {
     let scout = Arc::new(Scout::new(
@@ -403,15 +430,7 @@ async fn dispatch_connected(
 
     loop {
         if !draining
-            && let Err(e) = top_up(
-                store,
-                config,
-                &scout,
-                attempts,
-                &mut in_flight,
-                &mut in_flight_ids,
-            )
-            .await
+            && let Err(e) = top_up(store, config, &scout, &mut in_flight, &mut in_flight_ids).await
         {
             warn!(error = %e, "could not read the task queue; retrying next tick");
         }
@@ -425,7 +444,7 @@ async fn dispatch_connected(
                 match joined {
                     Ok((task_id, result)) => {
                         in_flight_ids.remove(&task_id);
-                        match record_outcome(store, attempts, &task_id, result).await {
+                        match record_outcome(store, &task_id, result).await {
                             Ok(ConnectionLost(true)) => draining = true,
                             Ok(ConnectionLost(false)) => {}
                             Err(e) => warn!(task_id = %task_id, error = %e, "recording scout outcome failed"),
@@ -449,7 +468,6 @@ async fn top_up(
     store: &Arc<Store>,
     config: &Config,
     scout: &Arc<Scout>,
-    attempts: &HashMap<TaskId, u32>,
     in_flight: &mut JoinSet<(TaskId, Result<Spec, ScoutError>)>,
     in_flight_ids: &mut HashSet<TaskId>,
 ) -> Result<(), StoreError> {
@@ -458,7 +476,7 @@ async fn top_up(
     }
 
     while in_flight.len() < config.scout_max_concurrent {
-        let Some((task, project)) = next_dispatchable(store, in_flight_ids, attempts).await? else {
+        let Some((task, project)) = next_dispatchable(store, in_flight_ids).await? else {
             break;
         };
 
@@ -488,16 +506,19 @@ async fn top_up(
 /// The next task to scout: queue order (which [`Store::list_tasks`] already
 /// applies), state `New`, still open on GitHub, not in flight, not past the
 /// attempt cap.
+///
+/// A task at the cap is rejected the moment it gets there, so the attempt
+/// filter here is belt-and-braces: it also covers rows an older build (or a
+/// crash between the increment and the rejection) left `New` at three strikes.
 async fn next_dispatchable(
     store: &Store,
     skip: &HashSet<TaskId>,
-    attempts: &HashMap<TaskId, u32>,
 ) -> Result<Option<(Task, Project)>, StoreError> {
     for task in store.list_tasks().await? {
         if task.state != TaskState::New
             || task.gh_state == GhState::Closed
             || skip.contains(&task.id)
-            || attempts.get(&task.id).copied().unwrap_or(0) >= MAX_DISPATCH_ATTEMPTS
+            || task.dispatch_attempts >= MAX_DISPATCH_ATTEMPTS
         {
             continue;
         }
@@ -513,18 +534,19 @@ async fn next_dispatchable(
 /// Whether the finished dispatch took the vm-pool connection down with it.
 struct ConnectionLost(bool);
 
-/// Fold a finished dispatch back into the loop's bookkeeping. The store writes
-/// themselves already happened inside [`Scout::dispatch`]; this only tracks
-/// retries and leaves a breadcrumb on the event log.
+/// Fold a finished dispatch back into the pipeline. The spec and session writes
+/// already happened inside [`Scout::dispatch`]; what is left is the retry
+/// accounting — count the failure, reject the task once it has used up its
+/// attempts, and leave a breadcrumb on the event log either way.
 async fn record_outcome(
     store: &Store,
-    attempts: &mut HashMap<TaskId, u32>,
     task_id: &TaskId,
     result: Result<Spec, ScoutError>,
 ) -> Result<ConnectionLost, StoreError> {
     let error = match result {
         Ok(spec) => {
-            attempts.remove(task_id);
+            // The attempt count is cleared by `Scout::finalize_succeeded`,
+            // alongside the rest of the success-path writes.
             info!(task_id = %task_id, spec_id = %spec.id, "scout produced a spec");
             return Ok(ConnectionLost(false));
         }
@@ -544,21 +566,61 @@ async fn record_outcome(
         return Ok(ConnectionLost(true));
     }
 
-    let count = attempts.entry(task_id.clone()).or_insert(0);
-    *count += 1;
-    warn!(task_id = %task_id, attempt = *count, error = %error, "scout dispatch failed");
-    let message = if *count >= MAX_DISPATCH_ATTEMPTS {
-        format!("scout for {task_id} failed {count}x, giving up: {error}")
+    let count = store.record_dispatch_failure(task_id).await?;
+    warn!(task_id = %task_id, attempt = count, error = %error, "scout dispatch failed");
+    if count >= MAX_DISPATCH_ATTEMPTS {
+        reject_exhausted(
+            store,
+            task_id,
+            format!("scout for {task_id} failed {count}x, rejecting the task: {error}"),
+        )
+        .await?;
     } else {
-        format!("scout for {task_id} failed (attempt {count}): {error}")
+        store
+            .append_event(EventPayload::Note {
+                source: DISPATCHER.into(),
+                message: format!("scout for {task_id} failed (attempt {count}): {error}"),
+            })
+            .await?;
+    }
+    Ok(ConnectionLost(false))
+}
+
+/// Retire a task that has burned through [`MAX_DISPATCH_ATTEMPTS`].
+///
+/// [`Scout::dispatch`]'s failure path has already put the task back to `New` by
+/// the time we get here, which is why this runs last and wins: a task left
+/// `New` at the cap would be picked up again by the next process, which is
+/// exactly the retry-forever loop the persisted count exists to stop.
+async fn reject_exhausted(
+    store: &Store,
+    task_id: &TaskId,
+    message: String,
+) -> Result<(), StoreError> {
+    let from = match store.get_task(task_id).await? {
+        Some(task) => task.state,
+        None => {
+            warn!(task_id = %task_id, "task vanished before it could be rejected");
+            return Ok(());
+        }
     };
+    store
+        .update_task_state(task_id, TaskState::Rejected)
+        .await?;
+    store
+        .append_event(EventPayload::TaskStateChanged {
+            task_id: task_id.clone(),
+            from,
+            to: TaskState::Rejected,
+        })
+        .await?;
     store
         .append_event(EventPayload::Note {
             source: DISPATCHER.into(),
             message,
         })
         .await?;
-    Ok(ConnectionLost(false))
+    Ok(())
 }
 
 /// A scout error that means the vm-pool connection is gone, rather than the

--- a/crates/tasks/src/scout.rs
+++ b/crates/tasks/src/scout.rs
@@ -228,6 +228,9 @@ impl Scout {
         self.store
             .update_task_state(&task.id, TaskState::SpecReady)
             .await?;
+        // A spec proves the task is dispatchable, so its past failures stop
+        // counting: a later `needs_revision` re-scout starts from zero strikes.
+        self.store.reset_dispatch_attempts(&task.id).await?;
 
         self.store
             .append_event(EventPayload::SessionCompleted {

--- a/crates/tasks/src/server.rs
+++ b/crates/tasks/src/server.rs
@@ -401,6 +401,7 @@ mod tests {
             state: TaskState::New,
             priority,
             manual_rank: None,
+            dispatch_attempts: 0,
             ingested_at: now,
             updated_at: now,
         };

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -39,6 +39,27 @@ impl<T> UpsertOutcome<T> {
 /// `events_since`.
 const EVENT_BROADCAST_CAPACITY: usize = 1024;
 
+/// `exit_reason` written to sessions that were still `running` when the server
+/// came back up.
+const ORPHANED_EXIT_REASON: &str = "orphaned by server restart";
+
+/// What [`Store::reconcile_orphaned_work`] cleaned up: rows that a previous
+/// process left mid-flight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ReconcileReport {
+    /// `running` sessions failed as orphaned.
+    pub sessions: usize,
+    /// `scouting` tasks put back in the queue as `new`.
+    pub tasks: usize,
+}
+
+impl ReconcileReport {
+    /// Whether anything at all was reconciled — the only case worth logging.
+    pub fn is_empty(&self) -> bool {
+        self.sessions == 0 && self.tasks == 0
+    }
+}
+
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
 #[derive(Debug, Error)]
@@ -126,8 +147,8 @@ impl Store {
     pub async fn insert_task(&self, task: &Task) -> Result<(), StoreError> {
         sqlx::query(
             "INSERT INTO tasks (id, project_id, gh_issue_number, title, body, labels, \
-             gh_state, state, priority, manual_rank, ingested_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             gh_state, state, priority, manual_rank, dispatch_attempts, ingested_at, \
+             updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(task.id.as_str())
         .bind(task.project_id.as_str())
@@ -139,6 +160,7 @@ impl Store {
         .bind(task.state.as_str())
         .bind(task.priority)
         .bind(task.manual_rank)
+        .bind(task.dispatch_attempts as i64)
         .bind(task.ingested_at.to_rfc3339())
         .bind(task.updated_at.to_rfc3339())
         .execute(&self.pool)
@@ -149,7 +171,8 @@ impl Store {
     pub async fn get_task(&self, id: &TaskId) -> Result<Option<Task>, StoreError> {
         let row = sqlx::query(
             "SELECT id, project_id, gh_issue_number, title, body, labels, gh_state, \
-             state, priority, manual_rank, ingested_at, updated_at FROM tasks WHERE id = ?",
+             state, priority, manual_rank, dispatch_attempts, ingested_at, updated_at \
+             FROM tasks WHERE id = ?",
         )
         .bind(id.as_str())
         .fetch_optional(&self.pool)
@@ -162,8 +185,8 @@ impl Store {
     pub async fn list_tasks(&self) -> Result<Vec<Task>, StoreError> {
         let rows = sqlx::query(
             "SELECT id, project_id, gh_issue_number, title, body, labels, gh_state, \
-             state, priority, manual_rank, ingested_at, updated_at FROM tasks \
-             ORDER BY manual_rank IS NULL, manual_rank, priority DESC, ingested_at",
+             state, priority, manual_rank, dispatch_attempts, ingested_at, updated_at \
+             FROM tasks ORDER BY manual_rank IS NULL, manual_rank, priority DESC, ingested_at",
         )
         .fetch_all(&self.pool)
         .await?;
@@ -233,8 +256,8 @@ impl Store {
     ) -> Result<UpsertOutcome<Task>, StoreError> {
         let existing = sqlx::query(
             "SELECT id, project_id, gh_issue_number, title, body, labels, gh_state, \
-             state, priority, manual_rank, ingested_at, updated_at FROM tasks \
-             WHERE project_id = ? AND gh_issue_number = ?",
+             state, priority, manual_rank, dispatch_attempts, ingested_at, updated_at \
+             FROM tasks WHERE project_id = ? AND gh_issue_number = ?",
         )
         .bind(project_id.as_str())
         .bind(issue.number as i64)
@@ -281,6 +304,7 @@ impl Store {
             state: TaskState::New,
             priority: 0,
             manual_rank: None,
+            dispatch_attempts: 0,
             ingested_at: now,
             updated_at: now,
         };
@@ -298,6 +322,50 @@ impl Store {
             .await?;
         if result.rows_affected() == 0 {
             return Err(StoreError::NotFound(format!("task {id}")));
+        }
+        Ok(())
+    }
+
+    /// Count one more failed dispatch against a task and return the new total.
+    ///
+    /// The counter lives in the database precisely so a restart can't forgive a
+    /// task its strikes — an in-memory tally would let a task that can never be
+    /// scouted be retried forever, one restart at a time.
+    pub async fn record_dispatch_failure(&self, id: &TaskId) -> Result<u32, StoreError> {
+        let row = sqlx::query(
+            "UPDATE tasks SET dispatch_attempts = dispatch_attempts + 1, updated_at = ? \
+             WHERE id = ? RETURNING dispatch_attempts",
+        )
+        .bind(Utc::now().to_rfc3339())
+        .bind(id.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+        let row = row.ok_or_else(|| StoreError::NotFound(format!("task {id}")))?;
+        Ok(row.try_get::<i64, _>("dispatch_attempts")?.max(0) as u32)
+    }
+
+    /// Clear a task's dispatch failures. Called when a scout produces a spec:
+    /// the task has proven dispatchable, so a later re-scout (`needs_revision`)
+    /// starts from a clean slate.
+    pub async fn reset_dispatch_attempts(&self, id: &TaskId) -> Result<(), StoreError> {
+        let result = sqlx::query(
+            "UPDATE tasks SET dispatch_attempts = 0, updated_at = ? \
+             WHERE id = ? AND dispatch_attempts != 0",
+        )
+        .bind(Utc::now().to_rfc3339())
+        .bind(id.as_str())
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            // Either the task is already at zero or it is gone; only the latter
+            // is an error.
+            let exists = sqlx::query("SELECT 1 FROM tasks WHERE id = ?")
+                .bind(id.as_str())
+                .fetch_optional(&self.pool)
+                .await?;
+            if exists.is_none() {
+                return Err(StoreError::NotFound(format!("task {id}")));
+            }
         }
         Ok(())
     }
@@ -379,6 +447,100 @@ impl Store {
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter().map(session_from_row).collect()
+    }
+
+    // --- reconciliation ---
+
+    /// Fail every `running` session and requeue every `scouting` task.
+    ///
+    /// Meant to be called once at startup, before any loop runs. One process
+    /// owns all dispatch, so at that moment a `running` session cannot be live:
+    /// it belongs to a process that died mid-scout. Left alone those rows are
+    /// phantom state — the session never completes, the task never leaves
+    /// `Scouting`, and the dispatch loop counts the ghost against its capacity
+    /// forever.
+    ///
+    /// Scouting tasks are requeued whether or not they have a session row, on
+    /// the theory that a task stuck in a transient state is always worth more
+    /// requeued than stranded. Attempt counts are deliberately untouched: a
+    /// crashed server is not the task's fault.
+    ///
+    /// The row updates are one transaction; the matching
+    /// [`EventPayload::SessionCompleted`] / [`EventPayload::TaskStateChanged`]
+    /// events are appended after it commits, exactly as the live failure path
+    /// writes them.
+    pub async fn reconcile_orphaned_work(&self) -> Result<ReconcileReport, StoreError> {
+        let now = Utc::now();
+
+        let mut tx = self.pool.begin().await?;
+        let session_rows = sqlx::query("SELECT id, task_id FROM sessions WHERE status = ?")
+            .bind(SessionStatus::Running.as_str())
+            .fetch_all(&mut *tx)
+            .await?;
+        let orphaned_sessions = session_rows
+            .into_iter()
+            .map(|row| {
+                Ok::<_, StoreError>((
+                    SessionId::from_raw(row.try_get::<String, _>("id")?),
+                    TaskId::from_raw(row.try_get::<String, _>("task_id")?),
+                ))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let task_rows = sqlx::query("SELECT id FROM tasks WHERE state = ?")
+            .bind(TaskState::Scouting.as_str())
+            .fetch_all(&mut *tx)
+            .await?;
+        let orphaned_tasks = task_rows
+            .into_iter()
+            .map(|row| Ok::<_, StoreError>(TaskId::from_raw(row.try_get::<String, _>("id")?)))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if !orphaned_sessions.is_empty() {
+            sqlx::query(
+                "UPDATE sessions SET status = ?, completed_at = ?, exit_reason = ? \
+                 WHERE status = ?",
+            )
+            .bind(SessionStatus::ScoutFailed.as_str())
+            .bind(now.to_rfc3339())
+            .bind(ORPHANED_EXIT_REASON)
+            .bind(SessionStatus::Running.as_str())
+            .execute(&mut *tx)
+            .await?;
+        }
+        if !orphaned_tasks.is_empty() {
+            sqlx::query("UPDATE tasks SET state = ?, updated_at = ? WHERE state = ?")
+                .bind(TaskState::New.as_str())
+                .bind(now.to_rfc3339())
+                .bind(TaskState::Scouting.as_str())
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+
+        let report = ReconcileReport {
+            sessions: orphaned_sessions.len(),
+            tasks: orphaned_tasks.len(),
+        };
+
+        for (session_id, task_id) in orphaned_sessions {
+            self.append_event(EventPayload::SessionCompleted {
+                session_id,
+                task_id,
+                status: SessionStatus::ScoutFailed,
+            })
+            .await?;
+        }
+        for task_id in orphaned_tasks {
+            self.append_event(EventPayload::TaskStateChanged {
+                task_id,
+                from: TaskState::Scouting,
+                to: TaskState::New,
+            })
+            .await?;
+        }
+
+        Ok(report)
     }
 
     // --- specs ---
@@ -719,6 +881,7 @@ fn task_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Task, StoreError> {
         })?,
         priority: row.try_get("priority")?,
         manual_rank: row.try_get("manual_rank")?,
+        dispatch_attempts: row.try_get::<i64, _>("dispatch_attempts")?.max(0) as u32,
         ingested_at: parse_ts(&row.try_get::<String, _>("ingested_at")?, "ingested_at")?,
         updated_at: parse_ts(&row.try_get::<String, _>("updated_at")?, "updated_at")?,
     })
@@ -833,6 +996,7 @@ mod tests {
             state: TaskState::New,
             priority: 10,
             manual_rank: None,
+            dispatch_attempts: 0,
             ingested_at: now,
             updated_at: now,
         }
@@ -1269,6 +1433,283 @@ mod tests {
         assert_eq!(
             store.get_task(&task.id).await.unwrap().unwrap().manual_rank,
             Some(1)
+        );
+    }
+
+    // --- dispatch attempts ---
+
+    #[tokio::test]
+    async fn dispatch_failures_accumulate_and_survive_a_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tasks.db");
+        let task_id;
+
+        {
+            let store = Store::open(&path).await.unwrap();
+            let project = sample_project();
+            store.insert_project(&project).await.unwrap();
+            let task = sample_task(&project.id);
+            store.insert_task(&task).await.unwrap();
+            task_id = task.id.clone();
+            assert_eq!(
+                store
+                    .get_task(&task_id)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .dispatch_attempts,
+                0
+            );
+
+            for expected in 1..=2 {
+                assert_eq!(
+                    store.record_dispatch_failure(&task_id).await.unwrap(),
+                    expected
+                );
+            }
+        }
+
+        // A restart must not forgive the strikes — that is the whole point.
+        let store = Store::open(&path).await.unwrap();
+        assert_eq!(
+            store
+                .get_task(&task_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .dispatch_attempts,
+            2
+        );
+        assert_eq!(store.record_dispatch_failure(&task_id).await.unwrap(), 3);
+
+        store.reset_dispatch_attempts(&task_id).await.unwrap();
+        assert_eq!(
+            store
+                .get_task(&task_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .dispatch_attempts,
+            0
+        );
+        // Resetting an already-clean task is a no-op, not an error.
+        store.reset_dispatch_attempts(&task_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dispatch_attempt_writes_reject_unknown_tasks() {
+        let store = Store::open_in_memory().await.unwrap();
+        let ghost = TaskId::new();
+        assert!(matches!(
+            store.record_dispatch_failure(&ghost).await.unwrap_err(),
+            StoreError::NotFound(_)
+        ));
+        assert!(matches!(
+            store.reset_dispatch_attempts(&ghost).await.unwrap_err(),
+            StoreError::NotFound(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn upsert_gh_issue_never_touches_dispatch_attempts() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+
+        let issue = GhIssue {
+            number: 11,
+            title: "First".into(),
+            body: "b".into(),
+            labels: vec![],
+            state: GhState::Open,
+            updated_at: Utc::now(),
+        };
+        let task = store
+            .upsert_gh_issue(&project.id, issue.clone())
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(
+            task.dispatch_attempts, 0,
+            "a fresh issue starts unpenalized"
+        );
+        store.record_dispatch_failure(&task.id).await.unwrap();
+        store.record_dispatch_failure(&task.id).await.unwrap();
+
+        let repoll = GhIssue {
+            title: "Retitled".into(),
+            body: "edited".into(),
+            ..issue
+        };
+        let observed = store
+            .upsert_gh_issue(&project.id, repoll)
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(observed.dispatch_attempts, 2);
+        assert_eq!(
+            store
+                .get_task(&task.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .dispatch_attempts,
+            2
+        );
+    }
+
+    // --- reconciliation ---
+
+    #[tokio::test]
+    async fn reconcile_orphaned_work_fails_sessions_and_requeues_tasks() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+
+        // Orphan 1: a scouting task with the running session it died under.
+        let orphaned = task_with(&project.id, 1, 0);
+        store.insert_task(&orphaned).await.unwrap();
+        store
+            .update_task_state(&orphaned.id, TaskState::Scouting)
+            .await
+            .unwrap();
+        let running = Session {
+            id: SessionId::new(),
+            task_id: orphaned.id.clone(),
+            vm_id: Some("vm-gone".into()),
+            branch: String::new(),
+            status: SessionStatus::Running,
+            started_at: Utc::now(),
+            completed_at: None,
+            exit_reason: None,
+        };
+        store.insert_session(&running).await.unwrap();
+
+        // Orphan 2: a scouting task with no session row at all.
+        let sessionless = task_with(&project.id, 2, 0);
+        store.insert_task(&sessionless).await.unwrap();
+        store
+            .update_task_state(&sessionless.id, TaskState::Scouting)
+            .await
+            .unwrap();
+
+        // Bystanders: a finished session and a task that never left New.
+        let (settled_task, _) = seed_spec(&store, 3).await;
+        let untouched = task_with(&project.id, 4, 0);
+        store.insert_task(&untouched).await.unwrap();
+
+        // Seqs are a 1-based AUTOINCREMENT, so the next one is count + 1.
+        let next_seq = store.events_since(0).await.unwrap().len() as i64 + 1;
+        let report = store.reconcile_orphaned_work().await.unwrap();
+        assert_eq!(
+            report,
+            ReconcileReport {
+                sessions: 1,
+                tasks: 2
+            }
+        );
+
+        let session = store.get_session(&running.id).await.unwrap().unwrap();
+        assert_eq!(session.status, SessionStatus::ScoutFailed);
+        assert!(session.completed_at.is_some());
+        assert_eq!(
+            session.exit_reason.as_deref(),
+            Some("orphaned by server restart")
+        );
+
+        for id in [&orphaned.id, &sessionless.id] {
+            assert_eq!(
+                store.get_task(id).await.unwrap().unwrap().state,
+                TaskState::New,
+                "task {id}"
+            );
+        }
+        assert_eq!(
+            store.get_task(&untouched.id).await.unwrap().unwrap().state,
+            TaskState::New
+        );
+        // A completed session and its task are none of reconciliation's business.
+        assert_eq!(
+            store
+                .get_task(&settled_task.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .state,
+            TaskState::New
+        );
+        assert_eq!(
+            store
+                .list_sessions()
+                .await
+                .unwrap()
+                .iter()
+                .filter(|s| s.status == SessionStatus::ScoutSucceeded)
+                .count(),
+            1
+        );
+
+        let payloads: Vec<_> = store
+            .events_since(next_seq)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.payload)
+            .collect();
+        assert!(payloads.contains(&EventPayload::SessionCompleted {
+            session_id: running.id.clone(),
+            task_id: orphaned.id.clone(),
+            status: SessionStatus::ScoutFailed,
+        }));
+        for id in [&orphaned.id, &sessionless.id] {
+            assert!(
+                payloads.contains(&EventPayload::TaskStateChanged {
+                    task_id: id.clone(),
+                    from: TaskState::Scouting,
+                    to: TaskState::New,
+                }),
+                "no TaskStateChanged for {id}"
+            );
+        }
+        assert_eq!(payloads.len(), 3, "no events beyond the affected rows");
+    }
+
+    #[tokio::test]
+    async fn reconcile_orphaned_work_is_a_no_op_on_a_clean_store() {
+        let store = Store::open_in_memory().await.unwrap();
+        seed_spec(&store, 1).await;
+        let before = store.events_since(0).await.unwrap().len();
+
+        let report = store.reconcile_orphaned_work().await.unwrap();
+        assert!(report.is_empty());
+        assert_eq!(report, ReconcileReport::default());
+        assert_eq!(store.events_since(0).await.unwrap().len(), before);
+    }
+
+    #[tokio::test]
+    async fn reconcile_orphaned_work_leaves_attempt_counts_alone() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+        let task = sample_task(&project.id);
+        store.insert_task(&task).await.unwrap();
+        store.record_dispatch_failure(&task.id).await.unwrap();
+        store
+            .update_task_state(&task.id, TaskState::Scouting)
+            .await
+            .unwrap();
+
+        store.reconcile_orphaned_work().await.unwrap();
+
+        // A crashed server is not the task's fault.
+        assert_eq!(
+            store
+                .get_task(&task.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .dispatch_attempts,
+            1
         );
     }
 

--- a/crates/tasks/tests/run.rs
+++ b/crates/tasks/tests/run.rs
@@ -23,7 +23,9 @@ use tasks_protocol::TasksProtocol;
 
 use tasks::events::EventPayload;
 use tasks::github::GitHubClient;
-use tasks::models::{GhState, Mode, Project, ProjectId, Task, TaskId, TaskState};
+use tasks::models::{
+    GhState, Mode, Project, ProjectId, Session, SessionId, SessionStatus, Task, TaskId, TaskState,
+};
 use tasks::run::{self, Config};
 use tasks::store::Store;
 
@@ -250,6 +252,21 @@ async fn dispatch_harness(
     Config,
     Arc<Service<SupervisorRuntime, TasksProtocol>>,
 ) {
+    dispatch_harness_with_agent(max_concurrent, stub_agent_path().to_str().unwrap()).await
+}
+
+/// [`dispatch_harness`] with the scout's agent command spelled out. `true`
+/// gives an agent that exits cleanly without writing `SPEC.md`, which the
+/// supervisor reports as a scout failure — a task that can never be scouted.
+async fn dispatch_harness_with_agent(
+    max_concurrent: usize,
+    agent_cmd: &str,
+) -> (
+    tempfile::TempDir,
+    Arc<Store>,
+    Config,
+    Arc<Service<SupervisorRuntime, TasksProtocol>>,
+) {
     let supervisor_bin = cargo_build("scout-supervisor").await;
     let tmp = tempfile::tempdir().unwrap();
     let clone_root = tmp.path().join("repos");
@@ -257,13 +274,8 @@ async fn dispatch_harness(
 
     let workdir_root = tmp.path().join("scout-workdirs");
     tokio::fs::create_dir_all(&workdir_root).await.unwrap();
-    let wrapper = write_supervisor_wrapper(
-        tmp.path(),
-        &supervisor_bin,
-        stub_agent_path().to_str().unwrap(),
-        &workdir_root,
-    )
-    .await;
+    let wrapper =
+        write_supervisor_wrapper(tmp.path(), &supervisor_bin, agent_cmd, &workdir_root).await;
     let (service, socket) = spawn_vm_pool(tmp.path(), &wrapper, max_concurrent.max(1)).await;
 
     let store = Arc::new(Store::open(tmp.path().join("tasks.db")).await.unwrap());
@@ -294,6 +306,7 @@ async fn insert_task_with_gh_state(
         state: TaskState::New,
         priority: 0,
         manual_rank: None,
+        dispatch_attempts: 0,
         ingested_at: now,
         updated_at: now,
     };
@@ -426,4 +439,185 @@ async fn pause_blocks_new_dispatches() {
         dispatch_order(&store).await,
         vec![first.id.clone(), second.id.clone()]
     );
+}
+
+// --- crash consistency ---
+
+/// Poll until `task` reaches `state`, then let the loop run a little longer so
+/// any dispatch it was still going to start would show up in the assertions.
+async fn wait_for_state(store: &Arc<Store>, task_id: &TaskId, state: TaskState) {
+    let s = store.clone();
+    let id = task_id.clone();
+    wait_until(Duration::from_secs(120), || {
+        let s = s.clone();
+        let id = id.clone();
+        async move { s.get_task(&id).await.unwrap().unwrap().state == state }
+    })
+    .await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+}
+
+/// A task whose scout can never succeed gets three tries and is then rejected,
+/// with the count on the row so a later process can't hand it three more.
+#[tokio::test]
+async fn three_failed_dispatches_reject_the_task() {
+    let (_tmp, store, config, _service) = dispatch_harness_with_agent(1, "true").await;
+    let project = insert_project(&store).await;
+    let task = insert_task(&store, &project, 1, "no spec, ever").await;
+    store.set_mode(Mode::Play).await.unwrap();
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = tokio::spawn(run::dispatch_loop(store.clone(), config, shutdown_rx));
+    wait_for_state(&store, &task.id, TaskState::Rejected).await;
+
+    shutdown_tx.send(true).unwrap();
+    tokio::time::timeout(Duration::from_secs(30), handle)
+        .await
+        .expect("dispatch loop exits on shutdown")
+        .unwrap();
+
+    let stored = store.get_task(&task.id).await.unwrap().unwrap();
+    assert_eq!(stored.state, TaskState::Rejected);
+    assert_eq!(stored.dispatch_attempts, 3, "strikes are persisted");
+    assert_eq!(
+        dispatch_order(&store).await,
+        vec![task.id.clone(); 3],
+        "exactly three dispatches, no more"
+    );
+    assert!(store.list_specs().await.unwrap().is_empty());
+    assert!(
+        store
+            .list_sessions()
+            .await
+            .unwrap()
+            .iter()
+            .all(|s| s.status == SessionStatus::ScoutFailed)
+    );
+
+    let payloads: Vec<_> = store
+        .events_since(0)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|e| e.payload)
+        .collect();
+    assert!(
+        payloads.iter().any(|p| matches!(
+            p,
+            EventPayload::TaskStateChanged { task_id, to: TaskState::Rejected, .. }
+                if *task_id == task.id
+        )),
+        "the rejection is on the event log"
+    );
+    assert!(
+        payloads.iter().any(|p| matches!(
+            p,
+            EventPayload::Note { source, message }
+                if source == "dispatcher" && message.contains("rejecting")
+        )),
+        "with a breadcrumb saying why"
+    );
+}
+
+/// Restart simulation: a task carrying two strikes from a previous process gets
+/// the one attempt it has left, not a fresh three.
+#[tokio::test]
+async fn a_restart_resumes_the_persisted_attempt_count() {
+    let (_tmp, store, config, _service) = dispatch_harness_with_agent(1, "true").await;
+    let project = insert_project(&store).await;
+    let task = insert_task(&store, &project, 1, "already on thin ice").await;
+    for expected in 1..=2 {
+        assert_eq!(
+            store.record_dispatch_failure(&task.id).await.unwrap(),
+            expected
+        );
+    }
+    store.set_mode(Mode::Play).await.unwrap();
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = tokio::spawn(run::dispatch_loop(store.clone(), config, shutdown_rx));
+    wait_for_state(&store, &task.id, TaskState::Rejected).await;
+
+    shutdown_tx.send(true).unwrap();
+    tokio::time::timeout(Duration::from_secs(30), handle)
+        .await
+        .expect("dispatch loop exits on shutdown")
+        .unwrap();
+
+    assert_eq!(
+        dispatch_order(&store).await,
+        vec![task.id.clone()],
+        "one attempt was left, so one dispatch"
+    );
+    let stored = store.get_task(&task.id).await.unwrap().unwrap();
+    assert_eq!(stored.state, TaskState::Rejected);
+    assert_eq!(stored.dispatch_attempts, 3);
+}
+
+/// A server killed mid-scout leaves a `running` session and a `Scouting` task.
+/// Startup reconciliation clears both, and the freed task is scouted normally.
+#[tokio::test]
+async fn startup_reconciles_orphaned_work_before_dispatch() {
+    let (_tmp, store, config, _service) = dispatch_harness(1).await;
+    let project = insert_project(&store).await;
+    let task = insert_task(&store, &project, 1, "was mid-scout when we died").await;
+
+    // Exactly what `tasks serve` leaves behind when it dies mid-dispatch.
+    store
+        .update_task_state(&task.id, TaskState::Scouting)
+        .await
+        .unwrap();
+    let orphan = Session {
+        id: SessionId::new(),
+        task_id: task.id.clone(),
+        vm_id: Some("vm-from-a-previous-life".into()),
+        branch: String::new(),
+        status: SessionStatus::Running,
+        started_at: Utc::now(),
+        completed_at: None,
+        exit_reason: None,
+    };
+    store.insert_session(&orphan).await.unwrap();
+    store.set_mode(Mode::Play).await.unwrap();
+
+    // Same call, same position in the sequence as `run()`: reconcile first,
+    // then start the loops.
+    run::reconcile_startup(&store).await.unwrap();
+
+    let reconciled = store.get_session(&orphan.id).await.unwrap().unwrap();
+    assert_eq!(reconciled.status, SessionStatus::ScoutFailed);
+    assert!(reconciled.completed_at.is_some());
+    assert_eq!(
+        reconciled.exit_reason.as_deref(),
+        Some("orphaned by server restart")
+    );
+    assert_eq!(
+        store.get_task(&task.id).await.unwrap().unwrap().state,
+        TaskState::New,
+        "the stranded task is back in the queue"
+    );
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = tokio::spawn(run::dispatch_loop(store.clone(), config, shutdown_rx));
+
+    let s = store.clone();
+    wait_until(Duration::from_secs(60), || {
+        let s = s.clone();
+        async move { s.list_specs().await.unwrap().len() == 1 }
+    })
+    .await;
+
+    shutdown_tx.send(true).unwrap();
+    tokio::time::timeout(Duration::from_secs(30), handle)
+        .await
+        .expect("dispatch loop exits on shutdown")
+        .unwrap();
+
+    let stored = store.get_task(&task.id).await.unwrap().unwrap();
+    assert_eq!(stored.state, TaskState::SpecReady);
+    assert_eq!(
+        stored.dispatch_attempts, 0,
+        "a crashed server is not the task's fault"
+    );
+    assert_eq!(dispatch_order(&store).await, vec![task.id.clone()]);
 }

--- a/crates/tasks/tests/scout.rs
+++ b/crates/tasks/tests/scout.rs
@@ -49,6 +49,7 @@ async fn insert_project_and_task(store: &Store, title: &str, body: &str) -> (Pro
         state: TaskState::New,
         priority: 0,
         manual_rank: None,
+        dispatch_attempts: 0,
         ingested_at: now,
         updated_at: now,
     };

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,0 +1,118 @@
+# Writing a Tasks client
+
+How a UI (SwiftUI app, TUI, CLI, Claude Code session) should talk to the
+Tasks server. The HTTP API on `127.0.0.1:4800` (`TASKS_SERVER_PORT`) is the
+only interface — clients never touch SQLite, GitHub, or vm-pool directly.
+
+## The idiomatic client loop
+
+Tasks is event-sourced at the edge: every write the server performs appends
+an `Event` with a monotonically increasing `seq`, and the API exposes both a
+catch-up read (`GET /events?since=`) and a live stream (`GET /events/stream`,
+SSE with 15s keepalive comments). The intended client shape:
+
+1. **Open the SSE stream first**, then snapshot (`GET /tasks`, `/sessions`,
+   `/specs`, `/spec-queue`, `/mode`, `/projects`). Opening the stream before
+   snapshotting means no gap between the two.
+2. **Treat events as invalidation signals, not data.** Payloads are
+   deliberately identifier-only (`task_id`, `spec_id`, …). On receiving an
+   event, refetch the affected entity (`GET /tasks/{id}`) or the affected
+   list. Don't reconstruct entity state by folding event payloads client-side
+   — the server's row is the truth, the event just tells you it changed.
+3. **Track the last `seq` you've seen.** On reconnect (or SSE lag — the
+   broadcast buffer holds 1024 events and drops the oldest for slow
+   consumers), resync with `GET /events?since=<last_seq>` and then resume the
+   stream. If the gap is large, just re-snapshot; it's cheap.
+4. **Writes are plain POSTs and return the updated resource(s)**, so you can
+   apply the response optimistically; the corresponding event will also
+   arrive on the stream (dedupe by refetching, which is idempotent).
+
+No auth, loopback only — don't build a login flow.
+
+## Interaction surface (where to hook UI actions)
+
+| UI action | Call | Semantics |
+| --- | --- | --- |
+| Add a repo | `POST /projects` `{"repo_owner","repo_name"}` | 201 with the project; 400 if it already exists |
+| Reorder task queue (drag & drop) | `POST /queue/reorder` `{"task_ids":[...]}` | **Full order, front to back.** Ranks are rewritten 1..N transactionally; any task not listed becomes unranked and sorts after all ranked tasks (then priority desc, then ingested_at). Send the complete on-screen order after every drop. |
+| Reorder spec queue | `POST /spec-queue/reorder` `{"spec_ids":[...]}` | Same full-order semantics |
+| Review a spec | `POST /spec-queue/{spec_id}/review` `{"status","feedback"?}` | `status` ∈ `approved` \| `needs_revision` \| `rejected` — the three verdicts a reviewer may deliver. `approved` → spec enters the queue for the Builder; `needs_revision` → the task goes back to `new` and will be re-scouted; `rejected` → dead end. `feedback` is free text; include it for `needs_revision` (it's the reviewer's message to the next scout). |
+| Play / pause / stop | `POST /mode` `{"mode":"play"\|"pause"\|"stop"}` | Gates **new** work only. A mode change never interrupts a scout in flight — reflect that in the UI (pausing ≠ cancelling; show in-flight sessions still running). |
+
+Everything else is read-only. There is deliberately no
+`POST /tasks` (tasks come from GitHub issue intake), no task-edit endpoint,
+and no way for a client to write GitHub state — GitHub writes funnel through
+the server only.
+
+## Reads and their shapes
+
+- `GET /tasks` — already in queue order; render it as-is, don't re-sort.
+  Task: `{id, project_id, gh_issue_number, title, body, labels, gh_state,
+  state, priority, manual_rank, dispatch_attempts, ingested_at, updated_at}`.
+- `GET /sessions` / `GET /sessions/{id}` — scout runs.
+- `GET /specs` / `GET /specs/{id}` — `spec_markdown` is the deliverable;
+  render it as Markdown. Also carries `files_touched`, `complexity`,
+  `agent_exit_code`.
+- `GET /spec-queue` — `{entry: {...}, task_id}` items for the review screen.
+- `GET /events?since=&limit=` — catch-up (default limit 100);
+  `GET /events/stream` — SSE, each `data:` line is one Event JSON.
+
+All enums are snake_case strings on the wire:
+
+- `Task.state`: `new` → `scouting` → `spec_ready` → `queued` → `done`, with
+  `rejected` as the terminal failure state.
+- `Session.status`: `running`, `scout_succeeded`, `scout_failed`, `cancelled`.
+- `SpecQueueEntry.status`: `pending_review`, `approved`, `needs_revision`,
+  `blocked`, `rejected` (only the three verdict values are accepted by the
+  review endpoint; `pending_review`/`blocked` are server-assigned).
+- `Complexity`: `simple`, `medium`, `complex`.
+- `Mode`: `play`, `pause`, `stop`.
+
+Parse enums leniently (unknown value → show raw string, don't crash): new
+states will appear as the pipeline grows.
+
+Event JSON: `{seq, timestamp, payload}` where payload is tagged by `"kind"`
+(snake_case): `project_added`, `task_ingested`, `task_state_changed`
+(`from`/`to`), `session_started`, `session_completed`, `spec_created`,
+`spec_queue_status_changed`, `queue_reordered`, `spec_queue_reordered`,
+`mode_changed`, `note` (`source`, `message` — free-form breadcrumbs; a
+scrolling activity feed of these is the cheapest useful "what is it doing"
+view).
+
+## Design constraints worth mirroring in the UI
+
+- **GitHub-owned facts are queried, not stored** (server-side rule). For the
+  client this means `gh_state` etc. are snapshots from the last poll — label
+  them as such, don't present them as live.
+- **`manual_rank` is human-authoritative.** The reorder endpoints are the
+  only writers. The GitHub poller can change `priority` but never ordering —
+  so a user's drag & drop is never clobbered by a poll.
+- **The spec is the deliverable** (Scout/Builder information barrier). The
+  review screen is the centerpiece of the whole product: spec markdown,
+  verdict buttons, feedback field. Scout code is intentionally not available
+  to show.
+- **Sessions can be long.** The first live scout took 23 minutes. Show
+  elapsed time, not a spinner that looks hung.
+
+## Changes in flight / coming (PR #757 and roadmap)
+
+- **Landed in PR #757** (branch `reconcile-and-attempts`): `Task` gains
+  `dispatch_attempts`; three consecutive failed dispatches move a task to
+  `rejected` with a dispatcher `note` explaining why; on server startup,
+  orphaned `running` sessions become `scout_failed`
+  (`exit_reason: "orphaned by server restart"`) and stuck `scouting` tasks
+  return to `new` — clients just see the normal events.
+- **Re-scout feedback loop** (next branch): `needs_revision` feedback will be
+  fed into the next scout's prompt. No API change expected; the review call
+  you make today is already the right hook.
+- **Progress visibility** (planned, coordinate before building): per-session
+  scout output (agent stdout/stderr lines) buffered server-side and exposed
+  via the API/SSE — the hook for a live session-detail view. Not built yet;
+  today `Progress` lines only reach the server logs.
+- **Builder / Diamond 2** (later): a builder-run resource referencing a *set*
+  of spec ids (batching is core to the design — model the review queue with
+  multi-select in mind), plus PR links as the builder's output.
+- **Orchestrator** (#756): spec reviews will increasingly be posted by an
+  agent through this same API; the UI's review verdicts and the
+  orchestrator's are the same call, so nothing special to do — but expect
+  `spec_queue_status_changed` events you didn't initiate.


### PR DESCRIPTION
First fix-forward branch off the v2 mainline (#755).

## What

1. **Startup reconciliation** — `Store::reconcile_orphaned_work()`, called in `run()` before either loop spawns. Every `running` session is by definition orphaned at startup (one process owns all dispatch), so each is failed with `exit_reason = "orphaned by server restart"` and every `scouting` task is requeued to `new` — one transaction, with the same `SessionCompleted`/`TaskStateChanged` events the live failure path writes. Previously a crash left phantom rows: sessions that never complete, tasks stranded in `scouting`.

2. **Persisted dispatch attempts** — migration 0003 adds `tasks.dispatch_attempts`, replacing the dispatcher's in-memory strike map (which a restart wiped, letting a poison task retry forever). Three consecutive failed dispatches now **reject** the task with a dispatcher note on the event log, instead of silently skipping it for the process lifetime. A successful spec resets the count; reconciliation deliberately does not (a crashed server isn't the task's fault); the GitHub poller never touches it (same rule as `manual_rank`).

## Tests

Store unit tests for the reconcile round-trip, attempts persistence across reopen, and poller isolation; three new integration tests in `tests/run.rs` against a real vm-pool + supervisor: three strikes → Rejected, restart resumes the persisted count, startup reconciles then successfully scouts.

`cargo fmt` / `clippy` clean (no new warnings), `cargo test --workspace` green.