### PR TITLE
Poller absence reconciliation: mark tasks closed when their issue leaves the open set

### DIFF
--- a/crates/tasks/src/events.rs
+++ b/crates/tasks/src/events.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::models::{
-    Mode, ProjectId, SessionId, SessionStatus, SpecId, SpecQueueStatus, TaskId, TaskState,
+    GhState, Mode, ProjectId, SessionId, SessionStatus, SpecId, SpecQueueStatus, TaskId, TaskState,
 };
 
 /// A timestamped, sequenced record. `seq` is assigned by the store on append.
@@ -36,6 +36,13 @@ pub enum EventPayload {
         task_id: TaskId,
         from: TaskState,
         to: TaskState,
+    },
+    /// The snapshot of GitHub's open/closed flag on a task changed. Emitted by
+    /// the poller — notably when an issue disappears from a repository's open
+    /// set, which is the only signal GitHub gives us that it was closed.
+    TaskGhStateChanged {
+        task_id: TaskId,
+        gh_state: GhState,
     },
     SessionStarted {
         session_id: SessionId,

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -336,7 +336,11 @@ pub async fn poll_loop(store: Arc<Store>, config: Config, mut shutdown: watch::R
 /// first time.
 ///
 /// A project whose fetch fails is logged and skipped so one unreachable repo
-/// can't stall intake for the others.
+/// can't stall intake for the others. That skip is load-bearing for the second
+/// half of the pass: GitHub only tells us an issue was closed by leaving it out
+/// of the open set, so absence reconciliation
+/// ([`Store::reconcile_closed_issues`]) is only sound on a complete open set. A
+/// partial fetch would read as a mass closure.
 pub async fn poll_once(store: &Store, github: &GitHubClient) -> Result<usize, StoreError> {
     let mut ingested = 0;
     for project in store.list_projects().await? {
@@ -355,6 +359,7 @@ pub async fn poll_once(store: &Store, github: &GitHubClient) -> Result<usize, St
             }
         };
 
+        let open_numbers: Vec<u64> = issues.iter().map(|issue| issue.number).collect();
         for issue in issues {
             let outcome = store.upsert_gh_issue(&project.id, issue).await?;
             if outcome.is_new() {
@@ -367,6 +372,25 @@ pub async fn poll_once(store: &Store, github: &GitHubClient) -> Result<usize, St
                     .await?;
                 ingested += 1;
             }
+        }
+
+        let closed = store
+            .reconcile_closed_issues(&project.id, &open_numbers)
+            .await?;
+        if !closed.is_empty() {
+            info!(
+                repo = format!("{}/{}", project.repo_owner, project.repo_name),
+                count = closed.len(),
+                "issues closed upstream since the last poll"
+            );
+        }
+        for task_id in closed {
+            store
+                .append_event(EventPayload::TaskGhStateChanged {
+                    task_id,
+                    gh_state: GhState::Closed,
+                })
+                .await?;
         }
     }
     Ok(ingested)

--- a/crates/tasks/src/server.rs
+++ b/crates/tasks/src/server.rs
@@ -157,8 +157,23 @@ async fn create_project(
 
 // --- tasks ---
 
-async fn list_tasks(State(store): State<Arc<Store>>) -> ApiResult<Json<Vec<Task>>> {
-    Ok(Json(store.list_tasks().await?))
+#[derive(Debug, Deserialize)]
+struct TasksQuery {
+    /// `?all=true` returns every row. The default hides tasks whose issue is
+    /// closed on GitHub and that never left `new` — intake noise from issues
+    /// that died before any work started.
+    all: Option<bool>,
+}
+
+async fn list_tasks(
+    State(store): State<Arc<Store>>,
+    Query(query): Query<TasksQuery>,
+) -> ApiResult<Json<Vec<Task>>> {
+    let tasks = match query.all.unwrap_or(false) {
+        true => store.list_tasks().await?,
+        false => store.list_active_tasks().await?,
+    };
+    Ok(Json(tasks))
 }
 
 async fn get_task(
@@ -542,6 +557,58 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(tasks[0].id, low.id);
+    }
+
+    /// An issue closed before any work started is intake noise; one that got as
+    /// far as a spec is history a client still needs.
+    #[tokio::test]
+    async fn tasks_listing_hides_closed_intake_unless_all_is_asked_for() {
+        let (store, project) = store_with_project().await;
+        let open_new = insert_task(&store, &project, 1, 0).await;
+        let closed_new = insert_task(&store, &project, 2, 0).await;
+        let closed_spec_ready = insert_task(&store, &project, 3, 0).await;
+        store
+            .reconcile_closed_issues(&project.id, &[open_new.gh_issue_number])
+            .await
+            .unwrap();
+        store
+            .update_task_state(&closed_spec_ready.id, TaskState::SpecReady)
+            .await
+            .unwrap();
+        let base = spawn(store.clone()).await;
+        let http = reqwest::Client::new();
+
+        let visible: Vec<TaskId> = http
+            .get(format!("{base}/tasks"))
+            .send()
+            .await
+            .unwrap()
+            .json::<Vec<Task>>()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        assert!(visible.contains(&open_new.id));
+        assert!(
+            visible.contains(&closed_spec_ready.id),
+            "work that reached a spec stays visible"
+        );
+        assert!(!visible.contains(&closed_new.id));
+
+        let all: Vec<TaskId> = http
+            .get(format!("{base}/tasks?all=true"))
+            .send()
+            .await
+            .unwrap()
+            .json::<Vec<Task>>()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(all.len(), 3);
+        assert!(all.contains(&closed_new.id));
     }
 
     #[tokio::test]

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -193,6 +193,27 @@ impl Store {
         rows.into_iter().map(task_from_row).collect()
     }
 
+    /// [`Self::list_tasks`] minus pure intake noise: tasks whose issue is closed
+    /// on GitHub and that never left `new`.
+    ///
+    /// Anything further along the pipeline stays visible whatever GitHub thinks
+    /// of the issue — in-flight and historical work must not vanish from a
+    /// client's list because someone closed the issue behind it. Ordering is
+    /// identical to [`Self::list_tasks`].
+    pub async fn list_active_tasks(&self) -> Result<Vec<Task>, StoreError> {
+        let rows = sqlx::query(
+            "SELECT id, project_id, gh_issue_number, title, body, labels, gh_state, \
+             state, priority, manual_rank, dispatch_attempts, ingested_at, updated_at \
+             FROM tasks WHERE NOT (gh_state = ? AND state = ?) \
+             ORDER BY manual_rank IS NULL, manual_rank, priority DESC, ingested_at",
+        )
+        .bind(GhState::Closed.as_str())
+        .bind(TaskState::New.as_str())
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(task_from_row).collect()
+    }
+
     /// Replace the manual queue order with `ids`, assigning ranks 1..N in the
     /// given order. Every task not listed is left unranked, so a reorder is
     /// always a complete statement of the curated queue.
@@ -310,6 +331,65 @@ impl Store {
         };
         self.insert_task(&task).await?;
         Ok(UpsertOutcome::Inserted(task))
+    }
+
+    /// Mark every task of `project_id` whose issue has vanished from the
+    /// repository's open set as closed. Returns the ids it changed.
+    ///
+    /// GitHub's open-issue query is the only intake we have, and a closed issue
+    /// simply stops appearing in it — absence is the close notification. So the
+    /// caller must pass a *complete* open set: `open_issue_numbers` is every
+    /// open issue number a successful fetch returned. A partial or failed fetch
+    /// would read as "everything was closed", which is why
+    /// [`crate::run::poll_once`] skips reconciliation for a project it could not
+    /// fetch.
+    ///
+    /// Only `gh_state` (and `updated_at`) is written. `state`, `manual_rank` and
+    /// `dispatch_attempts` are Tasks-owned — a task already scouting or queued
+    /// keeps flowing; `gh_state` gates *new* dispatch only. Reopening needs no
+    /// counterpart: the issue reappears in the open set and
+    /// [`Self::upsert_gh_issue`] refreshes `gh_state` from the snapshot.
+    ///
+    /// The row updates are one transaction; the matching
+    /// [`EventPayload::TaskGhStateChanged`] events are the caller's to append,
+    /// mirroring how the poller emits [`EventPayload::TaskIngested`].
+    pub async fn reconcile_closed_issues(
+        &self,
+        project_id: &ProjectId,
+        open_issue_numbers: &[u64],
+    ) -> Result<Vec<TaskId>, StoreError> {
+        let open: std::collections::HashSet<u64> = open_issue_numbers.iter().copied().collect();
+
+        let mut tx = self.pool.begin().await?;
+        let rows = sqlx::query(
+            "SELECT id, gh_issue_number FROM tasks WHERE project_id = ? AND gh_state = ?",
+        )
+        .bind(project_id.as_str())
+        .bind(GhState::Open.as_str())
+        .fetch_all(&mut *tx)
+        .await?;
+
+        let mut closed = Vec::new();
+        for row in rows {
+            let number = row.try_get::<i64, _>("gh_issue_number")?.max(0) as u64;
+            if open.contains(&number) {
+                continue;
+            }
+            closed.push(TaskId::from_raw(row.try_get::<String, _>("id")?));
+        }
+
+        let now = Utc::now().to_rfc3339();
+        for id in &closed {
+            sqlx::query("UPDATE tasks SET gh_state = ?, updated_at = ? WHERE id = ?")
+                .bind(GhState::Closed.as_str())
+                .bind(&now)
+                .bind(id.as_str())
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+
+        Ok(closed)
     }
 
     pub async fn update_task_state(&self, id: &TaskId, state: TaskState) -> Result<(), StoreError> {
@@ -1433,6 +1513,235 @@ mod tests {
         assert_eq!(
             store.get_task(&task.id).await.unwrap().unwrap().manual_rank,
             Some(1)
+        );
+    }
+
+    // --- gh_state reconciliation ---
+
+    /// A second project, so the bystander assertions are about a real neighbour
+    /// rather than a hypothetical one.
+    async fn second_project(store: &Store) -> Project {
+        let project = Project {
+            id: ProjectId::new(),
+            repo_owner: "iamnbutler".into(),
+            repo_name: "other".into(),
+            added_at: Utc::now(),
+        };
+        store.insert_project(&project).await.unwrap();
+        project
+    }
+
+    #[tokio::test]
+    async fn reconcile_closed_issues_closes_only_the_absent_open_tasks() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+        let other = second_project(&store).await;
+
+        let still_open = task_with(&project.id, 1, 0);
+        let vanished = task_with(&project.id, 2, 0);
+        let also_vanished = task_with(&project.id, 3, 0);
+        let already_closed = Task {
+            gh_state: GhState::Closed,
+            ..task_with(&project.id, 4, 0)
+        };
+        // Same issue number, different repo: absence over there says nothing
+        // about this project.
+        let bystander = task_with(&other.id, 2, 0);
+        for t in [
+            &still_open,
+            &vanished,
+            &also_vanished,
+            &already_closed,
+            &bystander,
+        ] {
+            store.insert_task(t).await.unwrap();
+        }
+
+        let mut closed = store
+            .reconcile_closed_issues(&project.id, &[1])
+            .await
+            .unwrap();
+        closed.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        let mut expected = vec![vanished.id.clone(), also_vanished.id.clone()];
+        expected.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        assert_eq!(closed, expected, "exactly the absent open tasks");
+
+        for id in [&vanished.id, &also_vanished.id] {
+            assert_eq!(
+                store.get_task(id).await.unwrap().unwrap().gh_state,
+                GhState::Closed,
+                "task {id}"
+            );
+        }
+        assert_eq!(
+            store
+                .get_task(&still_open.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .gh_state,
+            GhState::Open
+        );
+        assert_eq!(
+            store
+                .get_task(&bystander.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .gh_state,
+            GhState::Open,
+            "another project's rows are none of this project's business"
+        );
+
+        // An already-closed row is not reported a second time, and nothing about
+        // it moves.
+        let stored = store.get_task(&already_closed.id).await.unwrap().unwrap();
+        assert_eq!(stored, already_closed);
+
+        // An empty open set closes everything still open in the project — a real
+        // repository with no open issues left.
+        let closed = store
+            .reconcile_closed_issues(&project.id, &[])
+            .await
+            .unwrap();
+        assert_eq!(closed, vec![still_open.id.clone()]);
+        assert!(
+            store
+                .reconcile_closed_issues(&project.id, &[])
+                .await
+                .unwrap()
+                .is_empty(),
+            "reconciliation is idempotent"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_closed_issues_leaves_tasks_owned_state_alone() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+
+        let task = task_with(&project.id, 7, 0);
+        store.insert_task(&task).await.unwrap();
+        store
+            .update_task_state(&task.id, TaskState::Scouting)
+            .await
+            .unwrap();
+        store.record_dispatch_failure(&task.id).await.unwrap();
+        store
+            .set_queue_order(std::slice::from_ref(&task.id))
+            .await
+            .unwrap();
+        let before = store.get_task(&task.id).await.unwrap().unwrap();
+
+        let closed = store
+            .reconcile_closed_issues(&project.id, &[])
+            .await
+            .unwrap();
+        assert_eq!(closed, vec![task.id.clone()]);
+
+        let after = store.get_task(&task.id).await.unwrap().unwrap();
+        assert_eq!(after.gh_state, GhState::Closed);
+        assert!(after.updated_at >= before.updated_at, "timestamp refreshed");
+        // Everything Tasks owns is untouched: a task mid-pipeline keeps flowing.
+        assert_eq!(
+            after,
+            Task {
+                gh_state: GhState::Closed,
+                updated_at: after.updated_at,
+                ..before
+            }
+        );
+    }
+
+    /// Reopening needs no code of its own: the issue is back in the open set, so
+    /// the ordinary upsert path refreshes the snapshot.
+    #[tokio::test]
+    async fn a_reopened_issue_goes_back_to_open_through_upsert() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+
+        let issue = GhIssue {
+            number: 3,
+            title: "Round trip".into(),
+            body: "b".into(),
+            labels: vec![],
+            state: GhState::Open,
+            updated_at: Utc::now(),
+        };
+        let task = store
+            .upsert_gh_issue(&project.id, issue.clone())
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(
+            store
+                .reconcile_closed_issues(&project.id, &[])
+                .await
+                .unwrap(),
+            vec![task.id.clone()]
+        );
+        assert_eq!(
+            store.get_task(&task.id).await.unwrap().unwrap().gh_state,
+            GhState::Closed
+        );
+
+        let reopened = store
+            .upsert_gh_issue(&project.id, issue)
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(reopened.id, task.id, "same row, not a re-ingest");
+        assert_eq!(reopened.gh_state, GhState::Open);
+        assert_eq!(
+            store.get_task(&task.id).await.unwrap().unwrap().gh_state,
+            GhState::Open
+        );
+    }
+
+    #[tokio::test]
+    async fn list_active_tasks_hides_only_closed_intake() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+
+        let open_new = task_with(&project.id, 1, 0);
+        let closed_new = Task {
+            gh_state: GhState::Closed,
+            ..task_with(&project.id, 2, 0)
+        };
+        let closed_in_flight = Task {
+            gh_state: GhState::Closed,
+            ..task_with(&project.id, 3, 0)
+        };
+        for t in [&open_new, &closed_new, &closed_in_flight] {
+            store.insert_task(t).await.unwrap();
+        }
+        store
+            .update_task_state(&closed_in_flight.id, TaskState::SpecReady)
+            .await
+            .unwrap();
+
+        let visible: Vec<_> = store
+            .list_active_tasks()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        assert!(visible.contains(&open_new.id));
+        assert!(
+            visible.contains(&closed_in_flight.id),
+            "work already underway must not disappear"
+        );
+        assert!(!visible.contains(&closed_new.id));
+        assert_eq!(
+            store.list_tasks().await.unwrap().len(),
+            3,
+            "no rows deleted"
         );
     }
 

--- a/crates/tasks/tests/run.rs
+++ b/crates/tasks/tests/run.rs
@@ -157,6 +157,154 @@ async fn poll_ingests_issues_once_and_tracks_closures() {
     assert_eq!(project.id, closed.project_id);
 }
 
+/// Every `task_gh_state_changed` on the log, oldest first.
+async fn gh_state_changes(store: &Store) -> Vec<(TaskId, GhState)> {
+    store
+        .events_since(0)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter_map(|e| match e.payload {
+            EventPayload::TaskGhStateChanged { task_id, gh_state } => Some((task_id, gh_state)),
+            _ => None,
+        })
+        .collect()
+}
+
+/// GitHub never says "issue 3 was closed" — it just stops returning it from the
+/// open-issue query. A poll that sees a complete open set has to read that
+/// absence as a closure, or the row stays `open` forever and clients render a
+/// phantom task.
+#[tokio::test]
+async fn poll_closes_tasks_whose_issues_left_the_open_set() {
+    let url = spawn_fake_github(vec![
+        page(vec![
+            issue(1, "first", "OPEN"),
+            issue(2, "second", "OPEN"),
+            issue(3, "third", "OPEN"),
+        ]),
+        // A bulk cleanup upstream: only #2 is still open.
+        page(vec![issue(2, "second", "OPEN")]),
+    ])
+    .await;
+    let github = GitHubClient::with_base_url("token", url);
+
+    let store = Store::open_in_memory().await.unwrap();
+    let project = insert_project(&store).await;
+
+    assert_eq!(run::poll_once(&store, &github).await.unwrap(), 3);
+    let before = store.list_tasks().await.unwrap();
+    assert!(before.iter().all(|t| t.gh_state == GhState::Open));
+    let id_of = |number: u64| {
+        before
+            .iter()
+            .find(|t| t.gh_issue_number == number)
+            .unwrap()
+            .id
+            .clone()
+    };
+
+    assert_eq!(
+        run::poll_once(&store, &github).await.unwrap(),
+        0,
+        "nothing new to ingest"
+    );
+
+    let after = store.list_tasks().await.unwrap();
+    assert_eq!(after.len(), 3, "rows are marked, never deleted");
+    for (number, expected) in [
+        (1, GhState::Closed),
+        (2, GhState::Open),
+        (3, GhState::Closed),
+    ] {
+        let task = after
+            .iter()
+            .find(|t| t.gh_issue_number == number)
+            .unwrap_or_else(|| panic!("task for issue {number}"));
+        assert_eq!(task.gh_state, expected, "issue {number}");
+        assert_eq!(task.state, TaskState::New, "our state is ours to set");
+        assert_eq!(task.id, id_of(number), "same row, not a re-ingest");
+    }
+    assert_eq!(project.id, after[0].project_id);
+
+    let mut changes = gh_state_changes(&store).await;
+    changes.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+    let mut expected = vec![(id_of(1), GhState::Closed), (id_of(3), GhState::Closed)];
+    expected.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+    assert_eq!(changes, expected);
+
+    // The canned server repeats its last page, so a third poll sees the same
+    // open set: no further writes, no duplicate events.
+    assert_eq!(run::poll_once(&store, &github).await.unwrap(), 0);
+    assert_eq!(gh_state_changes(&store).await.len(), 2);
+}
+
+/// A failed fetch is not an empty repository. Reconciling on a partial open set
+/// would close every task in the project.
+#[tokio::test]
+async fn a_failed_fetch_reconciles_nothing() {
+    let url = spawn_fake_github(vec![
+        page(vec![issue(1, "first", "OPEN"), issue(2, "second", "OPEN")]),
+        json!({"errors": [{"message": "Bad credentials"}]}),
+    ])
+    .await;
+    let github = GitHubClient::with_base_url("token", url);
+
+    let store = Store::open_in_memory().await.unwrap();
+    insert_project(&store).await;
+    assert_eq!(run::poll_once(&store, &github).await.unwrap(), 2);
+
+    // The project is skipped, not failed: intake for other projects goes on.
+    assert_eq!(run::poll_once(&store, &github).await.unwrap(), 0);
+
+    let tasks = store.list_tasks().await.unwrap();
+    assert_eq!(tasks.len(), 2);
+    assert!(
+        tasks.iter().all(|t| t.gh_state == GhState::Open),
+        "an unreachable repo must not look like a closed one"
+    );
+    assert!(gh_state_changes(&store).await.is_empty());
+}
+
+/// Reopening rides the ordinary upsert path: the issue is back in the open set,
+/// so the snapshot is refreshed with it.
+#[tokio::test]
+async fn a_reopened_issue_polls_back_to_open() {
+    let url = spawn_fake_github(vec![
+        page(vec![issue(1, "first", "OPEN")]),
+        page(vec![]),
+        page(vec![issue(1, "first", "OPEN")]),
+    ])
+    .await;
+    let github = GitHubClient::with_base_url("token", url);
+
+    let store = Store::open_in_memory().await.unwrap();
+    insert_project(&store).await;
+
+    assert_eq!(run::poll_once(&store, &github).await.unwrap(), 1);
+    let task_id = store.list_tasks().await.unwrap()[0].id.clone();
+
+    run::poll_once(&store, &github).await.unwrap();
+    assert_eq!(
+        store.get_task(&task_id).await.unwrap().unwrap().gh_state,
+        GhState::Closed
+    );
+
+    assert_eq!(
+        run::poll_once(&store, &github).await.unwrap(),
+        0,
+        "a reopened issue is the same task, not a new one"
+    );
+    let reopened = store.get_task(&task_id).await.unwrap().unwrap();
+    assert_eq!(reopened.gh_state, GhState::Open);
+    assert_eq!(store.list_tasks().await.unwrap().len(), 1);
+    assert_eq!(
+        gh_state_changes(&store).await,
+        vec![(task_id, GhState::Closed)],
+        "only the poller-inferred closure needs an event of its own"
+    );
+}
+
 #[tokio::test]
 async fn poll_loop_skips_polling_while_stopped() {
     let github_url = spawn_fake_github(vec![page(vec![issue(1, "only", "OPEN")])]).await;

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -49,6 +49,12 @@ the server only.
 - `GET /tasks` — already in queue order; render it as-is, don't re-sort.
   Task: `{id, project_id, gh_issue_number, title, body, labels, gh_state,
   state, priority, manual_rank, dispatch_attempts, ingested_at, updated_at}`.
+  By default the list **omits tasks with `gh_state: "closed"` and
+  `state: "new"`** — issues that were closed on GitHub before any work started,
+  i.e. pure intake noise. Every other task stays visible whatever its
+  `gh_state`, so in-flight and historical work never disappears from the list
+  because someone closed the issue behind it. `GET /tasks?all=true` returns
+  every row including the closed intake. Ordering is identical either way.
 - `GET /sessions` / `GET /sessions/{id}` — scout runs.
 - `GET /specs` / `GET /specs/{id}` — `spec_markdown` is the deliverable;
   render it as Markdown. Also carries `files_touched`, `complexity`,
@@ -73,7 +79,10 @@ states will appear as the pipeline grows.
 
 Event JSON: `{seq, timestamp, payload}` where payload is tagged by `"kind"`
 (snake_case): `project_added`, `task_ingested`, `task_state_changed`
-(`from`/`to`), `session_started`, `session_completed`, `spec_created`,
+(`from`/`to`), `task_gh_state_changed` (`task_id`, `gh_state` — the poller's
+snapshot of GitHub's open/closed flag moved, most often because the issue
+dropped out of the repository's open set; refetch the task or the list),
+`session_started`, `session_completed`, `spec_created`,
 `spec_queue_status_changed`, `queue_reordered`, `spec_queue_reordered`,
 `mode_changed`, `note` (`source`, `message` — free-form breadcrumbs; a
 scrolling activity feed of these is the cheapest useful "what is it doing"


### PR DESCRIPTION
Fixes the staleness bug found while verifying the SwiftUI app: the poller queries `issues(states: [OPEN])` only, so issue closure is invisible — rows rot at `gh_state='open'`, `state='new'` forever (live DB: 32 tasks vs 9 open issues after today's issue cleanup).

**Fix:** after a project's fetch *succeeds*, `Store::reconcile_closed_issues` marks any open-gh_state task absent from the fetched set as `gh_state='closed'` (one transaction; returns affected ids). The skip-on-fetch-failure is load-bearing: reconciliation only runs on a complete open set, so a partial fetch can never mass-close. Tasks-owned state (`state`, `manual_rank`, `dispatch_attempts`) is untouched — in-flight work keeps flowing; closed gh_state only gates new dispatch, which the dispatcher already respects. Reopens heal via the existing upsert path.

**Also:** new `task_gh_state_changed` event kind (clients treat events as invalidation signals, so additive); `GET /tasks` defaults to hiding `gh_state=closed AND state=new` intake noise, `?all=true` for everything; `docs/clients.md` updated.

**Tests:** store unit tests (absent-only closure, bystander projects untouched, Tasks-owned columns asserted unchanged, reopen round-trip), poller integration against the canned GraphQL server (3→1 open closes 2 with events; failed fetch reconciles nothing), server default-vs-`?all` filter. fmt/clippy clean (22 pre-existing warnings, none new), full workspace green.

After merge: restart `tasks serve`; the next poll reconciles the 23 stale rows automatically.