### PR TITLE
Scout transcripts, re-scout feedback, and a scout timeout (#759, #760, #762)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ env / `.env`:
 | `TASKS_POLL_INTERVAL` | 60 | seconds between GitHub polls |
 | `SCOUT_MAX_CONCURRENT` | 2 | scouts running at once |
 | `SCOUT_IMAGE` | `agent:v1` | vm-pool image scouts run in |
+| `SCOUT_TIMEOUT_SECS` | 3600 | wall-clock budget per scout; past it the VM is deallocated and the attempt counts as a dispatch failure. Keep below vm-pool's `vm_timeout` (7200) |
 | `VM_POOL_SOCKET` | `/tmp/vm-pool.sock` | vm-pool service socket |
 | `GITHUB_TOKEN` | — | required for polling; also used for clones |
 | `GITHUB_API_URL` | api.github.com | GraphQL endpoint override |

--- a/crates/scout-supervisor/tests/fixtures/stub-agent-stream-json.sh
+++ b/crates/scout-supervisor/tests/fixtures/stub-agent-stream-json.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Stand-in agent that emits stream-json shaped output, like
+# `claude --print --output-format stream-json --verbose`.
+#
+# Paced so a test can attach to the live SSE tail part-way through the run
+# rather than only after it finishes.
+
+set -e
+
+PROMPT=$(cat)
+echo '{"type":"system","subtype":"init","cwd":"/work","model":"claude-opus-5"}'
+sleep 0.3
+echo '{"type":"assistant","message":{"content":[{"type":"text","text":"Reading the repo."}]}}'
+sleep 0.3
+echo '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"src/lib.rs"}}]}}'
+sleep 0.3
+echo '{"type":"user","message":{"content":[{"type":"tool_result","content":"pub fn x() {}"}]}}'
+sleep 0.3
+
+mkdir -p src
+printf 'pub fn stub() {}\n' > src/stub.rs
+git add src/stub.rs
+git -c user.email=stub@example.com -c user.name=Stub commit -q -m "stub implementation"
+
+cat > SPEC.md <<EOF
+## Spec: Stream-json stub
+
+### Summary
+Produced by the stream-json stub agent.
+
+### Implementation Approach
+- Added \`src/stub.rs\`
+
+### Complexity
+Simple
+EOF
+
+# The final result record. Deliberately does NOT put "type" first: real records
+# carry it near the end, and the parser must not depend on key order.
+echo '{"subtype":"success","duration_ms":1234,"num_turns":3,"total_cost_usd":0.0421,"usage":{"input_tokens":1200,"output_tokens":340,"cache_read_input_tokens":880,"cache_creation_input_tokens":64},"type":"result"}'

--- a/crates/tasks/migrations/0004_transcripts.sql
+++ b/crates/tasks/migrations/0004_transcripts.sql
@@ -1,0 +1,24 @@
+-- Per-session agent transcripts.
+--
+-- A table rather than per-session files: the read API is `?since=<seq>&limit=`,
+-- which is exactly an indexed range scan on this primary key. A file would need
+-- a parallel seq->offset index to answer the same question, plus its own cleanup
+-- path and its own half-written-line failure mode. ON DELETE CASCADE means
+-- transcript lifetime is free.
+--
+-- Deliberately NOT the event log: transcripts are a high-rate channel only an
+-- open session-detail view subscribes to, while every client refetches on every
+-- event. See docs/clients.md § "Event volume".
+CREATE TABLE transcript_lines (
+    session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    seq         INTEGER NOT NULL,           -- dense, per session, assigned at persist time
+    timestamp   TEXT NOT NULL,
+    stream      TEXT NOT NULL,              -- stdout / stderr
+    line        TEXT NOT NULL,
+    PRIMARY KEY (session_id, seq)
+);
+
+-- Token usage / cost parsed from the stream-json `result` record. JSON because
+-- the shape is Claude Code's, not ours; every field is optional so a renamed
+-- key costs a null rather than a failed scout.
+ALTER TABLE sessions ADD COLUMN agent_usage TEXT;

--- a/crates/tasks/src/main.rs
+++ b/crates/tasks/src/main.rs
@@ -31,6 +31,7 @@ environment:
   TASKS_POLL_INTERVAL    seconds between GitHub polls (default 60)
   SCOUT_MAX_CONCURRENT   scouts running at once (default 2)
   SCOUT_IMAGE            vm-pool image for scouts (default agent:v1)
+  SCOUT_TIMEOUT_SECS     wall-clock budget per scout (default 3600)
   VM_POOL_SOCKET         vm-pool service socket (default /tmp/vm-pool.sock)
   GITHUB_TOKEN           required for polling; also used for repo clones
   GITHUB_API_URL         GraphQL endpoint override

--- a/crates/tasks/src/models.rs
+++ b/crates/tasks/src/models.rs
@@ -147,7 +147,9 @@ impl TaskState {
 }
 
 /// A Scout run — one VM executing a throwaway implementation for a task.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Not `Eq`: `usage` carries `f64` costs. `PartialEq` is kept.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Session {
     pub id: SessionId,
     pub task_id: TaskId,
@@ -157,6 +159,61 @@ pub struct Session {
     pub started_at: DateTime<Utc>,
     pub completed_at: Option<DateTime<Utc>>,
     pub exit_reason: Option<String>,
+    /// Tokens and cost parsed from the agent's final stream-json `result`
+    /// record. `None` for sessions that predate transcript capture, that
+    /// never reached a result, or whose record didn't parse.
+    #[serde(default)]
+    pub usage: Option<SessionUsage>,
+}
+
+/// What one agent run cost. Every field is optional: the shape belongs to
+/// Claude Code, and a renamed key must cost us a null, not a failed scout.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SessionUsage {
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cache_read_input_tokens: Option<u64>,
+    pub cache_creation_input_tokens: Option<u64>,
+    pub total_cost_usd: Option<f64>,
+    pub duration_ms: Option<u64>,
+    pub num_turns: Option<u64>,
+}
+
+/// One line of agent output, as persisted. `seq` is dense per session and
+/// assigned at persist time, so readers can page and tail with `?since=`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TranscriptLine {
+    pub session_id: SessionId,
+    pub seq: i64,
+    pub timestamp: DateTime<Utc>,
+    pub stream: TranscriptStream,
+    pub line: String,
+}
+
+/// Which pipe a transcript line came from. Mirrors `tasks_protocol::LogStream`
+/// at the domain layer so the store doesn't depend on the wire enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TranscriptStream {
+    Stdout,
+    Stderr,
+}
+
+impl TranscriptStream {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TranscriptStream::Stdout => "stdout",
+            TranscriptStream::Stderr => "stderr",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "stdout" => Some(TranscriptStream::Stdout),
+            "stderr" => Some(TranscriptStream::Stderr),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -226,6 +283,16 @@ impl Complexity {
             _ => None,
         }
     }
+}
+
+/// A spec paired with the verdict a reviewer rendered on it. They always
+/// travel together — feedback is unusable without the artifact it refers to —
+/// so a re-scout carries both forward or neither.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewedSpec {
+    pub spec: Spec,
+    pub status: SpecQueueStatus,
+    pub feedback: Option<String>,
 }
 
 /// An entry in the spec queue — the orchestrator's working set for judging

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -15,10 +15,11 @@
 //! - `Pause` — poll, but start no new scouts.
 //! - `Stop` — neither poll nor dispatch.
 //!
-//! Mode gates *new* dispatches only. A scout already in flight always runs to
-//! completion: there is no in-band cancel command (see
-//! [`crate::protocol::ScoutCommand`]) — cancelling means deallocating the VM,
-//! and that path is deferred.
+//! Mode gates *new* dispatches only. A scout already in flight runs to
+//! completion or to its deadline: there is no in-band cancel command (see
+//! [`crate::protocol::ScoutCommand`]), so cancelling means deallocating the
+//! VM. That is exactly what `SCOUT_TIMEOUT_SECS` does when a scout hangs —
+//! a timeout is a dispatch failure like any other, not a mode concern.
 //!
 //! Crash consistency is the store's job, not memory's: startup calls
 //! [`reconcile_startup`] to clear work a dead process left mid-flight, and a
@@ -55,6 +56,13 @@ const DEFAULT_POLL_INTERVAL_SECS: u64 = 60;
 const DEFAULT_SCOUT_MAX_CONCURRENT: usize = 2;
 const DEFAULT_SCOUT_IMAGE: &str = "agent:v1";
 const DEFAULT_VM_POOL_SOCKET: &str = "/tmp/vm-pool.sock";
+/// Wall-clock budget for one scout. ~2.5x the observed 23-minute live run, and
+/// deliberately below vm-pool's own `PoolConfig::vm_timeout` (7200s): if the
+/// app deadline sat at or above the pool's reaper, infrastructure would tear
+/// the VM down first and the dispatcher would report a stream error instead of
+/// its own timeout — same recovery, worse diagnostics. Raising this past ~2h
+/// means raising the pool's `vm_timeout` too.
+const DEFAULT_SCOUT_TIMEOUT_SECS: u64 = 3600;
 const DEFAULT_CLONE_URL_BASE: &str = "https://github.com";
 
 /// How often the dispatch loop re-reads mode + queue.
@@ -66,8 +74,10 @@ const VM_POOL_RETRY: Duration = Duration::from_secs(10);
 /// How long in-flight scouts get to finish after ctrl_c before we walk away.
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(30);
 
-/// `source` on the breadcrumbs this module writes to the event log.
-const DISPATCHER: &str = "dispatcher";
+/// `source` on the breadcrumbs the dispatcher writes to the event log.
+/// `pub(crate)` because [`crate::scout`] emits the timeout note under the same
+/// source — it has the vm id and the deadline that make the entry useful.
+pub(crate) const DISPATCHER: &str = "dispatcher";
 
 /// Consecutive failed dispatches after which a task is rejected outright.
 /// Matches the re-explore cap the plan puts on the server rather than the
@@ -110,6 +120,9 @@ pub struct Config {
     pub scout_max_concurrent: usize,
     /// vm-pool image scouts run in (`SCOUT_IMAGE`).
     pub scout_image: String,
+    /// Wall-clock budget for one scout (`SCOUT_TIMEOUT_SECS`). Past it the VM
+    /// is deallocated and the attempt counts as a dispatch failure.
+    pub scout_timeout: Duration,
     /// vm-pool service socket (`VM_POOL_SOCKET`).
     pub vm_pool_socket: PathBuf,
     /// `GITHUB_TOKEN`. Absent disables polling and leaves clone URLs anonymous.
@@ -143,6 +156,11 @@ impl Config {
             )?
             .max(1),
             scout_image: env_string("SCOUT_IMAGE").unwrap_or_else(|| DEFAULT_SCOUT_IMAGE.into()),
+            scout_timeout: Duration::from_secs(parse_env(
+                "SCOUT_TIMEOUT_SECS",
+                "a number of seconds",
+                DEFAULT_SCOUT_TIMEOUT_SECS,
+            )?),
             vm_pool_socket: env_string("VM_POOL_SOCKET")
                 .unwrap_or_else(|| DEFAULT_VM_POOL_SOCKET.into())
                 .into(),
@@ -444,6 +462,7 @@ async fn dispatch_connected(
         ScoutConfig {
             image: config.scout_image.clone(),
             vm_config: config.vm_config.clone(),
+            timeout: config.scout_timeout,
         },
     ));
 
@@ -686,6 +705,7 @@ mod tests {
             poll_interval: Duration::from_secs(60),
             scout_max_concurrent: 1,
             scout_image: DEFAULT_SCOUT_IMAGE.into(),
+            scout_timeout: Duration::from_secs(DEFAULT_SCOUT_TIMEOUT_SECS),
             vm_pool_socket: PathBuf::from(DEFAULT_VM_POOL_SOCKET),
             github_token: None,
             github_api_url: None,

--- a/crates/tasks/src/scout.rs
+++ b/crates/tasks/src/scout.rs
@@ -477,8 +477,9 @@ impl TranscriptSink {
             self.dropped = 0;
         }
 
+        let len = line.len();
         match self.tx.try_send((stream, line)) {
-            Ok(()) => self.bytes += 1,
+            Ok(()) => self.bytes += len,
             Err(_) => {
                 self.dropped += 1;
                 self.dropped_total += 1;
@@ -862,6 +863,41 @@ mod tests {
 
         let short = "left alone".to_string();
         assert_eq!(truncate_line(short.clone()), short);
+    }
+
+    #[test]
+    fn the_session_byte_cap_counts_bytes_not_lines() {
+        // Room for every push, so nothing is lost to queue pressure and the
+        // cap is the only thing that can stop recording.
+        let (tx, mut rx) = tokio::sync::mpsc::channel(TRANSCRIPT_QUEUE_CAPACITY);
+        let mut sink = TranscriptSink {
+            tx,
+            bytes: 0,
+            capped: false,
+            dropped: 0,
+            dropped_total: 0,
+        };
+
+        let line = "x".repeat(MAX_TRANSCRIPT_LINE_BYTES);
+        let fits = MAX_TRANSCRIPT_BYTES_PER_SESSION / MAX_TRANSCRIPT_LINE_BYTES;
+        for _ in 0..fits {
+            sink.push(TranscriptStream::Stdout, line.clone());
+        }
+        assert!(!sink.capped, "exactly the budget must not trip the cap");
+
+        // One byte over the budget trips it and queues the notice.
+        sink.push(TranscriptStream::Stdout, "x".into());
+        assert!(sink.capped);
+        sink.push(TranscriptStream::Stdout, "ignored after the cap".into());
+
+        let mut recorded = 0;
+        let mut last = String::new();
+        while let Ok((_, l)) = rx.try_recv() {
+            recorded += 1;
+            last = l;
+        }
+        assert_eq!(recorded, fits + 1, "capped pushes must not be recorded");
+        assert!(last.contains("transcript truncated"));
     }
 
     #[test]

--- a/crates/tasks/src/scout.rs
+++ b/crates/tasks/src/scout.rs
@@ -10,6 +10,7 @@
 //! `Arc<Scout>` or clone the underlying [`ClientHandle`]).
 
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use thiserror::Error;
@@ -19,10 +20,10 @@ use vm_pool_protocol::{ServiceEvent, VmConfig, VmId};
 
 use crate::events::EventPayload;
 use crate::models::{
-    Complexity, Session, SessionId, SessionStatus, Spec, SpecId, SpecQueueEntry, SpecQueueStatus,
-    Task, TaskState,
+    Complexity, ReviewedSpec, Session, SessionId, SessionStatus, SessionUsage, Spec, SpecId,
+    SpecQueueEntry, SpecQueueStatus, Task, TaskState, TranscriptStream,
 };
-use crate::protocol::{ScoutCommand, ScoutEvent, TasksProtocol};
+use crate::protocol::{LogStream, ScoutCommand, ScoutEvent, TasksProtocol};
 use crate::store::{Store, StoreError};
 
 #[derive(Debug, Error)]
@@ -35,6 +36,10 @@ pub enum ScoutError {
     ScoutFailed(String),
     #[error("vm-pool event stream closed before completion")]
     StreamClosed,
+    /// Wall-clock deadline hit. The message lands verbatim in
+    /// `sessions.exit_reason`, so both integration tests match on `timed out`.
+    #[error("scout timed out after {secs}s")]
+    Timeout { secs: u64 },
 }
 
 /// How this dispatcher boots a Scout VM. Uniform across dispatches — anything
@@ -45,6 +50,10 @@ pub struct ScoutConfig {
     pub image: String,
     /// VM configuration passed to vm-pool.
     pub vm_config: VmConfig,
+    /// Wall-clock budget for one dispatch, measured from entry to
+    /// [`Scout::dispatch`] so allocation is charged to it too. On expiry the
+    /// VM is deallocated and the dispatch fails with [`ScoutError::Timeout`].
+    pub timeout: Duration,
 }
 
 /// The repository a single dispatch explores. Per-project, so one dispatcher
@@ -84,6 +93,9 @@ impl Scout {
     /// `PendingReview`.
     pub async fn dispatch(&self, task: Task, target: &ScoutTarget) -> Result<Spec, ScoutError> {
         info!(task_id = %task.id, "scout dispatch starting");
+        // Stamped before anything else so the deadline covers allocation too,
+        // making it a true wall-clock budget rather than a drain budget.
+        let started = Instant::now();
 
         // Subscribe before allocating so no event for our VM can be missed.
         let mut events = self.client.subscribe_events();
@@ -101,7 +113,20 @@ impl Scout {
             .await?;
 
         let session_id = SessionId::new();
-        let prompt = render_prompt(&task);
+
+        // A re-scout after a review carries the verdict forward. This is a fact
+        // about the task rather than a caller decision, so `dispatch`'s
+        // signature is unchanged and the dispatch loop needs no edit.
+        let prior = self.store.latest_reviewed_spec(&task.id).await?;
+        if let Some(p) = &prior {
+            info!(
+                task_id = %task.id,
+                prior_spec = %p.spec.id,
+                verdict = p.status.as_str(),
+                "re-scouting with the previous review"
+            );
+        }
+        let prompt = render_prompt(&task, prior.as_ref());
 
         // Allocate
         let vm_id = self
@@ -120,6 +145,7 @@ impl Scout {
             started_at: Utc::now(),
             completed_at: None,
             exit_reason: None,
+            usage: None,
         };
         self.store.insert_session(&session_row).await?;
         self.store
@@ -148,11 +174,53 @@ impl Scout {
             return Err(e.into());
         }
 
-        // Drain events until terminal Completed / Failed.
-        let result = drain_scout_events(&mut events, &vm_id).await;
+        // Drain events until terminal Completed / Failed, or until the budget
+        // runs out. `saturating_sub` means an already-blown budget fires
+        // immediately instead of wrapping.
+        let (mut sink, writer) = spawn_transcript_writer(self.store.clone(), session_id.clone());
+        let mut usage: Option<SessionUsage> = None;
+        let remaining = self.config.timeout.saturating_sub(started.elapsed());
+        let result = match tokio::time::timeout(
+            remaining,
+            drain_scout_events(&mut events, &vm_id, &mut sink, &mut usage),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                let secs = self.config.timeout.as_secs();
+                self.note_timeout(&task, &vm_id, secs).await;
+                Err(ScoutError::Timeout { secs })
+            }
+        };
+
+        // Close the queue and let the writer finish *before* any completion
+        // event is appended, so a client refetching on that event finds the
+        // whole transcript rather than a truncated one.
+        if sink.dropped_total > 0 {
+            warn!(
+                session_id = %session_id,
+                dropped = sink.dropped_total,
+                "transcript lines dropped under queue pressure"
+            );
+        }
+        drop(sink);
+        if let Err(e) = writer.await {
+            warn!(session_id = %session_id, error = %e, "transcript writer task failed");
+        }
+
+        // Recorded on the failure path too: a scout that burned tokens and then
+        // died is the case most worth costing.
+        if let Some(usage) = &usage
+            && let Err(e) = self.store.update_session_usage(&session_id, usage).await
+        {
+            warn!(session_id = %session_id, error = %e, "recording session usage failed");
+        }
 
         // Always try to deallocate. Ignore errors — the pool's health loop
-        // will reap if we die mid-call.
+        // will reap if we die mid-call. For a timeout this *is* the cancel:
+        // there is deliberately no in-band Cancel command, so freeing the slot
+        // means destroying the VM.
         if let Err(e) = self.client.deallocate(&vm_id).await {
             warn!(%vm_id, error = %e, "failed to deallocate scout VM");
         }
@@ -180,6 +248,26 @@ impl Scout {
                     .await?;
                 Err(e)
             }
+        }
+    }
+
+    /// Breadcrumb naming the deadline, written at expiry so the vm id and the
+    /// budget land in the entry. Best-effort on purpose: a failed breadcrumb
+    /// must not skip the deallocation that is the whole point of the timeout.
+    async fn note_timeout(&self, task: &Task, vm_id: &VmId, secs: u64) {
+        warn!(task_id = %task.id, %vm_id, timeout_secs = secs, "scout timed out");
+        if let Err(e) = self
+            .store
+            .append_event(EventPayload::Note {
+                source: crate::run::DISPATCHER.into(),
+                message: format!(
+                    "scout for {} timed out after {secs}s; deallocating {vm_id}",
+                    task.id
+                ),
+            })
+            .await
+        {
+            warn!(task_id = %task.id, error = %e, "could not record the timeout note");
         }
     }
 
@@ -313,6 +401,162 @@ struct DrainOutcome {
     exit_code: Option<i32>,
 }
 
+/// Longest single line we persist. One tool result can be enormous; past this
+/// the line is cut on a char boundary and marked.
+const MAX_TRANSCRIPT_LINE_BYTES: usize = 32 * 1024;
+/// Total transcript bytes persisted for one session. Past this we write one
+/// notice and stop recording — the scout itself keeps running untouched.
+const MAX_TRANSCRIPT_BYTES_PER_SESSION: usize = 8 * 1024 * 1024;
+/// Depth of the hand-off queue between the drain loop and the writer task.
+const TRANSCRIPT_QUEUE_CAPACITY: usize = 1024;
+/// Lines coalesced into one transaction.
+const TRANSCRIPT_BATCH: usize = 64;
+
+/// The wire enum meets the domain enum here, at the dispatcher boundary, so
+/// neither `models` nor `store` has to know about the protocol crate.
+impl From<LogStream> for TranscriptStream {
+    fn from(s: LogStream) -> Self {
+        match s {
+            LogStream::Stdout => TranscriptStream::Stdout,
+            LogStream::Stderr => TranscriptStream::Stderr,
+        }
+    }
+}
+
+/// Non-blocking handle the drain loop pushes agent output into.
+///
+/// `push` must never await the store: the drain loop is also what waits for
+/// `Completed`, and it reads a vm-pool broadcast that drops the oldest events
+/// for slow consumers. Making SQLite latency into lost scout events would be a
+/// bad trade, so this is a `try_send` onto a bounded queue and a separate task
+/// does the writing.
+struct TranscriptSink {
+    tx: tokio::sync::mpsc::Sender<(TranscriptStream, String)>,
+    /// Bytes accepted so far, against `MAX_TRANSCRIPT_BYTES_PER_SESSION`.
+    bytes: usize,
+    /// Set once the byte budget is spent, so the notice is written once.
+    capped: bool,
+    /// Lines lost to queue pressure since the last marker.
+    dropped: u64,
+    /// Total dropped, for the summary line on the way out.
+    dropped_total: u64,
+}
+
+impl TranscriptSink {
+    fn push(&mut self, stream: TranscriptStream, line: String) {
+        if self.capped {
+            return;
+        }
+        let line = truncate_line(line);
+        if self.bytes + line.len() > MAX_TRANSCRIPT_BYTES_PER_SESSION {
+            self.capped = true;
+            // Best-effort: if even this doesn't fit the queue, the log still
+            // records the cap when the sink is dropped.
+            let _ = self.tx.try_send((
+                TranscriptStream::Stderr,
+                format!(
+                    "[tasks] transcript truncated: session passed {} bytes; \
+                     nothing further will be recorded (the scout is unaffected)",
+                    MAX_TRANSCRIPT_BYTES_PER_SESSION
+                ),
+            ));
+            return;
+        }
+
+        // A dropped line leaves no hole a reader could detect, because seq is
+        // assigned at persist time. So say so explicitly as soon as there's room.
+        if self.dropped > 0
+            && self
+                .tx
+                .try_send((
+                    TranscriptStream::Stderr,
+                    format!("[tasks] {} transcript line(s) dropped here", self.dropped),
+                ))
+                .is_ok()
+        {
+            self.dropped = 0;
+        }
+
+        match self.tx.try_send((stream, line)) {
+            Ok(()) => self.bytes += 1,
+            Err(_) => {
+                self.dropped += 1;
+                self.dropped_total += 1;
+            }
+        }
+    }
+}
+
+/// Cut an over-long line on a char boundary and say how much went missing.
+fn truncate_line(line: String) -> String {
+    if line.len() <= MAX_TRANSCRIPT_LINE_BYTES {
+        return line;
+    }
+    let mut cut = MAX_TRANSCRIPT_LINE_BYTES;
+    while cut > 0 && !line.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let dropped = line.len() - cut;
+    let mut out = line;
+    out.truncate(cut);
+    out.push_str(&format!("…[tasks: truncated {dropped} bytes]"));
+    out
+}
+
+/// Spawn the task that drains the sink's queue into the store, coalescing up
+/// to [`TRANSCRIPT_BATCH`] lines per transaction. Finishes when the sink is
+/// dropped and the queue is empty.
+fn spawn_transcript_writer(
+    store: Arc<Store>,
+    session_id: SessionId,
+) -> (TranscriptSink, tokio::task::JoinHandle<()>) {
+    let (tx, mut rx) = tokio::sync::mpsc::channel(TRANSCRIPT_QUEUE_CAPACITY);
+    let handle = tokio::spawn(async move {
+        let mut batch = Vec::with_capacity(TRANSCRIPT_BATCH);
+        while rx.recv_many(&mut batch, TRANSCRIPT_BATCH).await > 0 {
+            if let Err(e) = store.append_transcript_lines(&session_id, &batch).await {
+                warn!(session_id = %session_id, error = %e, "persisting transcript lines failed");
+            }
+            batch.clear();
+        }
+    });
+    (
+        TranscriptSink {
+            tx,
+            bytes: 0,
+            capped: false,
+            dropped: 0,
+            dropped_total: 0,
+        },
+        handle,
+    )
+}
+
+/// Pull token usage out of the final stream-json `result` record.
+///
+/// Read field by field out of a `Value` rather than deserialized into a struct:
+/// the record's shape belongs to Claude Code, and a renamed key must cost us a
+/// null, not a failed scout. Key order is not assumed — real records don't put
+/// `type` first.
+fn parse_usage(line: &str) -> Option<SessionUsage> {
+    let value: serde_json::Value = serde_json::from_str(line).ok()?;
+    if value.get("type")?.as_str()? != "result" {
+        return None;
+    }
+    let usage = value.get("usage");
+    let u64_at =
+        |obj: Option<&serde_json::Value>, key: &str| -> Option<u64> { obj?.get(key)?.as_u64() };
+    Some(SessionUsage {
+        input_tokens: u64_at(usage, "input_tokens"),
+        output_tokens: u64_at(usage, "output_tokens"),
+        cache_read_input_tokens: u64_at(usage, "cache_read_input_tokens"),
+        cache_creation_input_tokens: u64_at(usage, "cache_creation_input_tokens"),
+        total_cost_usd: value.get("total_cost_usd").and_then(|v| v.as_f64()),
+        duration_ms: value.get("duration_ms").and_then(|v| v.as_u64()),
+        num_turns: value.get("num_turns").and_then(|v| v.as_u64()),
+    })
+}
+
 /// Consume this dispatch's own event subscription until its VM reports a
 /// terminal Completed/Failed. Events from other VMs (concurrent scouts) are
 /// ignored; service errors for our requests surface as [`ClientError`] on the
@@ -320,6 +564,8 @@ struct DrainOutcome {
 async fn drain_scout_events(
     events: &mut EventStream<TasksProtocol>,
     target_vm: &VmId,
+    sink: &mut TranscriptSink,
+    usage_out: &mut Option<SessionUsage>,
 ) -> Result<DrainOutcome, ScoutError> {
     let mut branch: Option<String> = None;
     let mut exit_code: Option<i32> = None;
@@ -331,8 +577,16 @@ async fn drain_scout_events(
                 ScoutEvent::Started { branch: b } => {
                     branch = Some(b);
                 }
-                ScoutEvent::Progress { .. } => {
-                    // Surface later via events/log tailing if useful.
+                ScoutEvent::Progress { stream, line } => {
+                    // The result record is the last thing the agent prints; it
+                    // is also just another stdout line, so it gets persisted
+                    // like the rest and parsed on the way past.
+                    if stream == LogStream::Stdout
+                        && let Some(usage) = parse_usage(&line)
+                    {
+                        *usage_out = Some(usage);
+                    }
+                    sink.push(stream.into(), line);
                 }
                 ScoutEvent::ImplementationFinished { exit_code: c } => {
                     exit_code = Some(c);
@@ -359,11 +613,16 @@ async fn drain_scout_events(
     }
 }
 
-fn render_prompt(task: &Task) -> String {
+/// Build the scout prompt, splicing in the previous attempt when the task has
+/// one. The section sits between the issue body and the instructions so the
+/// model reads issue → what went wrong last time → what to do.
+fn render_prompt(task: &Task, prior: Option<&ReviewedSpec>) -> String {
+    let previous = prior.map(render_previous_attempt).unwrap_or_default();
     format!(
         "You are a Scout in the Double Diamond architecture.\n\n\
          ## Issue: {title} (#{num})\n\n\
          {body}\n\n\
+         {previous}\
          ## Your job\n\n\
          1. Implement a working solution in the cloned repo (cwd).\n\
          2. Run the project's tests / lint / typecheck — get them green.\n\
@@ -388,7 +647,58 @@ fn render_prompt(task: &Task) -> String {
         title = task.title,
         num = task.gh_issue_number,
         body = task.body,
+        previous = previous,
     )
+}
+
+/// Render the `## Previous attempt` section: the verdict, the reviewer's
+/// feedback verbatim, and the spec it was written about. The spec is quoted
+/// rather than summarised because feedback like "section 3 is underspecified"
+/// is meaningless without section 3.
+fn render_previous_attempt(prior: &ReviewedSpec) -> String {
+    let feedback = prior
+        .feedback
+        .as_deref()
+        .map(str::trim)
+        .filter(|f| !f.is_empty())
+        .unwrap_or("(no written feedback was left)");
+    let fence = fence_for(&prior.spec.content);
+    format!(
+        "## Previous attempt\n\n\
+         A previous scout explored this same issue and produced the spec below. \
+         A reviewer read it and returned a verdict of **{verdict}**.\n\n\
+         Treat the reviewer's feedback as a requirement, not a suggestion. Do not \
+         resubmit the previous spec unchanged, and do not repeat the shortcomings \
+         it identifies. Explore the current code yourself — the previous spec may \
+         itself be out of date.\n\n\
+         ### Reviewer feedback\n\n\
+         {feedback}\n\n\
+         ### Previous spec\n\n\
+         {fence}markdown\n\
+         {spec}\n\
+         {fence}\n\n",
+        verdict = prior.status.as_str(),
+        feedback = feedback,
+        fence = fence,
+        spec = prior.spec.content.trim_end(),
+    )
+}
+
+/// A fence long enough to quote `content` intact: one backtick longer than the
+/// longest backtick run inside it, minimum three. Specs routinely contain
+/// fenced code, and a plain ``` wrapper would be closed by the first one.
+fn fence_for(content: &str) -> String {
+    let mut longest = 0usize;
+    let mut current = 0usize;
+    for ch in content.chars() {
+        if ch == '`' {
+            current += 1;
+            longest = longest.max(current);
+        } else {
+            current = 0;
+        }
+    }
+    "`".repeat(longest.max(2) + 1)
 }
 
 /// The Scout's self-reported complexity: the first non-empty line after a
@@ -438,6 +748,121 @@ fn infer_complexity(files_touched: &[String]) -> Complexity {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn task_fixture() -> Task {
+        Task {
+            id: crate::models::TaskId::new(),
+            project_id: crate::models::ProjectId::new(),
+            gh_issue_number: 42,
+            title: "A title".into(),
+            body: "The issue body.".into(),
+            labels: vec![],
+            gh_state: crate::models::GhState::Open,
+            state: TaskState::New,
+            priority: 0,
+            manual_rank: None,
+            dispatch_attempts: 0,
+            ingested_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn reviewed(content: &str, feedback: Option<&str>) -> ReviewedSpec {
+        ReviewedSpec {
+            spec: Spec {
+                id: SpecId::new(),
+                session_id: SessionId::new(),
+                task_id: crate::models::TaskId::new(),
+                content: content.into(),
+                complexity: Complexity::Simple,
+                files_touched: vec![],
+                created_at: Utc::now(),
+            },
+            status: SpecQueueStatus::NeedsRevision,
+            feedback: feedback.map(Into::into),
+        }
+    }
+
+    #[test]
+    fn a_fresh_prompt_has_no_previous_attempt_section() {
+        let prompt = render_prompt(&task_fixture(), None);
+        assert!(!prompt.contains("Previous attempt"));
+        // The body must still run straight into the instructions.
+        assert!(prompt.contains("The issue body.\n\n## Your job"));
+    }
+
+    #[test]
+    fn a_re_scout_prompt_carries_the_verdict_feedback_and_prior_spec() {
+        let prior = reviewed(
+            "## Spec: old\n\nSection 3 is thin.",
+            Some("Flesh out section 3."),
+        );
+        let prompt = render_prompt(&task_fixture(), Some(&prior));
+
+        let attempt = prompt.find("## Previous attempt").expect("section present");
+        let verdict = prompt.find("needs_revision").expect("verdict present");
+        let feedback = prompt
+            .find("Flesh out section 3.")
+            .expect("feedback present");
+        let spec = prompt
+            .find("Section 3 is thin.")
+            .expect("prior spec present");
+        let job = prompt.find("## Your job").expect("instructions present");
+
+        // Order matters: issue → verdict → feedback → prior spec → instructions.
+        assert!(attempt < verdict && verdict < feedback && feedback < spec && spec < job);
+    }
+
+    #[test]
+    fn missing_or_blank_feedback_still_renders() {
+        for empty in [None, Some(""), Some("   ")] {
+            let prompt = render_prompt(&task_fixture(), Some(&reviewed("spec body", empty)));
+            assert!(prompt.contains("## Previous attempt"));
+            assert!(prompt.contains("no written feedback"));
+        }
+    }
+
+    #[test]
+    fn the_fence_outlives_fences_nested_in_the_quoted_spec() {
+        // A spec containing its own ```rust block would break out of a plain
+        // ``` wrapper and merge its headings into the prompt's structure.
+        let nested = "## Spec\n\n```rust\nfn x() {}\n```\n";
+        let prompt = render_prompt(&task_fixture(), Some(&reviewed(nested, Some("f"))));
+        assert!(prompt.contains("````markdown"));
+        assert_eq!(fence_for("no fences"), "```");
+        assert_eq!(fence_for("a ``` b"), "````");
+        assert_eq!(fence_for("a ````` b"), "``````");
+    }
+
+    #[test]
+    fn usage_parses_regardless_of_key_order_and_survives_junk() {
+        let record = r#"{"subtype":"success","duration_ms":1234,"num_turns":3,
+            "total_cost_usd":0.0421,"usage":{"input_tokens":1200,"output_tokens":340},
+            "type":"result"}"#;
+        let usage = parse_usage(record).expect("parses with type last");
+        assert_eq!(usage.input_tokens, Some(1200));
+        assert_eq!(usage.output_tokens, Some(340));
+        assert_eq!(usage.total_cost_usd, Some(0.0421));
+        assert_eq!(usage.num_turns, Some(3));
+        // Absent keys are nulls, not failures.
+        assert_eq!(usage.cache_read_input_tokens, None);
+
+        assert!(parse_usage(r#"{"type":"assistant"}"#).is_none());
+        assert!(parse_usage("not json at all").is_none());
+        assert!(parse_usage(r#"{"type":"result"}"#).is_some());
+    }
+
+    #[test]
+    fn over_long_lines_are_cut_on_a_char_boundary_and_marked() {
+        // Multi-byte chars straddling the cut must not panic or corrupt.
+        let line = "é".repeat(MAX_TRANSCRIPT_LINE_BYTES);
+        let out = truncate_line(line);
+        assert!(out.contains("[tasks: truncated"));
+        assert!(out.len() < MAX_TRANSCRIPT_LINE_BYTES + 64);
+
+        let short = "left alone".to_string();
+        assert_eq!(truncate_line(short.clone()), short);
+    }
 
     #[test]
     fn parse_complexity_reads_section() {

--- a/crates/tasks/src/server.rs
+++ b/crates/tasks/src/server.rs
@@ -30,7 +30,7 @@ use tracing::{error, info, warn};
 use crate::events::{Event, EventPayload};
 use crate::models::{
     Mode, Project, ProjectId, Session, SessionId, Spec, SpecId, SpecQueueItem, SpecQueueStatus,
-    Task, TaskId,
+    Task, TaskId, TranscriptLine,
 };
 use crate::store::{Store, StoreError};
 
@@ -39,6 +39,12 @@ const DEFAULT_EVENT_LIMIT: i64 = 100;
 
 /// Interval between SSE keep-alive comments.
 const SSE_KEEPALIVE: Duration = Duration::from_secs(15);
+
+/// Transcript lines `/sessions/{id}/transcript` returns without an explicit
+/// `limit`, and the ceiling on one the caller asks for. The SSE replay pages at
+/// the maximum until it catches up.
+const DEFAULT_TRANSCRIPT_LIMIT: i64 = 500;
+const MAX_TRANSCRIPT_LIMIT: i64 = 2000;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
@@ -88,6 +94,11 @@ pub fn router(store: Arc<Store>) -> Router {
         .route("/tasks/{task_id}", get(get_task))
         .route("/sessions", get(list_sessions))
         .route("/sessions/{session_id}", get(get_session))
+        .route("/sessions/{session_id}/transcript", get(list_transcript))
+        .route(
+            "/sessions/{session_id}/transcript/stream",
+            get(stream_transcript),
+        )
         .route("/specs", get(list_specs))
         .route("/specs/{spec_id}", get(get_spec))
         .route("/spec-queue", get(list_spec_queue))
@@ -317,6 +328,107 @@ async fn set_mode(
     Ok(Json(ModeResponse { mode }))
 }
 
+// --- transcripts ---
+
+#[derive(Debug, Deserialize)]
+struct TranscriptQuery {
+    since: Option<i64>,
+    limit: Option<i64>,
+}
+
+/// Catch-up read of a session's agent output. `since` is **inclusive**, to
+/// match `/events?since=` — a tailing client passes `last_seq + 1`. An empty
+/// array means "nothing recorded", not an error: sessions that predate
+/// transcript capture have none.
+async fn list_transcript(
+    State(store): State<Arc<Store>>,
+    Path(session_id): Path<String>,
+    Query(query): Query<TranscriptQuery>,
+) -> ApiResult<Json<Vec<TranscriptLine>>> {
+    let session_id = SessionId::from_raw(session_id);
+    if store.get_session(&session_id).await?.is_none() {
+        return Err(ApiError::NotFound(format!("session {session_id}")));
+    }
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_TRANSCRIPT_LIMIT)
+        .min(MAX_TRANSCRIPT_LIMIT);
+    if limit <= 0 {
+        return Err(ApiError::BadRequest("limit must be positive".into()));
+    }
+    let lines = store
+        .transcript_since(&session_id, query.since.unwrap_or(0), limit)
+        .await?;
+    Ok(Json(lines))
+}
+
+/// SSE tail of a session's transcript: replay from `since`, then live lines.
+///
+/// The replay pages until it catches up and deliberately takes no `limit`. The
+/// obvious alternative — one limit-sized page, then attach the tail — hands the
+/// client a stream that jumps silently from the end of the page to the newest
+/// line, and a stream is exactly the shape in which that hole goes unnoticed.
+/// The per-session byte cap is what keeps reading it all affordable.
+async fn stream_transcript(
+    State(store): State<Arc<Store>>,
+    Path(session_id): Path<String>,
+    Query(query): Query<TranscriptQuery>,
+) -> ApiResult<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>> {
+    let session_id = SessionId::from_raw(session_id);
+    if store.get_session(&session_id).await?.is_none() {
+        return Err(ApiError::NotFound(format!("session {session_id}")));
+    }
+
+    // Subscribe *before* reading history, so a line appended between the two
+    // steps arrives on the live channel instead of falling down the gap.
+    let live = store.subscribe_transcript();
+
+    let mut backfill = Vec::new();
+    let mut next = query.since.unwrap_or(0);
+    loop {
+        let page = store
+            .transcript_since(&session_id, next, MAX_TRANSCRIPT_LIMIT)
+            .await?;
+        let Some(last) = page.last() else { break };
+        next = last.seq + 1;
+        let full = page.len() as i64 == MAX_TRANSCRIPT_LIMIT;
+        backfill.extend(page);
+        if !full {
+            break;
+        }
+    }
+
+    let session_filter = session_id.clone();
+    let tail = BroadcastStream::new(live).filter_map(move |result| {
+        let line = match result {
+            Ok(line) => line,
+            Err(err) => {
+                warn!(error = %err, "transcript sse subscriber lagged");
+                return None;
+            }
+        };
+        // Drop other sessions, and anything the backfill already delivered.
+        if line.session_id != session_filter || line.seq < next {
+            return None;
+        }
+        to_sse(&line)
+    });
+
+    let replay: Vec<_> = backfill.iter().filter_map(to_sse).collect();
+    let stream = tokio_stream::iter(replay).chain(tail);
+    Ok(Sse::new(stream).keep_alive(KeepAlive::new().interval(SSE_KEEPALIVE)))
+}
+
+fn to_sse(line: &TranscriptLine) -> Option<Result<SseEvent, Infallible>> {
+    match SseEvent::default().json_data(line) {
+        Ok(sse) => Some(Ok(sse)),
+        Err(err) => {
+            error!(error = %err, seq = line.seq, "serializing transcript line for sse");
+            None
+        }
+    }
+}
+
 // --- events ---
 
 #[derive(Debug, Deserialize)]
@@ -436,6 +548,7 @@ mod tests {
             started_at: Utc::now(),
             completed_at: Some(Utc::now()),
             exit_reason: None,
+            usage: None,
         };
         store.insert_session(&session).await.unwrap();
         let spec = Spec {
@@ -1003,5 +1116,207 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(fetched, spec);
+    }
+
+    // --- transcripts (#759) ---
+
+    /// A running session with no transcript yet.
+    async fn seed_session(store: &Arc<Store>) -> SessionId {
+        let (_, project) = (store, {
+            let project = Project {
+                id: ProjectId::new(),
+                repo_owner: "o".into(),
+                repo_name: "r".into(),
+                added_at: Utc::now(),
+            };
+            store.insert_project(&project).await.unwrap();
+            project
+        });
+        let task = insert_task(store, &project, 1, 0).await;
+        let session = Session {
+            id: SessionId::new(),
+            task_id: task.id.clone(),
+            vm_id: None,
+            branch: String::new(),
+            status: SessionStatus::Running,
+            started_at: Utc::now(),
+            completed_at: None,
+            exit_reason: None,
+            usage: None,
+        };
+        store.insert_session(&session).await.unwrap();
+        session.id
+    }
+
+    #[tokio::test]
+    async fn transcript_reads_page_and_honour_inclusive_since() {
+        let store = Arc::new(Store::open_in_memory().await.unwrap());
+        let session_id = seed_session(&store).await;
+        let batch: Vec<_> = (1..=5)
+            .map(|i| (crate::models::TranscriptStream::Stdout, format!("line {i}")))
+            .collect();
+        store
+            .append_transcript_lines(&session_id, &batch)
+            .await
+            .unwrap();
+
+        let base = spawn(store.clone()).await;
+        let http = reqwest::Client::new();
+
+        let all: Vec<TranscriptLine> = http
+            .get(format!("{base}/sessions/{session_id}/transcript"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 5);
+        assert_eq!(all[0].line, "line 1");
+
+        // Inclusive, like /events?since=.
+        let tail: Vec<TranscriptLine> = http
+            .get(format!("{base}/sessions/{session_id}/transcript?since=4"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(tail.iter().map(|l| l.seq).collect::<Vec<_>>(), vec![4, 5]);
+
+        // An unknown session is a 404, not an empty array — those mean
+        // different things to a client.
+        let resp = http
+            .get(format!("{base}/sessions/sess_nope/transcript"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+
+        let resp = http
+            .get(format!("{base}/sessions/{session_id}/transcript?limit=0"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+    }
+
+    /// A session with no lines is "nothing recorded", not an error.
+    #[tokio::test]
+    async fn an_empty_transcript_is_an_empty_array() {
+        let store = Arc::new(Store::open_in_memory().await.unwrap());
+        let session_id = seed_session(&store).await;
+        let base = spawn(store.clone()).await;
+
+        let lines: Vec<TranscriptLine> = reqwest::Client::new()
+            .get(format!("{base}/sessions/{session_id}/transcript"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert!(lines.is_empty());
+    }
+
+    /// The regression guard for the SSE replay: one limit-sized page followed
+    /// by the live tail would silently skip everything in between. The count is
+    /// an exact multiple of the page size, which is the boundary where a naive
+    /// loop stops early.
+    #[tokio::test]
+    async fn transcript_stream_replays_past_one_page_without_a_hole() {
+        let store = Arc::new(Store::open_in_memory().await.unwrap());
+        let session_id = seed_session(&store).await;
+
+        let total = (MAX_TRANSCRIPT_LIMIT * 2) as usize;
+        let batch: Vec<_> = (1..=total)
+            .map(|i| (crate::models::TranscriptStream::Stdout, format!("line {i}")))
+            .collect();
+        store
+            .append_transcript_lines(&session_id, &batch)
+            .await
+            .unwrap();
+
+        let base = spawn(store.clone()).await;
+        let mut stream = reqwest::Client::new()
+            .get(format!("{base}/sessions/{session_id}/transcript/stream"))
+            .send()
+            .await
+            .unwrap();
+
+        let mut body = String::new();
+        let mut seqs: Vec<i64> = Vec::new();
+        while seqs.len() < total {
+            let chunk = tokio::time::timeout(Duration::from_secs(30), stream.chunk())
+                .await
+                .expect("sse chunk timed out")
+                .unwrap()
+                .expect("sse stream closed early");
+            body.push_str(&String::from_utf8_lossy(&chunk));
+            while let Some(end) = body.find("\n\n") {
+                let frame: String = body.drain(..end + 2).collect();
+                if let Some(data) = frame.lines().find_map(|l| l.strip_prefix("data: ")) {
+                    seqs.push(serde_json::from_str::<TranscriptLine>(data).unwrap().seq);
+                }
+            }
+        }
+
+        // Dense 1..=total with nothing skipped in the middle.
+        assert_eq!(seqs.len(), total);
+        assert_eq!(seqs, (1..=total as i64).collect::<Vec<_>>());
+    }
+
+    /// Subscribe-then-backfill: a line appended while the handler is reading
+    /// history must arrive on the live channel rather than fall down the gap.
+    #[tokio::test]
+    async fn transcript_stream_tails_lines_appended_after_it_attached() {
+        let store = Arc::new(Store::open_in_memory().await.unwrap());
+        let session_id = seed_session(&store).await;
+        store
+            .append_transcript_lines(
+                &session_id,
+                &[(crate::models::TranscriptStream::Stdout, "historic".into())],
+            )
+            .await
+            .unwrap();
+
+        let base = spawn(store.clone()).await;
+        let mut stream = reqwest::Client::new()
+            .get(format!("{base}/sessions/{session_id}/transcript/stream"))
+            .send()
+            .await
+            .unwrap();
+
+        store
+            .append_transcript_lines(
+                &session_id,
+                &[(crate::models::TranscriptStream::Stderr, "live".into())],
+            )
+            .await
+            .unwrap();
+
+        let mut body = String::new();
+        let mut lines: Vec<TranscriptLine> = Vec::new();
+        while lines.len() < 2 {
+            let chunk = tokio::time::timeout(Duration::from_secs(5), stream.chunk())
+                .await
+                .expect("sse chunk timed out")
+                .unwrap()
+                .expect("sse stream closed early");
+            body.push_str(&String::from_utf8_lossy(&chunk));
+            while let Some(end) = body.find("\n\n") {
+                let frame: String = body.drain(..end + 2).collect();
+                if let Some(data) = frame.lines().find_map(|l| l.strip_prefix("data: ")) {
+                    lines.push(serde_json::from_str(data).unwrap());
+                }
+            }
+        }
+        assert_eq!(lines[0].line, "historic");
+        assert_eq!(lines[1].line, "live");
+        assert_eq!(
+            lines[1].seq, 2,
+            "no duplicate or skipped seq at the handoff"
+        );
     }
 }

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -11,8 +11,9 @@ use tokio::sync::broadcast;
 use crate::events::{Event, EventPayload};
 use crate::github::GhIssue;
 use crate::models::{
-    Complexity, GhState, Mode, Project, ProjectId, Session, SessionId, SessionStatus, Spec, SpecId,
-    SpecQueueEntry, SpecQueueItem, SpecQueueStatus, Task, TaskId, TaskState,
+    Complexity, GhState, Mode, Project, ProjectId, ReviewedSpec, Session, SessionId, SessionStatus,
+    SessionUsage, Spec, SpecId, SpecQueueEntry, SpecQueueItem, SpecQueueStatus, Task, TaskId,
+    TaskState, TranscriptLine, TranscriptStream,
 };
 
 /// Result of upserting an external record into our domain.
@@ -38,6 +39,11 @@ impl<T> UpsertOutcome<T> {
 /// fall this far behind receive `RecvError::Lagged` and must catch up via
 /// `events_since`.
 const EVENT_BROADCAST_CAPACITY: usize = 1024;
+
+/// Capacity of the transcript broadcast channel. Larger than the event one:
+/// agent output is far higher-rate, and a session-detail view that lags briefly
+/// should resync rather than lose its place.
+const TRANSCRIPT_BROADCAST_CAPACITY: usize = 4096;
 
 /// `exit_reason` written to sessions that were still `running` when the server
 /// came back up.
@@ -81,6 +87,7 @@ pub enum StoreError {
 pub struct Store {
     pool: SqlitePool,
     event_tx: broadcast::Sender<Event>,
+    transcript_tx: broadcast::Sender<TranscriptLine>,
 }
 
 impl Store {
@@ -94,7 +101,12 @@ impl Store {
             .await?;
         MIGRATOR.run(&pool).await?;
         let (event_tx, _) = broadcast::channel(EVENT_BROADCAST_CAPACITY);
-        Ok(Self { pool, event_tx })
+        let (transcript_tx, _) = broadcast::channel(TRANSCRIPT_BROADCAST_CAPACITY);
+        Ok(Self {
+            pool,
+            event_tx,
+            transcript_tx,
+        })
     }
 
     /// Open an in-memory database (useful for tests).
@@ -105,7 +117,12 @@ impl Store {
             .await?;
         MIGRATOR.run(&pool).await?;
         let (event_tx, _) = broadcast::channel(EVENT_BROADCAST_CAPACITY);
-        Ok(Self { pool, event_tx })
+        let (transcript_tx, _) = broadcast::channel(TRANSCRIPT_BROADCAST_CAPACITY);
+        Ok(Self {
+            pool,
+            event_tx,
+            transcript_tx,
+        })
     }
 
     // --- projects ---
@@ -511,7 +528,7 @@ impl Store {
     pub async fn get_session(&self, id: &SessionId) -> Result<Option<Session>, StoreError> {
         let row = sqlx::query(
             "SELECT id, task_id, vm_id, branch, status, started_at, completed_at, \
-             exit_reason FROM sessions WHERE id = ?",
+             exit_reason, agent_usage FROM sessions WHERE id = ?",
         )
         .bind(id.as_str())
         .fetch_optional(&self.pool)
@@ -522,11 +539,111 @@ impl Store {
     pub async fn list_sessions(&self) -> Result<Vec<Session>, StoreError> {
         let rows = sqlx::query(
             "SELECT id, task_id, vm_id, branch, status, started_at, completed_at, \
-             exit_reason FROM sessions ORDER BY started_at",
+             exit_reason, agent_usage FROM sessions ORDER BY started_at",
         )
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter().map(session_from_row).collect()
+    }
+
+    pub async fn update_session_usage(
+        &self,
+        id: &SessionId,
+        usage: &SessionUsage,
+    ) -> Result<(), StoreError> {
+        let result = sqlx::query("UPDATE sessions SET agent_usage = ? WHERE id = ?")
+            .bind(serde_json::to_string(usage)?)
+            .bind(id.as_str())
+            .execute(&self.pool)
+            .await?;
+        if result.rows_affected() == 0 {
+            return Err(StoreError::NotFound(format!("session {id}")));
+        }
+        Ok(())
+    }
+
+    // --- transcripts ---
+
+    /// Append agent output lines for a session, assigning dense `seq` values
+    /// from `MAX(seq)+1`. One transaction for the batch; subscribers are
+    /// notified only after it commits, so a live tail can never announce a line
+    /// a catch-up read would fail to return.
+    ///
+    /// Returns the persisted lines with their seq values filled in.
+    pub async fn append_transcript_lines(
+        &self,
+        session_id: &SessionId,
+        lines: &[(TranscriptStream, String)],
+    ) -> Result<Vec<TranscriptLine>, StoreError> {
+        if lines.is_empty() {
+            return Ok(Vec::new());
+        }
+        let now = Utc::now();
+        let mut tx = self.pool.begin().await?;
+
+        let next: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(MAX(seq), 0) + 1 FROM transcript_lines WHERE session_id = ?",
+        )
+        .bind(session_id.as_str())
+        .fetch_one(&mut *tx)
+        .await?;
+
+        let mut persisted = Vec::with_capacity(lines.len());
+        for (offset, (stream, line)) in lines.iter().enumerate() {
+            let seq = next + offset as i64;
+            sqlx::query(
+                "INSERT INTO transcript_lines (session_id, seq, timestamp, stream, line) \
+                 VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(session_id.as_str())
+            .bind(seq)
+            .bind(now.to_rfc3339())
+            .bind(stream.as_str())
+            .bind(line)
+            .execute(&mut *tx)
+            .await?;
+            persisted.push(TranscriptLine {
+                session_id: session_id.clone(),
+                seq,
+                timestamp: now,
+                stream: *stream,
+                line: line.clone(),
+            });
+        }
+        tx.commit().await?;
+
+        for line in &persisted {
+            let _ = self.transcript_tx.send(line.clone());
+        }
+        Ok(persisted)
+    }
+
+    /// Transcript lines for a session with `seq >= since`, oldest first.
+    /// `since` is inclusive, matching `/events?since=`; a tailing client passes
+    /// `last_seq + 1`.
+    pub async fn transcript_since(
+        &self,
+        session_id: &SessionId,
+        since: i64,
+        limit: i64,
+    ) -> Result<Vec<TranscriptLine>, StoreError> {
+        let rows = sqlx::query(
+            "SELECT session_id, seq, timestamp, stream, line FROM transcript_lines \
+             WHERE session_id = ? AND seq >= ? ORDER BY seq LIMIT ?",
+        )
+        .bind(session_id.as_str())
+        .bind(since)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(transcript_line_from_row).collect()
+    }
+
+    /// Live transcript lines for *every* session; subscribers filter by id.
+    /// One channel rather than per-session ones because `SCOUT_MAX_CONCURRENT`
+    /// is small and per-session channel lifetimes aren't worth managing.
+    pub fn subscribe_transcript(&self) -> broadcast::Receiver<TranscriptLine> {
+        self.transcript_tx.subscribe()
     }
 
     // --- reconciliation ---
@@ -661,6 +778,35 @@ impl Store {
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter().map(spec_from_row).collect()
+    }
+
+    /// The most recently created spec for `task` that a reviewer has actually
+    /// ruled on, with its verdict and feedback.
+    ///
+    /// Only the three verdict statuses count. `PendingReview` and `Blocked` are
+    /// server-assigned, so there is no reviewer opinion to replay. Ordering is
+    /// `created_at DESC` with `rowid DESC` as the tiebreak: two specs for one
+    /// task can share a timestamp to second resolution, and the query has to be
+    /// deterministic. `created_at` is always written as UTC RFC-3339, so
+    /// lexicographic ordering matches chronological ordering.
+    pub async fn latest_reviewed_spec(
+        &self,
+        task_id: &TaskId,
+    ) -> Result<Option<ReviewedSpec>, StoreError> {
+        let row = sqlx::query(
+            "SELECT s.id, s.session_id, s.task_id, s.content, s.complexity, \
+             s.files_touched, s.created_at, q.status, q.feedback \
+             FROM specs s JOIN spec_queue q ON q.spec_id = s.id \
+             WHERE s.task_id = ? AND q.status IN (?, ?, ?) \
+             ORDER BY s.created_at DESC, s.rowid DESC LIMIT 1",
+        )
+        .bind(task_id.as_str())
+        .bind(SpecQueueStatus::Approved.as_str())
+        .bind(SpecQueueStatus::NeedsRevision.as_str())
+        .bind(SpecQueueStatus::Rejected.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(reviewed_spec_from_row).transpose()
     }
 
     // --- spec queue ---
@@ -984,6 +1130,23 @@ fn session_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Session, StoreError>
             .map(|s| parse_ts(&s, "completed_at"))
             .transpose()?,
         exit_reason: row.try_get("exit_reason")?,
+        usage: row
+            .try_get::<Option<String>, _>("agent_usage")?
+            .and_then(|raw| serde_json::from_str(&raw).ok()),
+    })
+}
+
+fn transcript_line_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptLine, StoreError> {
+    let stream_raw: String = row.try_get("stream")?;
+    Ok(TranscriptLine {
+        session_id: SessionId::from_raw(row.try_get::<String, _>("session_id")?),
+        seq: row.try_get("seq")?,
+        timestamp: parse_ts(&row.try_get::<String, _>("timestamp")?, "timestamp")?,
+        stream: TranscriptStream::from_str(&stream_raw).ok_or(StoreError::BadEnum {
+            column: "stream",
+            value: stream_raw,
+        })?,
+        line: row.try_get("line")?,
     })
 }
 
@@ -1001,6 +1164,22 @@ fn spec_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Spec, StoreError> {
         })?,
         files_touched: serde_json::from_str(&files_raw)?,
         created_at: parse_ts(&row.try_get::<String, _>("created_at")?, "created_at")?,
+    })
+}
+
+/// Maps a `specs` ⋈ `spec_queue` row. Safe to reuse [`spec_from_row`] on the
+/// joined row because `specs` has no `status` or `feedback` column of its own,
+/// so the two projections can't collide.
+fn reviewed_spec_from_row(row: sqlx::sqlite::SqliteRow) -> Result<ReviewedSpec, StoreError> {
+    let status_raw: String = row.try_get("status")?;
+    let feedback: Option<String> = row.try_get("feedback")?;
+    Ok(ReviewedSpec {
+        status: SpecQueueStatus::from_str(&status_raw).ok_or(StoreError::BadEnum {
+            column: "status",
+            value: status_raw,
+        })?,
+        feedback,
+        spec: spec_from_row(row)?,
     })
 }
 
@@ -1274,6 +1453,7 @@ mod tests {
             started_at: Utc::now(),
             completed_at: None,
             exit_reason: None,
+            usage: None,
         };
         store.insert_session(&session).await.unwrap();
 
@@ -1311,6 +1491,7 @@ mod tests {
             started_at: Utc::now(),
             completed_at: Some(Utc::now()),
             exit_reason: None,
+            usage: None,
         };
         store.insert_session(&session).await.unwrap();
         let spec = Spec {
@@ -1891,6 +2072,7 @@ mod tests {
             started_at: Utc::now(),
             completed_at: None,
             exit_reason: None,
+            usage: None,
         };
         store.insert_session(&running).await.unwrap();
 
@@ -2045,6 +2227,7 @@ mod tests {
             started_at: Utc::now(),
             completed_at: Some(Utc::now()),
             exit_reason: None,
+            usage: None,
         };
         store.insert_session(&session).await.unwrap();
         let spec = Spec {
@@ -2355,5 +2538,245 @@ mod tests {
             EventPayload::Note { message, .. } => assert_eq!(message, "first"),
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    // --- previous-attempt lookup (#760) ---
+
+    #[tokio::test]
+    async fn latest_reviewed_spec_returns_the_newest_verdict_for_that_task() {
+        let store = Store::open_in_memory().await.unwrap();
+        let (task, first) = seed_spec(&store, 1).await;
+
+        // Pending review is not a verdict — nothing to replay yet.
+        assert!(
+            store
+                .latest_reviewed_spec(&task.id)
+                .await
+                .unwrap()
+                .is_none(),
+            "a pending spec is not a reviewed one"
+        );
+
+        store
+            .review_spec(
+                &first.id,
+                SpecQueueStatus::NeedsRevision,
+                Some("fix it".to_string()),
+            )
+            .await
+            .unwrap();
+        let found = store.latest_reviewed_spec(&task.id).await.unwrap().unwrap();
+        assert_eq!(found.spec.id, first.id);
+        assert_eq!(found.status, SpecQueueStatus::NeedsRevision);
+        assert_eq!(found.feedback.as_deref(), Some("fix it"));
+
+        // A newer *unreviewed* spec must not displace the reviewed one.
+        let session = Session {
+            id: SessionId::new(),
+            task_id: task.id.clone(),
+            vm_id: None,
+            branch: "scout/2".into(),
+            status: SessionStatus::ScoutSucceeded,
+            started_at: Utc::now(),
+            completed_at: Some(Utc::now()),
+            exit_reason: None,
+            usage: None,
+        };
+        store.insert_session(&session).await.unwrap();
+        let second = Spec {
+            id: SpecId::new(),
+            session_id: session.id.clone(),
+            task_id: task.id.clone(),
+            content: "## Spec two".into(),
+            complexity: Complexity::Simple,
+            files_touched: vec![],
+            created_at: Utc::now(),
+        };
+        store.insert_spec(&second).await.unwrap();
+        store
+            .upsert_spec_queue_entry(&SpecQueueEntry {
+                spec_id: second.id.clone(),
+                status: SpecQueueStatus::PendingReview,
+                rank: None,
+                approved_at: None,
+                feedback: None,
+                blocking_dependencies: vec![],
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .latest_reviewed_spec(&task.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .spec
+                .id,
+            first.id,
+            "an unreviewed newer spec must not displace the reviewed one"
+        );
+
+        // Once reviewed, the newer one wins.
+        store
+            .review_spec(
+                &second.id,
+                SpecQueueStatus::Rejected,
+                Some("no".to_string()),
+            )
+            .await
+            .unwrap();
+        let found = store.latest_reviewed_spec(&task.id).await.unwrap().unwrap();
+        assert_eq!(found.spec.id, second.id);
+        assert_eq!(found.status, SpecQueueStatus::Rejected);
+    }
+
+    #[tokio::test]
+    async fn latest_reviewed_spec_does_not_leak_across_tasks() {
+        let store = Store::open_in_memory().await.unwrap();
+        let (_task_a, spec_a) = seed_spec(&store, 1).await;
+        let (task_b, _spec_b) = seed_spec(&store, 2).await;
+        store
+            .review_spec(
+                &spec_a.id,
+                SpecQueueStatus::NeedsRevision,
+                Some("a only".to_string()),
+            )
+            .await
+            .unwrap();
+        assert!(
+            store
+                .latest_reviewed_spec(&task_b.id)
+                .await
+                .unwrap()
+                .is_none(),
+            "another task's review must not surface here"
+        );
+    }
+
+    // --- transcripts (#759) ---
+
+    #[tokio::test]
+    async fn transcript_lines_get_dense_seqs_and_read_back_from_since() {
+        let store = Store::open_in_memory().await.unwrap();
+        let (task, _) = seed_spec(&store, 1).await;
+        let session = Session {
+            id: SessionId::new(),
+            task_id: task.id.clone(),
+            vm_id: None,
+            branch: String::new(),
+            status: SessionStatus::Running,
+            started_at: Utc::now(),
+            completed_at: None,
+            exit_reason: None,
+            usage: None,
+        };
+        store.insert_session(&session).await.unwrap();
+
+        let first = store
+            .append_transcript_lines(
+                &session.id,
+                &[
+                    (TranscriptStream::Stdout, "one".into()),
+                    (TranscriptStream::Stderr, "two".into()),
+                ],
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.iter().map(|l| l.seq).collect::<Vec<_>>(), vec![1, 2]);
+
+        // A second batch continues the sequence rather than restarting it.
+        let second = store
+            .append_transcript_lines(&session.id, &[(TranscriptStream::Stdout, "three".into())])
+            .await
+            .unwrap();
+        assert_eq!(second[0].seq, 3);
+
+        let all = store.transcript_since(&session.id, 0, 100).await.unwrap();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[1].stream, TranscriptStream::Stderr);
+
+        // `since` is inclusive, matching /events?since=.
+        let tail = store.transcript_since(&session.id, 2, 100).await.unwrap();
+        assert_eq!(tail.iter().map(|l| l.seq).collect::<Vec<_>>(), vec![2, 3]);
+
+        let capped = store.transcript_since(&session.id, 0, 2).await.unwrap();
+        assert_eq!(capped.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn appending_transcript_lines_notifies_subscribers_after_commit() {
+        let store = Store::open_in_memory().await.unwrap();
+        let (task, _) = seed_spec(&store, 1).await;
+        let session = Session {
+            id: SessionId::new(),
+            task_id: task.id.clone(),
+            vm_id: None,
+            branch: String::new(),
+            status: SessionStatus::Running,
+            started_at: Utc::now(),
+            completed_at: None,
+            exit_reason: None,
+            usage: None,
+        };
+        store.insert_session(&session).await.unwrap();
+
+        let mut rx = store.subscribe_transcript();
+        store
+            .append_transcript_lines(&session.id, &[(TranscriptStream::Stdout, "hello".into())])
+            .await
+            .unwrap();
+
+        let line = rx.try_recv().expect("broadcast after commit");
+        assert_eq!(line.line, "hello");
+        assert_eq!(line.seq, 1);
+        // Anything announced on the channel must already be readable.
+        assert_eq!(
+            store
+                .transcript_since(&session.id, line.seq, 10)
+                .await
+                .unwrap()[0]
+                .line,
+            "hello"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_usage_round_trips() {
+        let store = Store::open_in_memory().await.unwrap();
+        let (task, _) = seed_spec(&store, 1).await;
+        let session = Session {
+            id: SessionId::new(),
+            task_id: task.id.clone(),
+            vm_id: None,
+            branch: String::new(),
+            status: SessionStatus::Running,
+            started_at: Utc::now(),
+            completed_at: None,
+            exit_reason: None,
+            usage: None,
+        };
+        store.insert_session(&session).await.unwrap();
+        assert!(
+            store
+                .get_session(&session.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .usage
+                .is_none()
+        );
+
+        let usage = SessionUsage {
+            input_tokens: Some(1200),
+            output_tokens: Some(340),
+            total_cost_usd: Some(0.0421),
+            ..Default::default()
+        };
+        store
+            .update_session_usage(&session.id, &usage)
+            .await
+            .unwrap();
+        let back = store.get_session(&session.id).await.unwrap().unwrap();
+        assert_eq!(back.usage, Some(usage));
     }
 }

--- a/crates/tasks/tests/common/mod.rs
+++ b/crates/tasks/tests/common/mod.rs
@@ -116,6 +116,26 @@ pub fn stub_agent_path() -> PathBuf {
         .join("stub-agent.sh")
 }
 
+/// A stand-in agent that copies its whole stdin prompt into SPEC.md, so a test
+/// can assert on what the scout was told.
+pub fn echo_prompt_agent_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("echo-prompt-agent.sh")
+}
+
+/// A stand-in agent that emits stream-json shaped output, paced so a test can
+/// attach to the live transcript tail mid-run.
+pub fn stream_json_agent_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("scout-supervisor")
+        .join("tests")
+        .join("fixtures")
+        .join("stub-agent-stream-json.sh")
+}
+
 /// Start a vm-pool Service on a fresh Unix socket. Returns the service + socket path.
 pub async fn spawn_vm_pool(
     tmp: &Path,

--- a/crates/tasks/tests/fixtures/echo-prompt-agent.sh
+++ b/crates/tasks/tests/fixtures/echo-prompt-agent.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Stand-in agent that copies its ENTIRE stdin prompt into SPEC.md, so a test can
+# assert on what the scout was actually told.
+#
+# The existing crates/scout-supervisor/tests/fixtures/stub-agent.sh only echoes
+# the prompt's first line, and it is shared with the supervisor's own tests, so
+# it is left alone.
+#
+# NOTE: this file's own `### Complexity` section must come BEFORE the echoed
+# prompt. `parse_complexity` takes the first such section in the produced spec,
+# and the echoed prompt contains the template's `Simple | Medium | Complex`
+# line, which parse_complexity deliberately rejects as ambiguous. Same trap
+# applies to any future prompt-echoing fixture.
+
+set -e
+
+PROMPT=$(cat)
+echo "[echo-prompt-agent] starting in $(pwd)"
+
+mkdir -p src
+printf 'pub fn stub() {}\n' > src/stub.rs
+git add src/stub.rs
+git -c user.email=stub@example.com -c user.name=Stub commit -q -m "stub implementation"
+
+cat > SPEC.md <<EOF
+## Spec: Echoed prompt
+
+### Complexity
+Simple
+
+### Summary
+The prompt this scout received is reproduced verbatim below.
+
+### Implementation Approach
+- Added \`src/stub.rs\` with a no-op function
+
+### Received prompt
+
+$PROMPT
+EOF
+
+echo "[echo-prompt-agent] done"

--- a/crates/tasks/tests/run.rs
+++ b/crates/tasks/tests/run.rs
@@ -380,6 +380,7 @@ fn test_config(vm_pool_socket: &Path, clone_root: &Path, max_concurrent: usize) 
         poll_interval: Duration::from_secs(3600),
         scout_max_concurrent: max_concurrent,
         scout_image: "agent:v1".into(),
+        scout_timeout: Duration::from_secs(300),
         vm_pool_socket: vm_pool_socket.to_path_buf(),
         github_token: None,
         github_api_url: None,
@@ -724,6 +725,7 @@ async fn startup_reconciles_orphaned_work_before_dispatch() {
         started_at: Utc::now(),
         completed_at: None,
         exit_reason: None,
+        usage: None,
     };
     store.insert_session(&orphan).await.unwrap();
     store.set_mode(Mode::Play).await.unwrap();
@@ -768,4 +770,104 @@ async fn startup_reconciles_orphaned_work_before_dispatch() {
         "a crashed server is not the task's fault"
     );
     assert_eq!(dispatch_order(&store).await, vec![task.id.clone()]);
+}
+
+/// #762: a hung scout is ended by its deadline, counts as a dispatch failure
+/// like any other, and — the point of the feature — frees its slot so the
+/// queue keeps moving.
+#[tokio::test]
+async fn a_hung_scout_times_out_and_frees_its_slot() {
+    // 10s against a 2s deadline; see the comment in tests/scout.rs on why not
+    // 300s. One slot, so the second task can only run once the first lets go.
+    let (_tmp, store, mut config, service) = dispatch_harness_with_agent(1, "sleep 10").await;
+    config.scout_timeout = Duration::from_secs(2);
+    let project = insert_project(&store).await;
+    let hung = insert_task(&store, &project, 1, "hangs forever").await;
+    let queued = insert_task(&store, &project, 2, "waiting behind it").await;
+    store
+        .set_queue_order(&[hung.id.clone(), queued.id.clone()])
+        .await
+        .unwrap();
+    store.set_mode(Mode::Play).await.unwrap();
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = tokio::spawn(run::dispatch_loop(store.clone(), config, shutdown_rx));
+
+    // Three timeouts exhaust the attempt cap, exactly as three of anything else.
+    wait_for_state(&store, &hung.id, TaskState::Rejected).await;
+    // The slot is free: the task behind it gets dispatched.
+    wait_until(Duration::from_secs(60), || {
+        let store = store.clone();
+        let id = queued.id.clone();
+        async move { dispatch_order(&store).await.contains(&id) }
+    })
+    .await;
+
+    shutdown_tx.send(true).unwrap();
+    tokio::time::timeout(Duration::from_secs(60), handle)
+        .await
+        .expect("dispatch loop exits on shutdown")
+        .unwrap();
+
+    let stored = store.get_task(&hung.id).await.unwrap().unwrap();
+    assert_eq!(stored.state, TaskState::Rejected);
+    assert_eq!(
+        stored.dispatch_attempts, 3,
+        "a timeout is a dispatch failure"
+    );
+
+    let sessions = store.list_sessions().await.unwrap();
+    let timed_out: Vec<_> = sessions
+        .iter()
+        .filter(|s| s.task_id == hung.id)
+        .inspect(|s| assert_eq!(s.status, SessionStatus::ScoutFailed))
+        .filter(|s| {
+            s.exit_reason
+                .as_deref()
+                .is_some_and(|r| r.contains("timed out"))
+        })
+        .collect();
+    assert_eq!(timed_out.len(), 3, "three sessions ended on the deadline");
+
+    let payloads: Vec<_> = store
+        .events_since(0)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|e| e.payload)
+        .collect();
+    // The task returns to New after each timeout. Asserted on the append-only
+    // log rather than by polling the row: the dispatch loop re-picks the task
+    // within a tick, so a row read can legitimately miss the window. Don't
+    // "fix" this back into a get_task().state check.
+    let back_to_new = payloads
+        .iter()
+        .filter(|p| {
+            matches!(
+                p,
+                EventPayload::TaskStateChanged {
+                    task_id,
+                    from: TaskState::Scouting,
+                    to: TaskState::New
+                } if *task_id == hung.id
+            )
+        })
+        .count();
+    assert_eq!(back_to_new, 3, "each timeout requeues the task");
+    assert!(
+        payloads.iter().any(|p| matches!(
+            p,
+            EventPayload::Note { source, message }
+                if source == "dispatcher" && message.contains("timed out")
+        )),
+        "the dispatcher leaves a breadcrumb naming the timeout"
+    );
+
+    // Cancellation is deallocation — no VM may outlive its dispatch, or the
+    // pool leaks a slot per hang.
+    wait_until(Duration::from_secs(60), || {
+        let service = service.clone();
+        async move { service.pool.list().await.is_empty() }
+    })
+    .await;
 }

--- a/crates/tasks/tests/scout.rs
+++ b/crates/tasks/tests/scout.rs
@@ -11,6 +11,7 @@
 //! land in the store with the expected state transitions. No mocks.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use chrono::Utc;
 use vm_pool_protocol::VmConfig;
@@ -88,6 +89,7 @@ async fn scout_dispatch_end_to_end_produces_spec() {
     let scout_config = ScoutConfig {
         image: "agent:v1".into(),
         vm_config: VmConfig::default(),
+        timeout: Duration::from_secs(300),
     };
     let target = ScoutTarget {
         repo_clone_url: repo_url,
@@ -173,6 +175,7 @@ async fn two_scouts_dispatch_concurrently() {
     let scout_config = ScoutConfig {
         image: "agent:v1".into(),
         vm_config: VmConfig::default(),
+        timeout: Duration::from_secs(300),
     };
     let target = ScoutTarget {
         repo_clone_url: repo_url,
@@ -220,6 +223,7 @@ async fn scout_dispatch_failure_resets_task_to_new() {
     let scout_config = ScoutConfig {
         image: "agent:v1".into(),
         vm_config: VmConfig::default(),
+        timeout: Duration::from_secs(300),
     };
     let target = ScoutTarget {
         repo_clone_url: repo_url,
@@ -237,5 +241,161 @@ async fn scout_dispatch_failure_resets_task_to_new() {
         stored_task.state,
         TaskState::New,
         "failed scout should reset task to New for retry"
+    );
+}
+
+/// #760: a task re-dispatched after `needs_revision` must receive the
+/// reviewer's feedback and the spec it referred to.
+///
+/// The echo-prompt agent copies its whole stdin into SPEC.md, so the second
+/// run's spec content *is* the prompt the scout was given.
+#[tokio::test]
+async fn re_scout_after_needs_revision_receives_the_review() {
+    let supervisor_bin = cargo_build("scout-supervisor").await;
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = make_fixture_repo(tmp.path(), "fixture-repo").await;
+    let repo_url = format!("file://{}", repo.display());
+    let workdir_root = tmp.path().join("scout-workdirs");
+    tokio::fs::create_dir_all(&workdir_root).await.unwrap();
+    let wrapper = write_supervisor_wrapper(
+        tmp.path(),
+        &supervisor_bin,
+        common::echo_prompt_agent_path().to_str().unwrap(),
+        &workdir_root,
+    )
+    .await;
+    let (_service, socket) = spawn_vm_pool(tmp.path(), &wrapper, 2).await;
+    let client: Client<TasksProtocol> = Client::connect(&socket).await.unwrap();
+
+    let store = Arc::new(Store::open(tmp.path().join("tasks.db")).await.unwrap());
+    let (_project, task) = insert_project_and_task(&store, "Needs work", "The issue body.").await;
+
+    let scout = Scout::new(
+        store.clone(),
+        client.handle(),
+        ScoutConfig {
+            image: "agent:v1".into(),
+            vm_config: VmConfig::default(),
+            timeout: Duration::from_secs(300),
+        },
+    );
+    let target = ScoutTarget {
+        repo_clone_url: repo_url,
+        base_branch: "main".into(),
+    };
+
+    // First pass: a fresh task, so no "Previous attempt" anywhere.
+    let first = scout.dispatch(task.clone(), &target).await.expect("first");
+    assert!(
+        !first.content.contains("## Previous attempt"),
+        "a fresh task's prompt must be unchanged"
+    );
+
+    // Review it back.
+    const FEEDBACK: &str = "Section 3 is underspecified — name the files.";
+    store
+        .review_spec(
+            &first.id,
+            SpecQueueStatus::NeedsRevision,
+            Some(FEEDBACK.to_string()),
+        )
+        .await
+        .unwrap();
+
+    // Re-dispatch: the task is back in `New`.
+    let requeued = store.get_task(&task.id).await.unwrap().unwrap();
+    assert_eq!(requeued.state, TaskState::New);
+    let second = scout.dispatch(requeued, &target).await.expect("second");
+
+    assert!(
+        second.content.contains(FEEDBACK),
+        "re-scout prompt is missing the reviewer's feedback:\n{}",
+        second.content
+    );
+    assert!(
+        second.content.contains("## Previous attempt"),
+        "re-scout prompt is missing the Previous attempt section"
+    );
+    assert!(
+        second.content.contains("needs_revision"),
+        "re-scout prompt should name the verdict"
+    );
+    // The prior spec travels with the feedback — feedback about "section 3" is
+    // meaningless without section 3.
+    assert!(
+        second.content.contains("### Received prompt"),
+        "the prior spec's own text should be quoted into the new prompt"
+    );
+}
+
+/// #762: a scout whose agent never reports back is ended by the deadline
+/// rather than holding its slot forever.
+#[tokio::test]
+async fn a_scout_that_never_reports_back_times_out() {
+    let supervisor_bin = cargo_build("scout-supervisor").await;
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = make_fixture_repo(tmp.path(), "fixture-repo").await;
+    let repo_url = format!("file://{}", repo.display());
+    let workdir_root = tmp.path().join("scout-workdirs");
+    tokio::fs::create_dir_all(&workdir_root).await.unwrap();
+
+    // A 10s sleep against a 2s deadline. Deliberately not 300s: deallocating a
+    // supervisor *process* does not kill the agent under it (SupervisorRuntime
+    // ::stop is a no-op and the supervisor is blocked on child.wait()), so a
+    // long-sleeping stub keeps the test binary's inherited stderr open and makes
+    // piped `cargo test` output look hung for the sleep's duration. 5x the
+    // deadline is margin enough — keep the ratio if you retune.
+    let wrapper =
+        write_supervisor_wrapper(tmp.path(), &supervisor_bin, "sleep 10", &workdir_root).await;
+    let (service, socket) = spawn_vm_pool(tmp.path(), &wrapper, 2).await;
+    let client: Client<TasksProtocol> = Client::connect(&socket).await.unwrap();
+
+    let store = Arc::new(Store::open(tmp.path().join("tasks.db")).await.unwrap());
+    let (_project, task) = insert_project_and_task(&store, "Hangs", "never finishes").await;
+
+    let scout = Scout::new(
+        store.clone(),
+        client.handle(),
+        ScoutConfig {
+            image: "agent:v1".into(),
+            vm_config: VmConfig::default(),
+            timeout: Duration::from_secs(2),
+        },
+    );
+    let target = ScoutTarget {
+        repo_clone_url: repo_url,
+        base_branch: "main".into(),
+    };
+
+    let err = scout
+        .dispatch(task.clone(), &target)
+        .await
+        .expect_err("should time out");
+    assert!(
+        matches!(err, tasks::scout::ScoutError::Timeout { secs: 2 }),
+        "unexpected error: {err:?}"
+    );
+
+    // Session failed with a timeout reason, task returned for retry.
+    let sessions = store.list_sessions().await.unwrap();
+    let session = sessions.last().expect("a session row");
+    assert_eq!(session.status, SessionStatus::ScoutFailed);
+    assert!(
+        session
+            .exit_reason
+            .as_deref()
+            .is_some_and(|r| r.contains("timed out")),
+        "exit_reason: {:?}",
+        session.exit_reason
+    );
+    assert_eq!(
+        store.get_task(&task.id).await.unwrap().unwrap().state,
+        TaskState::New
+    );
+
+    // Cancellation is deallocation: the VM must be gone, or the slot leaks.
+    assert!(
+        service.pool.list().await.is_empty(),
+        "timed-out scout left its VM allocated"
     );
 }

--- a/crates/tasks/tests/transcript.rs
+++ b/crates/tasks/tests/transcript.rs
@@ -1,0 +1,217 @@
+//! Transcript capture end to end (#759): a real vm-pool service, the real
+//! scout-supervisor binary, real SQLite, a real git repo and a stub agent that
+//! emits stream-json. No mocks — see CLAUDE.md.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use vm_pool_client::Client;
+use vm_pool_protocol::VmConfig;
+
+use tasks::models::{
+    GhState, Project, ProjectId, SessionStatus, Task, TaskId, TaskState, TranscriptStream,
+};
+use tasks::scout::{Scout, ScoutConfig, ScoutTarget};
+use tasks::store::Store;
+use tasks_protocol::TasksProtocol;
+
+mod common;
+use common::{
+    cargo_build, make_fixture_repo, spawn_vm_pool, stream_json_agent_path, write_supervisor_wrapper,
+};
+
+async fn insert_project_and_task(store: &Store) -> (Project, Task) {
+    let project = Project {
+        id: ProjectId::new(),
+        repo_owner: "test".into(),
+        repo_name: "repo".into(),
+        added_at: Utc::now(),
+    };
+    store.insert_project(&project).await.unwrap();
+    let now = Utc::now();
+    let task = Task {
+        id: TaskId::new(),
+        project_id: project.id.clone(),
+        gh_issue_number: 1,
+        title: "Transcribed task".into(),
+        body: "Do the thing".into(),
+        labels: vec![],
+        gh_state: GhState::Open,
+        state: TaskState::New,
+        priority: 0,
+        manual_rank: None,
+        dispatch_attempts: 0,
+        ingested_at: now,
+        updated_at: now,
+    };
+    store.insert_task(&task).await.unwrap();
+    (project, task)
+}
+
+/// The acceptance criterion: a scout run leaves a queryable transcript, and the
+/// final `result` record is costed onto the session.
+#[tokio::test]
+async fn a_scout_run_produces_a_queryable_transcript_and_usage() {
+    let supervisor_bin = cargo_build("scout-supervisor").await;
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = make_fixture_repo(tmp.path(), "fixture-repo").await;
+    let repo_url = format!("file://{}", repo.display());
+    let workdir_root = tmp.path().join("scout-workdirs");
+    tokio::fs::create_dir_all(&workdir_root).await.unwrap();
+    let wrapper = write_supervisor_wrapper(
+        tmp.path(),
+        &supervisor_bin,
+        stream_json_agent_path().to_str().unwrap(),
+        &workdir_root,
+    )
+    .await;
+    let (_service, socket) = spawn_vm_pool(tmp.path(), &wrapper, 2).await;
+    let client: Client<TasksProtocol> = Client::connect(&socket).await.unwrap();
+
+    let store = Arc::new(Store::open(tmp.path().join("tasks.db")).await.unwrap());
+    let (_project, task) = insert_project_and_task(&store).await;
+
+    let scout = Scout::new(
+        store.clone(),
+        client.handle(),
+        ScoutConfig {
+            image: "agent:v1".into(),
+            vm_config: VmConfig::default(),
+            timeout: Duration::from_secs(300),
+        },
+    );
+    let spec = scout
+        .dispatch(
+            task.clone(),
+            &ScoutTarget {
+                repo_clone_url: repo_url,
+                base_branch: "main".into(),
+            },
+        )
+        .await
+        .expect("dispatch");
+
+    let session_id = spec.session_id.clone();
+    let lines = store.transcript_since(&session_id, 0, 1000).await.unwrap();
+    assert!(!lines.is_empty(), "the run recorded no transcript at all");
+
+    // Dense, 1-based, in order — that is what `?since=` paging relies on.
+    assert_eq!(
+        lines.iter().map(|l| l.seq).collect::<Vec<_>>(),
+        (1..=lines.len() as i64).collect::<Vec<_>>()
+    );
+
+    let joined = lines
+        .iter()
+        .map(|l| l.line.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        joined.contains(r#""type":"assistant""#),
+        "stream-json assistant messages missing from:\n{joined}"
+    );
+    assert!(
+        joined.contains(r#""type":"tool_use""#) || joined.contains(r#""name":"Read""#),
+        "tool calls missing from the transcript:\n{joined}"
+    );
+    assert!(
+        lines.iter().all(|l| l.session_id == session_id),
+        "another session's lines leaked in"
+    );
+    assert!(
+        lines.iter().any(|l| l.stream == TranscriptStream::Stdout),
+        "no stdout lines recorded"
+    );
+
+    // The final result record is parsed onto the session rather than left in
+    // the transcript only.
+    let session = store.get_session(&session_id).await.unwrap().unwrap();
+    assert_eq!(session.status, SessionStatus::ScoutSucceeded);
+    let usage = session.usage.expect("usage parsed from the result record");
+    assert_eq!(usage.input_tokens, Some(1200));
+    assert_eq!(usage.output_tokens, Some(340));
+    assert_eq!(usage.cache_read_input_tokens, Some(880));
+    assert_eq!(usage.total_cost_usd, Some(0.0421));
+    assert_eq!(usage.num_turns, Some(3));
+
+    // Transcripts are a separate channel: nothing from them may reach the
+    // event log, which every client refetches on.
+    let events = store.events_since(0).await.unwrap();
+    assert!(
+        !events
+            .iter()
+            .any(|e| format!("{:?}", e.payload).contains("tool_use")),
+        "transcript content leaked into the event log"
+    );
+    assert!(
+        events.len() < 20,
+        "the event log should stay low-rate, got {} events",
+        events.len()
+    );
+}
+
+/// A transcript is complete by the time the session's completion event lands —
+/// a client that refetches on `session_completed` must not find a truncated one.
+#[tokio::test]
+async fn the_transcript_is_complete_before_the_session_completes() {
+    let supervisor_bin = cargo_build("scout-supervisor").await;
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = make_fixture_repo(tmp.path(), "fixture-repo").await;
+    let repo_url = format!("file://{}", repo.display());
+    let workdir_root = tmp.path().join("scout-workdirs");
+    tokio::fs::create_dir_all(&workdir_root).await.unwrap();
+    let wrapper = write_supervisor_wrapper(
+        tmp.path(),
+        &supervisor_bin,
+        stream_json_agent_path().to_str().unwrap(),
+        &workdir_root,
+    )
+    .await;
+    let (_service, socket) = spawn_vm_pool(tmp.path(), &wrapper, 2).await;
+    let client: Client<TasksProtocol> = Client::connect(&socket).await.unwrap();
+
+    let store = Arc::new(Store::open(tmp.path().join("tasks.db")).await.unwrap());
+    let (_project, task) = insert_project_and_task(&store).await;
+
+    let mut events = store.subscribe_events();
+
+    let scout = Scout::new(
+        store.clone(),
+        client.handle(),
+        ScoutConfig {
+            image: "agent:v1".into(),
+            vm_config: VmConfig::default(),
+            timeout: Duration::from_secs(300),
+        },
+    );
+    let spec = scout
+        .dispatch(
+            task.clone(),
+            &ScoutTarget {
+                repo_clone_url: repo_url,
+                base_branch: "main".into(),
+            },
+        )
+        .await
+        .expect("dispatch");
+
+    // Find the completion event, then read the transcript: everything the run
+    // produced must already be readable.
+    let mut saw_completion = false;
+    while let Ok(event) = events.try_recv() {
+        if format!("{:?}", event.payload).contains("SessionCompleted") {
+            saw_completion = true;
+        }
+    }
+    assert!(saw_completion, "no session_completed event was appended");
+
+    let lines = store
+        .transcript_since(&spec.session_id, 0, 1000)
+        .await
+        .unwrap();
+    assert!(
+        lines.iter().any(|l| l.line.contains(r#""type":"result""#)),
+        "the final result line was not persisted before completion"
+    );
+}

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -63,6 +63,55 @@ the server only.
 - `GET /events?since=&limit=` — catch-up (default limit 100);
   `GET /events/stream` — SSE, each `data:` line is one Event JSON.
 
+## Session transcripts
+
+Agent output is a **separate channel from the event log**, on purpose (see
+*Event volume* below). Two endpoints, both scoped to one session:
+
+- `GET /sessions/{id}/transcript?since=<seq>&limit=` — catch-up read. Returns
+  `[{session_id, seq, timestamp, stream, line}]`, oldest first. `stream` is
+  `stdout` \| `stderr`. `since` is **inclusive**, matching `/events?since=` — a
+  tailing client passes `last_seq + 1`. `limit` defaults to 500, capped at 2000.
+- `GET /sessions/{id}/transcript/stream` — SSE tail. Replays from `since` (all
+  of it, paging internally — no `limit`, so the stream can't silently skip a
+  span) and then streams live lines, with the same 15s keepalive as
+  `/events/stream`.
+
+`seq` is dense per session and assigned server-side at persist time. An empty
+transcript means *nothing was recorded* — sessions predating transcript capture
+have none — so render it as "no transcript", never as a failure.
+
+Lines are the agent's stream-json output: one JSON object per line (assistant
+messages, thinking, tool calls with their inputs, tool results, and a final
+`result` record). Treat each `line` as opaque text unless you're prepared to
+parse Claude Code's schema — it's forwarded verbatim, and a transcript can
+contain any file the agent read, so it carries the same trust boundary as the
+rest of this API: local SQLite, loopback only, no auth.
+
+`Session` also carries `usage` (`{input_tokens, output_tokens,
+cache_read_input_tokens, cache_creation_input_tokens, total_cost_usd,
+duration_ms, num_turns}`), parsed from that final record. Every field is
+nullable and so is `usage` itself — a renamed upstream key costs a null, not a
+failed scout.
+
+Two caps bound a session server-side: 32 KiB per line (over-long lines are cut
+and marked) and 8 MiB per session, after which one notice is written and
+recording stops — the scout itself is unaffected. Lines lost to queue pressure
+are announced inline as `[tasks] N transcript line(s) dropped here` rather than
+left as an invisible gap.
+
+## Event volume
+
+The event log is deliberately low-rate. Clients are told to treat events as
+invalidation signals and refetch, so every event costs every connected client a
+request — which only works while events are rare and meaningful (a state
+change, a spec, a mode flip). High-rate data must not go through it.
+
+Transcripts are the worked example: a single scout emits thousands of output
+lines, and only an open session-detail view wants them. They live in their own
+table, their own broadcast channel and their own endpoints, and they never
+touch `append_event`. Apply the same rule to anything similar you add later.
+
 All enums are snake_case strings on the wire:
 
 - `Task.state`: `new` → `scouting` → `spec_ready` → `queued` → `done`, with

--- a/images/scout/Dockerfile
+++ b/images/scout/Dockerfile
@@ -20,6 +20,11 @@ ENV PATH="/home/agent/.cargo/bin:${PATH}"
 # Headless agent invocation. The prompt arrives on stdin; SPEC.md is the
 # artifact. Credentials (ANTHROPIC_API_KEY) are injected per-VM, never baked
 # into the image.
-ENV SCOUT_AGENT_CMD="claude --print --dangerously-skip-permissions"
+# stream-json turns stdout into typed JSON-lines (assistant messages, thinking,
+# tool calls with inputs, tool results, and a final result record with usage and
+# cost) which the server persists as the session transcript. --verbose is
+# mandatory: `--print --output-format stream-json` without it exits with
+# "requires --verbose" and every scout fails at the agent step.
+ENV SCOUT_AGENT_CMD="claude --print --output-format stream-json --verbose --dangerously-skip-permissions"
 
 ENTRYPOINT ["/usr/local/bin/scout-supervisor"]


### PR DESCRIPTION
Builder output for three approved specs, batched into one branch. Batching is the design intent: specs are text, so N of them compose into one implementation pass where N feature branches would conflict. All three touch `crates/tasks/src/scout.rs`, so landing them separately would have meant three rebases.

Implemented from spec markdown only — no scout branch was fetched, read, or diffed.

| Issue | Spec | Complexity |
| --- | --- | --- |
| #759 Capture scout transcripts | `spec_b68da1a1d9694e09831ac4167ed245be` | medium |
| #760 Feed needs_revision feedback into the re-scout prompt | `spec_a6ab9c40e36a4cb7a9589bf35099f180` | simple |
| #762 Scout wall-clock timeout | `spec_356f8078427b49e285af22345c783fb7` | simple |

## #759 — transcripts

New `transcript_lines` table keyed `(session_id, seq)` with `ON DELETE CASCADE`, a dedicated broadcast channel, and two endpoints: `GET /sessions/{id}/transcript?since=&limit=` and `GET /sessions/{id}/transcript/stream`. `since` is inclusive, matching `/events?since=`.

Transcripts never enter the event log. That channel is deliberately low-rate because clients refetch on every event; a single scout emits thousands of lines and only an open session-detail view wants them. `docs/clients.md` gains the *Event volume* section it was already citing but never had.

Two subtleties worth reviewing:
- **The SSE replay pages until it catches up** rather than sending one `limit`-sized page and attaching the tail. The naive version silently jumps from the end of page one to the newest line, and a stream is exactly where that hole goes unnoticed. Guarded by `transcript_stream_replays_past_one_page_without_a_hole`, which uses an exact multiple of the page size — the boundary where a loop stops early.
- **Subscribe before the backfill read, filter after**, so a line appended between the two steps arrives live instead of vanishing.

Writes happen off the drain loop (bounded queue + `try_send`, batched 64/transaction), because that loop is also what waits for `Completed` and reads a broadcast that drops for slow consumers. Caps: 32 KiB/line, 8 MiB/session. Dropped lines are announced inline rather than left as an invisible gap — `seq` is assigned at persist time, so a gap would otherwise be undetectable.

**Operational note:** this changes `SCOUT_AGENT_CMD` in `images/scout/Dockerfile`, and a Dockerfile edit doesn't change the running image. Transcripts won't flow from live scouts until `make image-scout` is run on a macOS host with the cross toolchain and `apple/container`. The API and persistence work as soon as this merges; there's just nothing to read until then.

## #760 — re-scout feedback

`Store::latest_reviewed_spec` joins `specs` to `spec_queue` at dispatch time (no new state) and splices a `## Previous attempt` section between the issue body and the instructions: verdict, feedback verbatim, and the prior spec quoted. Feedback like "section 3 is underspecified" is useless without section 3, so both travel or neither does.

Most recent reviewed attempt only — each spec is a full rewrite, so stacking them buries the feedback that applies. The quoting fence is one backtick longer than the longest run inside the spec, because specs routinely contain their own code fences.

The barrier holds: specs and reviews are text deliverables, scout code and branches still never move forward.

## #762 — timeout

`SCOUT_TIMEOUT_SECS`, default 3600, enforced dispatcher-side and measured from entry to `dispatch` so allocation is charged to the budget. Default sits deliberately below vm-pool's own `vm_timeout` (7200) — above it, infrastructure would reap the VM first and we'd report a stream error instead of our own timeout. Raising one means raising the other; noted in the CLAUDE.md table.

Cancellation is deallocation (there is no in-band Cancel command), and a timeout routes through `ScoutError` so `record_dispatch_failure` and the three-strike rejection apply unchanged.

## Verification

- `cargo fmt --all --check` clean
- `cargo test --workspace` green — 214 tests, including 3 new integration suites against a real vm-pool service, the real supervisor binary, real SQLite and real git repos (no mocks)
- `cargo clippy --workspace --all-targets`: **+1 warning**, `TranscriptStream::from_str` "can be confused for `std::str::FromStr`". `models.rs` already emits this for all six of its persisted enums (10 before, 11 after). Matching the file's established pattern beat silencing one enum differently from its siblings — flagging it explicitly since the bar is normally "no new warnings".

Two things the specs surfaced that are worth knowing independently of this PR:
- `.cargo/config.toml` pins `linker = "aarch64-unknown-linux-gnu-gcc"`, which doesn't exist on a native aarch64 Linux box, so every scout works around it per-invocation. Correct for the machine it was written for; a scout tax everywhere else.
- The stream-json `system` init record includes cwd, model, the full tool list and `apiKeySource` (name, not value). Transcripts are verbatim agent output and can contain any file the agent read — same trust boundary as specs, but worth knowing before anyone proposes syncing them anywhere.