### PR TITLE
Bring the SwiftUI mac app to main (re-target of #758)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ target/
 Cargo.lock
 .claude/worktrees/
 .worktrees/
+
+# Xcode
+xcuserdata/
+DerivedData/

--- a/app/Tasks.xcodeproj/project.pbxproj
+++ b/app/Tasks.xcodeproj/project.pbxproj
@@ -1,0 +1,243 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		A100000000000000000000A1 /* Tasks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tasks.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A100000000000000000000A2 /* Tasks */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Tasks;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A100000000000000000000A3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A100000000000000000000A4 = {
+			isa = PBXGroup;
+			children = (
+				A100000000000000000000A2 /* Tasks */,
+				A100000000000000000000A5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A100000000000000000000A5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A100000000000000000000A1 /* Tasks.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A100000000000000000000A6 /* Tasks */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A100000000000000000000A7 /* Build configuration list for PBXNativeTarget "Tasks" */;
+			buildPhases = (
+				A100000000000000000000A8 /* Sources */,
+				A100000000000000000000A3 /* Frameworks */,
+				A100000000000000000000A9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A100000000000000000000A2 /* Tasks */,
+			);
+			name = Tasks;
+			packageProductDependencies = (
+			);
+			productName = Tasks;
+			productReference = A100000000000000000000A1 /* Tasks.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A100000000000000000000AA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2600;
+				LastUpgradeCheck = 2600;
+				TargetAttributes = {
+					A100000000000000000000A6 = {
+						CreatedOnToolsVersion = 26.0;
+					};
+				};
+			};
+			buildConfigurationList = A100000000000000000000AB /* Build configuration list for PBXProject "Tasks" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A100000000000000000000A4;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = A100000000000000000000A5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A100000000000000000000A6 /* Tasks */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A100000000000000000000A9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A100000000000000000000A8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A100000000000000000000AC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		A100000000000000000000AD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		A100000000000000000000AE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.iamnbutler.tasks;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Debug;
+		};
+		A100000000000000000000AF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.iamnbutler.tasks;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A100000000000000000000AB /* Build configuration list for PBXProject "Tasks" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A100000000000000000000AC /* Debug */,
+				A100000000000000000000AD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A100000000000000000000A7 /* Build configuration list for PBXNativeTarget "Tasks" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A100000000000000000000AE /* Debug */,
+				A100000000000000000000AF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A100000000000000000000AA /* Project object */;
+}

--- a/app/Tasks.xcodeproj/xcshareddata/xcschemes/Tasks.xcscheme
+++ b/app/Tasks.xcodeproj/xcshareddata/xcschemes/Tasks.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A100000000000000000000A6"
+               BuildableName = "Tasks.app"
+               BlueprintName = "Tasks"
+               ReferencedContainer = "container:Tasks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A100000000000000000000A6"
+            BuildableName = "Tasks.app"
+            BlueprintName = "Tasks"
+            ReferencedContainer = "container:Tasks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A100000000000000000000A6"
+            BuildableName = "Tasks.app"
+            BlueprintName = "Tasks"
+            ReferencedContainer = "container:Tasks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Observation
+
+/// All server state the UI renders, refreshed wholesale. The lists are small
+/// and the server is loopback, so any event on the SSE stream just triggers a
+/// full refetch — no incremental patching to drift.
+@MainActor
+@Observable
+final class AppModel {
+    var projects: [Project] = []
+    var tasks: [TaskItem] = []
+    var sessions: [ScoutSession] = []
+    var specs: [Spec] = []
+    var specQueue: [SpecQueueItem] = []
+    var mode: Mode?
+
+    var connectionError: String?
+    var lastRefreshed: Date?
+
+    private let client = TasksClient()
+    private var started = false
+
+    func task(_ id: String) -> TaskItem? {
+        tasks.first { $0.id == id }
+    }
+
+    func spec(_ id: String) -> Spec? {
+        specs.first { $0.id == id }
+    }
+
+    func session(_ id: String) -> ScoutSession? {
+        sessions.first { $0.id == id }
+    }
+
+    func queueEntry(forSpec specId: String) -> SpecQueueItem? {
+        specQueue.first { $0.specId == specId }
+    }
+
+    /// Optimistic drag-reorder; the server's answer (or a refresh on failure)
+    /// is authoritative.
+    func moveTasks(from source: IndexSet, to destination: Int) {
+        var reordered = tasks
+        reordered.move(fromOffsets: source, toOffset: destination)
+        tasks = reordered
+        Task {
+            do {
+                tasks = try await client.reorderQueue(reordered.map(\.id))
+            } catch {
+                connectionError = error.localizedDescription
+                await refresh()
+            }
+        }
+    }
+
+    /// The clients.md loop: open the SSE stream first, snapshot once it's
+    /// established (`.connected`), refetch on every event, reconnect forever.
+    /// Full re-snapshot per event stands in for per-entity refetch + seq
+    /// tracking — always correct, and cheap at loopback list sizes.
+    func start() async {
+        guard !started else { return }
+        started = true
+        while !Task.isCancelled {
+            do {
+                for try await _ in client.eventStream() {
+                    // .connected and .event both mean the same thing here:
+                    // our lists may be stale — refetch.
+                    await refresh()
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                connectionError = error.localizedDescription
+            }
+            try? await Task.sleep(for: .seconds(3))
+        }
+    }
+
+    func refresh() async {
+        do {
+            async let projects = client.projects()
+            async let tasks = client.tasks()
+            async let sessions = client.sessions()
+            async let specs = client.specs()
+            async let specQueue = client.specQueue()
+            async let mode = client.mode()
+            self.projects = try await projects
+            self.tasks = try await tasks
+            self.sessions = try await sessions
+            self.specs = try await specs
+            self.specQueue = try await specQueue
+            self.mode = try await mode
+            connectionError = nil
+            lastRefreshed = Date()
+        } catch is CancellationError {
+            return
+        } catch {
+            connectionError = error.localizedDescription
+        }
+    }
+}

--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -36,6 +36,20 @@ final class AppModel {
         specQueue.first { $0.specId == specId }
     }
 
+    /// One verdict = one POST. Applies the returned entry optimistically;
+    /// the event-driven refresh reconciles everything else (task state
+    /// changes on approve/needs-revision). Throws so the review form can
+    /// show the server's real error message.
+    func review(specId: String, verdict: ReviewVerdict, feedback: String?) async throws {
+        let updated = try await client.reviewSpec(specId, verdict: verdict, feedback: feedback)
+        if let index = specQueue.firstIndex(where: { $0.specId == specId }) {
+            specQueue[index] = updated
+        } else {
+            specQueue.append(updated)
+        }
+        await refresh()
+    }
+
     /// Optimistic drag-reorder; the server's answer (or a refresh on failure)
     /// is authoritative.
     func moveTasks(from source: IndexSet, to destination: Int) {

--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -1,0 +1,341 @@
+import SwiftUI
+
+enum NavSection: Hashable {
+    case review, queue, sessions
+}
+
+struct ContentView: View {
+    @Environment(AppModel.self) private var model
+    @State private var section: NavSection? = .queue
+    @State private var selectedTask: TaskItem.ID?
+    @State private var selectedSpec: Spec.ID?
+    @State private var selectedSession: ScoutSession.ID?
+
+    var body: some View {
+        NavigationSplitView {
+            sidebar
+                .navigationSplitViewColumnWidth(min: 150, ideal: 180)
+        } content: {
+            listColumn
+                .navigationSplitViewColumnWidth(min: 300, ideal: 380)
+        } detail: {
+            detail
+                .frame(minWidth: 380)
+        }
+        .navigationTitle("Tasks")
+        .navigationSubtitle(subtitle)
+        .toolbar {
+            ToolbarItem {
+                ModeBadge(mode: model.mode)
+            }
+            ToolbarItem {
+                Button("Refresh", systemImage: "arrow.clockwise") {
+                    Task { await model.refresh() }
+                }
+            }
+        }
+    }
+
+    // MARK: Sidebar
+
+    private var sidebar: some View {
+        List(selection: $section) {
+            Section {
+                Label("Review", systemImage: "text.badge.checkmark")
+                    .badge(pendingReviewCount)
+                    .tag(NavSection.review)
+                Label("Queue", systemImage: "list.number")
+                    .badge(model.tasks.count)
+                    .tag(NavSection.queue)
+            }
+            Section {
+                Label("Sessions", systemImage: "terminal")
+                    .tag(NavSection.sessions)
+            }
+        }
+        .listStyle(.sidebar)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            if let error = model.connectionError {
+                ConnectionBanner(error: error)
+            }
+        }
+    }
+
+    private var pendingReviewCount: Int {
+        model.specQueue.filter { $0.status == .pendingReview }.count
+    }
+
+    // MARK: List column
+
+    @ViewBuilder
+    private var listColumn: some View {
+        switch section {
+        case .review, nil:
+            List(selection: $selectedSpec) {
+                if model.specs.isEmpty {
+                    emptyRow("No specs produced yet")
+                }
+                ForEach(reviewOrdered) { spec in
+                    SpecRow(
+                        spec: spec,
+                        entry: model.queueEntry(forSpec: spec.id),
+                        task: model.task(spec.taskId))
+                }
+            }
+            .navigationTitle("Review")
+        case .queue:
+            List(selection: $selectedTask) {
+                if model.tasks.isEmpty {
+                    emptyRow("No tasks ingested yet")
+                }
+                ForEach(model.tasks) { task in
+                    TaskRow(task: task)
+                }
+                .onMove { source, destination in
+                    model.moveTasks(from: source, to: destination)
+                }
+            }
+            .navigationTitle("Queue")
+        case .sessions:
+            List(selection: $selectedSession) {
+                if model.sessions.isEmpty {
+                    emptyRow("No scouts have run")
+                }
+                ForEach(model.sessions.sorted { $0.startedAt > $1.startedAt }) { session in
+                    SessionRow(session: session, task: model.task(session.taskId))
+                }
+            }
+            .navigationTitle("Sessions")
+        }
+    }
+
+    /// Pending review floats to the top; everything else newest-first.
+    private var reviewOrdered: [Spec] {
+        model.specs.sorted { a, b in
+            let aPending = model.queueEntry(forSpec: a.id)?.status == .pendingReview
+            let bPending = model.queueEntry(forSpec: b.id)?.status == .pendingReview
+            if aPending != bPending { return aPending }
+            return a.createdAt > b.createdAt
+        }
+    }
+
+    // MARK: Detail
+
+    @ViewBuilder
+    private var detail: some View {
+        switch section {
+        case .review, nil:
+            if let id = selectedSpec, let spec = model.spec(id) {
+                SpecDetailView(
+                    spec: spec,
+                    entry: model.queueEntry(forSpec: spec.id),
+                    task: model.task(spec.taskId))
+            } else {
+                noSelection("Select a spec to review")
+            }
+        case .queue:
+            if let id = selectedTask, let task = model.task(id) {
+                TaskDetailView(task: task)
+            } else {
+                noSelection("Select a task")
+            }
+        case .sessions:
+            if let id = selectedSession, let session = model.session(id) {
+                SessionDetailView(session: session, task: model.task(session.taskId))
+            } else {
+                noSelection("Select a session")
+            }
+        }
+    }
+
+    private func noSelection(_ text: String) -> some View {
+        ContentUnavailableView(text, systemImage: "sidebar.left")
+    }
+
+    private var subtitle: String {
+        model.projects.isEmpty
+            ? "no projects" : model.projects.map(\.slug).joined(separator: " · ")
+    }
+
+    private func emptyRow(_ text: String) -> some View {
+        Text(text)
+            .foregroundStyle(.tertiary)
+            .font(.callout)
+    }
+}
+
+// MARK: - Rows
+
+struct TaskRow: View {
+    let task: TaskItem
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(task.title)
+                    .lineLimit(2)
+                HStack(spacing: 4) {
+                    Text("#\(task.ghIssueNumber)")
+                        .monospaced()
+                    if !task.labels.isEmpty {
+                        Text("· " + task.labels.joined(separator: " · "))
+                            .lineLimit(1)
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            Spacer()
+            StatusBadge(text: task.state.wire, color: task.state.color)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+struct SpecRow: View {
+    let spec: Spec
+    let entry: SpecQueueItem?
+    let task: TaskItem?
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(task?.title ?? spec.taskId)
+                    .lineLimit(2)
+                Text("\(spec.complexity.wire) · \(spec.createdAt.formatted(.relative(presentation: .named)))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if let entry {
+                StatusBadge(text: entry.status.wire, color: entry.status.color)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+struct SessionRow: View {
+    let session: ScoutSession
+    let task: TaskItem?
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(task?.title ?? session.taskId)
+                    .lineLimit(2)
+                Text(session.startedAt.formatted(.relative(presentation: .named)))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            StatusBadge(text: session.status.wire, color: session.status.color)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+// MARK: - Shared components
+
+struct ConnectionBanner: View {
+    let error: String
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Server unreachable")
+                    .font(.callout.weight(.semibold))
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: "bolt.horizontal.circle")
+                .foregroundStyle(.orange)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quaternary.opacity(0.5))
+    }
+}
+
+struct StatusBadge: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Text(text.replacingOccurrences(of: "_", with: " "))
+            .font(.caption.weight(.medium))
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15), in: Capsule())
+            .foregroundStyle(color)
+    }
+}
+
+struct ModeBadge: View {
+    let mode: Mode?
+
+    var body: some View {
+        Label(mode?.wire ?? "unknown", systemImage: icon)
+            .foregroundStyle(color)
+            .labelStyle(.titleAndIcon)
+    }
+
+    private var icon: String {
+        switch mode {
+        case .play: "play.circle.fill"
+        case .pause: "pause.circle.fill"
+        case .stop: "stop.circle.fill"
+        case .unknown, nil: "questionmark.circle"
+        }
+    }
+
+    private var color: Color {
+        switch mode {
+        case .play: .green
+        case .pause: .yellow
+        case .stop: .red
+        case .unknown, nil: .secondary
+        }
+    }
+}
+
+extension TaskState {
+    var color: Color {
+        switch self {
+        case .new: .gray
+        case .scouting: .blue
+        case .specReady: .purple
+        case .queued: .orange
+        case .done: .green
+        case .rejected: .red
+        case .unknown: .secondary
+        }
+    }
+}
+
+extension SpecQueueStatus {
+    var color: Color {
+        switch self {
+        case .pendingReview: .blue
+        case .approved: .green
+        case .needsRevision: .orange
+        case .blocked: .gray
+        case .rejected: .red
+        case .unknown: .secondary
+        }
+    }
+}
+
+extension SessionStatus {
+    var color: Color {
+        switch self {
+        case .running: .blue
+        case .scoutSucceeded: .green
+        case .scoutFailed: .red
+        case .cancelled: .gray
+        case .unknown: .secondary
+        }
+    }
+}

--- a/app/Tasks/DetailViews.swift
+++ b/app/Tasks/DetailViews.swift
@@ -1,0 +1,241 @@
+import SwiftUI
+
+struct TaskDetailView: View {
+    let task: TaskItem
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(task.title)
+                        .font(.title2.weight(.semibold))
+                        .textSelection(.enabled)
+                    Spacer()
+                    StatusBadge(text: task.state.wire, color: task.state.color)
+                }
+
+                HStack(spacing: 8) {
+                    Text("#\(task.ghIssueNumber)")
+                        .font(.callout.monospaced())
+                        .foregroundStyle(.secondary)
+                    StatusBadge(
+                        text: task.ghState.wire,
+                        color: task.ghState == .open ? .green : .purple)
+                        .help("GitHub state as of the last poll — not live")
+                    ForEach(task.labels, id: \.self) { label in
+                        StatusBadge(text: label, color: .secondary)
+                    }
+                }
+
+                DetailFields {
+                    LabeledContent("Priority", value: "\(task.priority)")
+                    LabeledContent("Manual rank", value: task.manualRank.map(String.init) ?? "—")
+                    if let attempts = task.dispatchAttempts, attempts > 0 {
+                        LabeledContent("Dispatch attempts", value: "\(attempts)")
+                    }
+                    LabeledContent("Ingested", value: task.ingestedAt.formatted())
+                    LabeledContent("Updated", value: task.updatedAt.formatted())
+                }
+
+                Divider()
+
+                MarkdownBody(text: task.body)
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+struct SpecDetailView: View {
+    let spec: Spec
+    let entry: SpecQueueItem?
+    let task: TaskItem?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(task?.title ?? "Spec")
+                        .font(.title2.weight(.semibold))
+                        .textSelection(.enabled)
+                    Spacer()
+                    if let entry {
+                        StatusBadge(text: entry.status.wire, color: entry.status.color)
+                    }
+                }
+
+                DetailFields {
+                    LabeledContent("Complexity", value: spec.complexity.wire)
+                    LabeledContent("Created", value: spec.createdAt.formatted())
+                    if let rank = entry?.rank {
+                        LabeledContent("Rank", value: "\(rank)")
+                    }
+                    if let approved = entry?.approvedAt {
+                        LabeledContent("Approved", value: approved.formatted())
+                    }
+                    if let code = spec.agentExitCode {
+                        LabeledContent("Agent exit", value: "\(code)")
+                    }
+                }
+
+                if let feedback = entry?.feedback, !feedback.isEmpty {
+                    Callout(title: "Review feedback", text: feedback, color: .orange)
+                }
+
+                if !spec.filesTouched.isEmpty {
+                    DisclosureGroup("Files touched (\(spec.filesTouched.count))") {
+                        VStack(alignment: .leading, spacing: 2) {
+                            ForEach(spec.filesTouched, id: \.self) { file in
+                                Text(file)
+                                    .font(.caption.monospaced())
+                                    .textSelection(.enabled)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 4)
+                    }
+                }
+
+                Divider()
+
+                MarkdownBody(text: spec.content)
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+struct SessionDetailView: View {
+    let session: ScoutSession
+    let task: TaskItem?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(task?.title ?? "Scout session")
+                        .font(.title2.weight(.semibold))
+                        .textSelection(.enabled)
+                    Spacer()
+                    StatusBadge(text: session.status.wire, color: session.status.color)
+                }
+
+                DetailFields {
+                    LabeledContent("Branch") {
+                        Text(session.branch)
+                            .font(.callout.monospaced())
+                            .textSelection(.enabled)
+                    }
+                    LabeledContent("VM", value: session.vmId ?? "—")
+                    LabeledContent("Started", value: session.startedAt.formatted())
+                    if session.completedAt == nil {
+                        // Scouts run for tens of minutes; a live clock reads
+                        // as "working", a static timestamp reads as "hung".
+                        LabeledContent("Elapsed") {
+                            Text(session.startedAt, style: .timer)
+                                .monospacedDigit()
+                        }
+                    }
+                    if let completed = session.completedAt {
+                        LabeledContent("Completed", value: completed.formatted())
+                        LabeledContent(
+                            "Duration",
+                            value: Duration.seconds(
+                                completed.timeIntervalSince(session.startedAt)
+                            ).formatted(.units(allowed: [.hours, .minutes, .seconds], width: .abbreviated)))
+                    }
+                }
+
+                if let reason = session.exitReason, !reason.isEmpty {
+                    Callout(title: "Exit reason", text: reason, color: .red)
+                }
+
+                Divider()
+
+                // Transcript pane lands here once the server persists scout
+                // output — docs/plans/2026-08-09-session-transcripts.md.
+                ContentUnavailableView {
+                    Label("No transcript", systemImage: "text.bubble")
+                } description: {
+                    Text("The server doesn't capture scout output yet.")
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - Pieces
+
+/// Two-column key/value block used across the detail views.
+struct DetailFields<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            content
+        }
+        .labeledContentStyle(.detailField)
+    }
+}
+
+struct DetailFieldStyle: LabeledContentStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            configuration.label
+                .foregroundStyle(.secondary)
+                .frame(width: 100, alignment: .trailing)
+            configuration.content
+                .textSelection(.enabled)
+        }
+        .font(.callout)
+    }
+}
+
+extension LabeledContentStyle where Self == DetailFieldStyle {
+    static var detailField: DetailFieldStyle { DetailFieldStyle() }
+}
+
+struct Callout: View {
+    let title: String
+    let text: String
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(color)
+            Text(text)
+                .font(.callout)
+                .textSelection(.enabled)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(color.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+/// Renders GitHub-flavored markdown-ish text. Inline styles only, newlines
+/// preserved — good enough until a real markdown view earns its place.
+struct MarkdownBody: View {
+    let text: String
+
+    var body: some View {
+        if let attributed = try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace))
+        {
+            Text(attributed)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            Text(text)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/app/Tasks/DetailViews.swift
+++ b/app/Tasks/DetailViews.swift
@@ -100,9 +100,92 @@ struct SpecDetailView: View {
                 Divider()
 
                 MarkdownBody(text: spec.content)
+
+                if entry != nil {
+                    Divider()
+
+                    ReviewForm(specId: spec.id)
+                }
             }
             .padding(16)
             .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+/// Verdict buttons + feedback field. The server is the authority on verdict
+/// legality — this form only pre-disables the obviously-unhelpful case
+/// (needs_revision without feedback, since feedback is the reviewer's
+/// message to the next scout).
+struct ReviewForm: View {
+    @Environment(AppModel.self) private var model
+    let specId: String
+
+    @State private var feedback = ""
+    @State private var submitting = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Verdict")
+                .font(.headline)
+
+            TextField(
+                "Feedback — fed to the next scout on needs revision",
+                text: $feedback, axis: .vertical
+            )
+            .lineLimit(3...8)
+            .textFieldStyle(.roundedBorder)
+
+            HStack(spacing: 8) {
+                Button("Approve") {
+                    submit(.approved)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.green)
+
+                Button("Needs revision") {
+                    submit(.needsRevision)
+                }
+                .tint(.orange)
+                .disabled(feedback.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .help("Write feedback first — it's the message the re-scout sees")
+
+                Button("Reject") {
+                    submit(.rejected)
+                }
+                .tint(.red)
+
+                if submitting {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .disabled(submitting)
+    }
+
+    private func submit(_ verdict: ReviewVerdict) {
+        submitting = true
+        errorMessage = nil
+        let trimmed = feedback.trimmingCharacters(in: .whitespacesAndNewlines)
+        Task {
+            do {
+                try await model.review(
+                    specId: specId,
+                    verdict: verdict,
+                    feedback: trimmed.isEmpty ? nil : trimmed)
+                feedback = ""
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            submitting = false
         }
     }
 }

--- a/app/Tasks/Models.swift
+++ b/app/Tasks/Models.swift
@@ -1,0 +1,256 @@
+import Foundation
+
+// Mirrors crates/tasks/src/models.rs, per docs/clients.md. Keys arrive
+// snake_case and are converted by the decoder's key strategy.
+//
+// Enums parse leniently (clients.md): an unknown wire value becomes
+// .unknown(raw) and renders as its raw string instead of failing the decode —
+// new states will appear as the pipeline grows.
+
+/// String-backed wire enum with a lossless fallback for unknown values.
+protocol WireEnum: Decodable, Hashable, Sendable {
+    init(wire: String)
+    var wire: String { get }
+}
+
+extension WireEnum {
+    init(from decoder: any Decoder) throws {
+        self.init(wire: try decoder.singleValueContainer().decode(String.self))
+    }
+}
+
+struct Project: Decodable, Identifiable, Hashable {
+    let id: String
+    let repoOwner: String
+    let repoName: String
+    let addedAt: Date
+
+    var slug: String { "\(repoOwner)/\(repoName)" }
+}
+
+// Named TaskItem rather than Task to stay out of Swift Concurrency's way.
+struct TaskItem: Decodable, Identifiable, Hashable {
+    let id: String
+    let projectId: String
+    let ghIssueNumber: UInt64
+    let title: String
+    let body: String
+    let labels: [String]
+    let ghState: GhState
+    let state: TaskState
+    let priority: Int
+    let manualRank: Int?
+    /// Landing in PR #757; absent on older servers.
+    let dispatchAttempts: Int?
+    let ingestedAt: Date
+    let updatedAt: Date
+}
+
+enum GhState: WireEnum {
+    case open, closed
+    case unknown(String)
+
+    init(wire: String) {
+        switch wire {
+        case "open": self = .open
+        case "closed": self = .closed
+        default: self = .unknown(wire)
+        }
+    }
+
+    var wire: String {
+        switch self {
+        case .open: "open"
+        case .closed: "closed"
+        case .unknown(let raw): raw
+        }
+    }
+}
+
+enum TaskState: WireEnum {
+    case new, scouting, specReady, queued, done, rejected
+    case unknown(String)
+
+    init(wire: String) {
+        switch wire {
+        case "new": self = .new
+        case "scouting": self = .scouting
+        case "spec_ready": self = .specReady
+        case "queued": self = .queued
+        case "done": self = .done
+        case "rejected": self = .rejected
+        default: self = .unknown(wire)
+        }
+    }
+
+    var wire: String {
+        switch self {
+        case .new: "new"
+        case .scouting: "scouting"
+        case .specReady: "spec_ready"
+        case .queued: "queued"
+        case .done: "done"
+        case .rejected: "rejected"
+        case .unknown(let raw): raw
+        }
+    }
+}
+
+struct ScoutSession: Decodable, Identifiable, Hashable {
+    let id: String
+    let taskId: String
+    let vmId: String?
+    let branch: String
+    let status: SessionStatus
+    let startedAt: Date
+    let completedAt: Date?
+    let exitReason: String?
+}
+
+enum SessionStatus: WireEnum {
+    case running, scoutSucceeded, scoutFailed, cancelled
+    case unknown(String)
+
+    init(wire: String) {
+        switch wire {
+        case "running": self = .running
+        case "scout_succeeded": self = .scoutSucceeded
+        case "scout_failed": self = .scoutFailed
+        case "cancelled": self = .cancelled
+        default: self = .unknown(wire)
+        }
+    }
+
+    var wire: String {
+        switch self {
+        case .running: "running"
+        case .scoutSucceeded: "scout_succeeded"
+        case .scoutFailed: "scout_failed"
+        case .cancelled: "cancelled"
+        case .unknown(let raw): raw
+        }
+    }
+}
+
+struct Spec: Decodable, Identifiable, Hashable {
+    let id: String
+    let sessionId: String
+    let taskId: String
+    let content: String
+    let complexity: Complexity
+    let filesTouched: [String]
+    /// Present after the PR #757 shape; absent on older servers.
+    let agentExitCode: Int?
+    let createdAt: Date
+
+    // clients.md calls the deliverable `spec_markdown`; v2 HEAD serves
+    // `content`. Accept both until the name settles.
+    enum CodingKeys: String, CodingKey {
+        case id, sessionId, taskId, content, specMarkdown
+        case complexity, filesTouched, agentExitCode, createdAt
+    }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        sessionId = try c.decode(String.self, forKey: .sessionId)
+        taskId = try c.decode(String.self, forKey: .taskId)
+        content =
+            try c.decodeIfPresent(String.self, forKey: .content)
+            ?? c.decode(String.self, forKey: .specMarkdown)
+        complexity = try c.decode(Complexity.self, forKey: .complexity)
+        filesTouched = try c.decodeIfPresent([String].self, forKey: .filesTouched) ?? []
+        agentExitCode = try c.decodeIfPresent(Int.self, forKey: .agentExitCode)
+        createdAt = try c.decode(Date.self, forKey: .createdAt)
+    }
+}
+
+enum Complexity: WireEnum {
+    case simple, medium, complex
+    case unknown(String)
+
+    init(wire: String) {
+        switch wire {
+        case "simple": self = .simple
+        case "medium": self = .medium
+        case "complex": self = .complex
+        default: self = .unknown(wire)
+        }
+    }
+
+    var wire: String {
+        switch self {
+        case .simple: "simple"
+        case .medium: "medium"
+        case .complex: "complex"
+        case .unknown(let raw): raw
+        }
+    }
+}
+
+/// The server flattens SpecQueueEntry and joins in the spec's task_id.
+struct SpecQueueItem: Decodable, Identifiable, Hashable {
+    let specId: String
+    let status: SpecQueueStatus
+    let rank: Int?
+    let approvedAt: Date?
+    let feedback: String?
+    let blockingDependencies: [String]
+    let taskId: String
+
+    var id: String { specId }
+}
+
+enum SpecQueueStatus: WireEnum {
+    case pendingReview, approved, needsRevision, blocked, rejected
+    case unknown(String)
+
+    init(wire: String) {
+        switch wire {
+        case "pending_review": self = .pendingReview
+        case "approved": self = .approved
+        case "needs_revision": self = .needsRevision
+        case "blocked": self = .blocked
+        case "rejected": self = .rejected
+        default: self = .unknown(wire)
+        }
+    }
+
+    var wire: String {
+        switch self {
+        case .pendingReview: "pending_review"
+        case .approved: "approved"
+        case .needsRevision: "needs_revision"
+        case .blocked: "blocked"
+        case .rejected: "rejected"
+        case .unknown(let raw): raw
+        }
+    }
+}
+
+enum Mode: WireEnum {
+    case play, pause, stop
+    case unknown(String)
+
+    init(wire: String) {
+        switch wire {
+        case "play": self = .play
+        case "pause": self = .pause
+        case "stop": self = .stop
+        default: self = .unknown(wire)
+        }
+    }
+
+    var wire: String {
+        switch self {
+        case .play: "play"
+        case .pause: "pause"
+        case .stop: "stop"
+        case .unknown(let raw): raw
+        }
+    }
+}
+
+struct ModeResponse: Decodable {
+    let mode: Mode
+}

--- a/app/Tasks/TasksApp.swift
+++ b/app/Tasks/TasksApp.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+@main
+struct TasksApp: App {
+    @State private var model = AppModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(model)
+                .task { await model.start() }
+                .frame(minWidth: 480, minHeight: 360)
+        }
+        .defaultSize(width: 640, height: 720)
+    }
+}

--- a/app/Tasks/TasksClient.swift
+++ b/app/Tasks/TasksClient.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// Thin client for the tasks server's loopback HTTP API.
+struct TasksClient: Sendable {
+    // Honors the same TASKS_SERVER_PORT the server reads.
+    var baseURL = URL(
+        string: "http://127.0.0.1:\(ProcessInfo.processInfo.environment["TASKS_SERVER_PORT"] ?? "4800")"
+    )!
+
+    func projects() async throws -> [Project] { try await get("projects") }
+    func tasks() async throws -> [TaskItem] { try await get("tasks") }
+    func sessions() async throws -> [ScoutSession] { try await get("sessions") }
+    func specs() async throws -> [Spec] { try await get("specs") }
+    func specQueue() async throws -> [SpecQueueItem] { try await get("spec-queue") }
+    func spec(_ id: String) async throws -> Spec { try await get("specs/\(id)") }
+
+    func mode() async throws -> Mode {
+        let response: ModeResponse = try await get("mode")
+        return response.mode
+    }
+
+    /// Sets manual_rank 1..n in the given order; unlisted tasks go unranked.
+    /// Returns the full re-sorted queue.
+    func reorderQueue(_ taskIds: [String]) async throws -> [TaskItem] {
+        try await post("queue/reorder", body: ["task_ids": taskIds])
+    }
+
+    enum SSESignal: Sendable {
+        /// Response head received — the server-side subscription exists, so a
+        /// snapshot taken now can't miss events (clients.md: stream first,
+        /// then snapshot).
+        case connected
+        /// One `data:` payload.
+        case event(String)
+    }
+
+    /// Signals from /events/stream. Finishes when the server closes the
+    /// connection; the caller owns reconnect policy.
+    func eventStream() -> AsyncThrowingStream<SSESignal, Error> {
+        let url = baseURL.appending(path: "events/stream")
+        return AsyncThrowingStream { continuation in
+            let reader = Task {
+                do {
+                    let (bytes, response) = try await URLSession.shared.bytes(from: url)
+                    try Self.checkOK(response)
+                    continuation.yield(.connected)
+                    for try await line in bytes.lines where line.hasPrefix("data: ") {
+                        continuation.yield(.event(String(line.dropFirst("data: ".count))))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in reader.cancel() }
+        }
+    }
+
+    private func post<T: Decodable>(_ path: String, body: some Encodable & Sendable)
+        async throws -> T
+    {
+        var request = URLRequest(url: baseURL.appending(path: path))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try Self.checkOK(response)
+        return try Self.makeDecoder().decode(T.self, from: data)
+    }
+
+    private func get<T: Decodable>(_ path: String) async throws -> T {
+        let (data, response) = try await URLSession.shared.data(from: baseURL.appending(path: path))
+        try Self.checkOK(response)
+        return try Self.makeDecoder().decode(T.self, from: data)
+    }
+
+    private static func checkOK(_ response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse,
+            !(200..<300).contains(http.statusCode)
+        else { return }
+        throw URLError(
+            .badServerResponse,
+            userInfo: [NSLocalizedDescriptionKey: "HTTP \(http.statusCode)"])
+    }
+
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            guard let date = parseRFC3339(raw) else {
+                throw DecodingError.dataCorruptedError(
+                    in: container, debugDescription: "unparseable date: \(raw)")
+            }
+            return date
+        }
+        return decoder
+    }
+
+    /// chrono emits RFC3339 with 0–9 fractional digits depending on the value;
+    /// normalize to exactly 3 so a single format style parses everything.
+    private static func parseRFC3339(_ raw: String) -> Date? {
+        var s = raw
+        guard let dot = s.firstIndex(of: ".") else {
+            return try? Date(s, strategy: .iso8601)
+        }
+        let start = s.index(after: dot)
+        var end = start
+        while end < s.endIndex, s[end].isNumber { end = s.index(after: end) }
+        let frac = String(s[start..<end].prefix(3))
+            .padding(toLength: 3, withPad: "0", startingAt: 0)
+        s.replaceSubrange(dot..<end, with: ".\(frac)")
+        return try? Date(s, strategy: Date.ISO8601FormatStyle(includingFractionalSeconds: true))
+    }
+}

--- a/app/Tasks/TasksClient.swift
+++ b/app/Tasks/TasksClient.swift
@@ -1,5 +1,22 @@
 import Foundation
 
+/// A non-2xx response. The server always ships `{"error": "..."}` JSON;
+/// `message` carries it so UI surfaces the real reason, not just a code.
+struct APIError: LocalizedError {
+    let status: Int
+    let message: String
+
+    var errorDescription: String? { message }
+}
+
+/// The three verdicts a reviewer may deliver (clients.md); `pending_review`
+/// and `blocked` are server-assigned.
+enum ReviewVerdict: String, Sendable {
+    case approved
+    case needsRevision = "needs_revision"
+    case rejected
+}
+
 /// Thin client for the tasks server's loopback HTTP API.
 struct TasksClient: Sendable {
     // Honors the same TASKS_SERVER_PORT the server reads.
@@ -23,6 +40,17 @@ struct TasksClient: Sendable {
     /// Returns the full re-sorted queue.
     func reorderQueue(_ taskIds: [String]) async throws -> [TaskItem] {
         try await post("queue/reorder", body: ["task_ids": taskIds])
+    }
+
+    /// Deliver a review verdict. Returns the updated queue entry.
+    func reviewSpec(_ specId: String, verdict: ReviewVerdict, feedback: String?)
+        async throws -> SpecQueueItem
+    {
+        var body = ["status": verdict.rawValue]
+        if let feedback {
+            body["feedback"] = feedback
+        }
+        return try await post("spec-queue/\(specId)/review", body: body)
     }
 
     enum SSESignal: Sendable {
@@ -64,23 +92,28 @@ struct TasksClient: Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(body)
         let (data, response) = try await URLSession.shared.data(for: request)
-        try Self.checkOK(response)
+        try Self.checkOK(response, body: data)
         return try Self.makeDecoder().decode(T.self, from: data)
     }
 
     private func get<T: Decodable>(_ path: String) async throws -> T {
         let (data, response) = try await URLSession.shared.data(from: baseURL.appending(path: path))
-        try Self.checkOK(response)
+        try Self.checkOK(response, body: data)
         return try Self.makeDecoder().decode(T.self, from: data)
     }
 
-    private static func checkOK(_ response: URLResponse) throws {
+    private struct ServerError: Decodable {
+        let error: String
+    }
+
+    private static func checkOK(_ response: URLResponse, body: Data? = nil) throws {
         guard let http = response as? HTTPURLResponse,
             !(200..<300).contains(http.statusCode)
         else { return }
-        throw URLError(
-            .badServerResponse,
-            userInfo: [NSLocalizedDescriptionKey: "HTTP \(http.statusCode)"])
+        let message = body.flatMap { try? JSONDecoder().decode(ServerError.self, from: $0).error }
+        throw APIError(
+            status: http.statusCode,
+            message: message ?? "HTTP \(http.statusCode)")
     }
 
     private static func makeDecoder() -> JSONDecoder {

--- a/docs/plans/2026-08-09-session-transcripts.md
+++ b/docs/plans/2026-08-09-session-transcripts.md
@@ -1,0 +1,90 @@
+# Session transcripts: what the app needs to render scout chat/history
+
+Written from the SwiftUI app's perspective (app/Tasks). The app wants to show
+a scout session as a chat: what the agent said, which tools it ran, what came
+back, and the final result — live while the scout runs, and replayable after.
+
+None of that data survives today. Three gaps, in pipeline order:
+
+## Gap 1 — the agent doesn't emit a transcript
+
+`scout-supervisor` runs `SCOUT_AGENT_CMD`, defaulting to `claude --print`
+(crates/scout-supervisor/src/main.rs, `run_agent`). Plain `--print` emits only
+final response text. The fix is the engine's own typed output:
+
+```
+claude --print --output-format stream-json --verbose
+```
+
+Every stdout line becomes one JSON event: `system/init` (session id, model,
+tools), `assistant` (text + `tool_use` blocks), `user` (`tool_result` blocks),
+and a terminal `result` (subtype, duration, cost, turn count). This is the
+Claude Code typed output the CLAUDE.md rule already points at — the server
+consumes it, no home-rolled loop. No supervisor protocol change needed:
+`ScoutEvent::Progress { stream, line }` already carries lines; they just
+become one-JSON-object-per-line. Bump the default in the agent image /
+supervisor env.
+
+## Gap 2 — the server discards Progress events
+
+`drain_scout_events` (crates/tasks/src/scout.rs) matches
+`ScoutEvent::Progress { .. }` and drops it. Needed:
+
+- New table, Tasks-owned state (fine to persist — nothing GitHub-owned):
+
+  ```sql
+  CREATE TABLE session_log (
+      session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      seq         INTEGER NOT NULL,          -- per-session, monotonic
+      stream      TEXT NOT NULL,             -- stdout / stderr
+      line        TEXT NOT NULL,             -- raw line; stream-json when stdout
+      logged_at   TEXT NOT NULL,
+      PRIMARY KEY (session_id, seq)
+  );
+  ```
+
+- Append on every Progress event during the drain loop. Best-effort matches
+  the protocol's stated semantics (lines may drop under load); an insert
+  failure should warn, not kill the scout.
+- Store raw lines. Don't parse stream-json server-side beyond validation —
+  the schema belongs to the engine, and the app is the renderer. stderr lines
+  stay as-is (clone/branch noise, agent diagnostics).
+
+## Gap 3 — no read path
+
+Two routes on the existing axum server (crates/tasks/src/server.rs):
+
+- `GET /sessions/{id}/log?since_seq=&limit=` — catch-up read, same shape as
+  `/events`. Returns `[{seq, stream, line, logged_at}]`.
+- `GET /sessions/{id}/log/stream` — per-session SSE tail. Deliberately NOT
+  folded into the global `/events/stream`: a scout emits hundreds of lines
+  and every dashboard subscriber would eat them. The global stream keeps
+  state-change events only; one `SessionLogStarted`-style event there is
+  optional and probably unnecessary (the app already refreshes sessions on
+  `session_started`).
+
+The store needs a per-session broadcast (or one broadcast keyed by session id)
+so the SSE route can tail inserts without polling SQLite.
+
+## What the app does with it
+
+Already-planned rendering once the above lands:
+
+- Session detail grows a transcript pane: catch-up via `GET .../log`, then
+  live-follow the SSE stream while `status == running`.
+- stdout lines parse as stream-json: assistant text renders as chat bubbles,
+  `tool_use` as collapsed rows (tool name + input summary), `tool_result`
+  inline under its tool, `result` as a footer (duration, cost, turns).
+  Unparseable stdout and all stderr render as a monospaced log section —
+  nothing is hidden.
+- No app-side persistence; the server log is the source of truth, same as
+  everything else.
+
+## Sizing / retention notes
+
+- A scout run is typically a few hundred to a few thousand lines; tool
+  results dominate. At ~1–2 MB/session worst case, SQLite is fine. If it ever
+  matters, cap per-session rows or add a retention sweep keyed on
+  `sessions.completed_at` — decide when it hurts, not now.
+- `ScoutEvent::Progress` is lossy by design; per-session `seq` is assigned
+  server-side at insert, so gaps in agent output don't break ordering.


### PR DESCRIPTION
PR #758 merged the mac app into the stale `v2` branch, which is missing #757 (reconciliation + attempts) and #765 (poller absence reconciliation). This re-targets that work onto `main`. Content is exactly #758's two commits: the read-only dashboard, review screen, API error decoding, and the Xcode .gitignore entries. After this merges, `v2` is fully contained in `main` and will be deleted.