### PR TITLE
App: live session transcripts, usage badges, closed-issue chips

### DIFF
--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -17,7 +17,8 @@ final class AppModel {
     var connectionError: String?
     var lastRefreshed: Date?
 
-    private let client = TasksClient()
+    // Non-private: session-detail views borrow it for transcript tailing.
+    let client = TasksClient()
     private var started = false
 
     func task(_ id: String) -> TaskItem? {

--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -186,6 +186,12 @@ struct TaskRow: View {
                 .foregroundStyle(.secondary)
             }
             Spacer()
+            // A closed issue on a non-terminal task usually means the work
+            // shipped outside the pipeline — make that legible.
+            if task.ghState == .closed {
+                StatusBadge(text: "closed", color: .purple)
+                    .help("GitHub issue is closed (as of the last poll)")
+            }
             StatusBadge(text: task.state.wire, color: task.state.color)
         }
         .padding(.vertical, 2)

--- a/app/Tasks/DetailViews.swift
+++ b/app/Tasks/DetailViews.swift
@@ -231,22 +231,47 @@ struct SessionDetailView: View {
                     }
                 }
 
+                if let usage = session.usage {
+                    UsageBadgeRow(usage: usage)
+                }
+
                 if let reason = session.exitReason, !reason.isEmpty {
                     Callout(title: "Exit reason", text: reason, color: .red)
                 }
 
                 Divider()
 
-                // Transcript pane lands here once the server persists scout
-                // output — docs/plans/2026-08-09-session-transcripts.md.
-                ContentUnavailableView {
-                    Label("No transcript", systemImage: "text.bubble")
-                } description: {
-                    Text("The server doesn't capture scout output yet.")
-                }
+                TranscriptView(session: session)
             }
             .padding(16)
             .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+/// Compact chips for what a scout run cost, from the agent's final result
+/// record. Renders whatever fields survived parsing; each is independently
+/// optional.
+struct UsageBadgeRow: View {
+    let usage: SessionUsage
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if let cost = usage.totalCostUsd {
+                StatusBadge(text: String(format: "$%.2f", cost), color: .green)
+            }
+            if let turns = usage.numTurns {
+                StatusBadge(text: "\(turns) turns", color: .blue)
+            }
+            if let input = usage.inputTokens {
+                StatusBadge(text: "\(input.formatted()) in", color: .secondary)
+            }
+            if let output = usage.outputTokens {
+                StatusBadge(text: "\(output.formatted()) out", color: .secondary)
+            }
+            if let cached = usage.cacheReadInputTokens, cached > 0 {
+                StatusBadge(text: "\(cached.formatted()) cached", color: .secondary)
+            }
         }
     }
 }

--- a/app/Tasks/Models.swift
+++ b/app/Tasks/Models.swift
@@ -105,6 +105,54 @@ struct ScoutSession: Decodable, Identifiable, Hashable {
     let startedAt: Date
     let completedAt: Date?
     let exitReason: String?
+    /// Parsed from the agent's final stream-json `result` record. Nil for
+    /// sessions predating transcript capture or that never reached a result.
+    let usage: SessionUsage?
+}
+
+/// What one agent run cost. Everything optional — the shape belongs to
+/// Claude Code, and a renamed upstream key costs a null, not a crash.
+struct SessionUsage: Decodable, Hashable {
+    let inputTokens: UInt64?
+    let outputTokens: UInt64?
+    let cacheReadInputTokens: UInt64?
+    let cacheCreationInputTokens: UInt64?
+    let totalCostUsd: Double?
+    let durationMs: UInt64?
+    let numTurns: UInt64?
+}
+
+/// One line of agent output. `seq` is dense per session, assigned by the
+/// server at persist time; tailing clients resume with `since = last + 1`.
+struct TranscriptLine: Decodable, Identifiable, Hashable {
+    let sessionId: String
+    let seq: Int64
+    let timestamp: Date
+    let stream: TranscriptStream
+    let line: String
+
+    var id: Int64 { seq }
+}
+
+enum TranscriptStream: WireEnum {
+    case stdout, stderr
+    case unknown(String)
+
+    init(wire: String) {
+        switch wire {
+        case "stdout": self = .stdout
+        case "stderr": self = .stderr
+        default: self = .unknown(wire)
+        }
+    }
+
+    var wire: String {
+        switch self {
+        case .stdout: "stdout"
+        case .stderr: "stderr"
+        case .unknown(let raw): raw
+        }
+    }
 }
 
 enum SessionStatus: WireEnum {

--- a/app/Tasks/TasksClient.swift
+++ b/app/Tasks/TasksClient.swift
@@ -53,6 +53,47 @@ struct TasksClient: Sendable {
         return try await post("spec-queue/\(specId)/review", body: body)
     }
 
+    /// Catch-up read of a session transcript. `since` is inclusive; a tailing
+    /// client passes `last_seq + 1`. Server default limit 500, cap 2000.
+    func transcript(sessionId: String, since: Int64 = 0, limit: Int = 500)
+        async throws -> [TranscriptLine]
+    {
+        try await get(
+            "sessions/\(sessionId)/transcript",
+            query: [
+                URLQueryItem(name: "since", value: "\(since)"),
+                URLQueryItem(name: "limit", value: "\(limit)"),
+            ])
+    }
+
+    /// SSE tail of a session transcript: the server replays everything from
+    /// `since` (paging internally, no holes), then streams live lines.
+    /// Subscribe only while a session-detail view is open.
+    func transcriptStream(sessionId: String, since: Int64 = 0)
+        -> AsyncThrowingStream<TranscriptLine, Error>
+    {
+        let url = baseURL
+            .appending(path: "sessions/\(sessionId)/transcript/stream")
+            .appending(queryItems: [URLQueryItem(name: "since", value: "\(since)")])
+        return AsyncThrowingStream { continuation in
+            let reader = Task {
+                do {
+                    let (bytes, response) = try await URLSession.shared.bytes(from: url)
+                    try Self.checkOK(response)
+                    let decoder = Self.makeDecoder()
+                    for try await raw in bytes.lines where raw.hasPrefix("data: ") {
+                        let payload = Data(raw.dropFirst("data: ".count).utf8)
+                        continuation.yield(try decoder.decode(TranscriptLine.self, from: payload))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in reader.cancel() }
+        }
+    }
+
     enum SSESignal: Sendable {
         /// Response head received — the server-side subscription exists, so a
         /// snapshot taken now can't miss events (clients.md: stream first,
@@ -96,8 +137,12 @@ struct TasksClient: Sendable {
         return try Self.makeDecoder().decode(T.self, from: data)
     }
 
-    private func get<T: Decodable>(_ path: String) async throws -> T {
-        let (data, response) = try await URLSession.shared.data(from: baseURL.appending(path: path))
+    private func get<T: Decodable>(_ path: String, query: [URLQueryItem] = []) async throws -> T {
+        var url = baseURL.appending(path: path)
+        if !query.isEmpty {
+            url = url.appending(queryItems: query)
+        }
+        let (data, response) = try await URLSession.shared.data(from: url)
         try Self.checkOK(response, body: data)
         return try Self.makeDecoder().decode(T.self, from: data)
     }

--- a/app/Tasks/TranscriptView.swift
+++ b/app/Tasks/TranscriptView.swift
@@ -1,0 +1,239 @@
+import SwiftUI
+
+/// Live transcript pane for one scout session. Subscribes to the per-session
+/// SSE stream only while visible (`.task(id:)` tears it down on close or
+/// session change), which is the contract clients.md asks for — transcript
+/// lines never ride the main event stream.
+struct TranscriptView: View {
+    @Environment(AppModel.self) private var model
+    let session: ScoutSession
+
+    @State private var lines: [TranscriptLine] = []
+    @State private var streamError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if lines.isEmpty {
+                // Empty means nothing was recorded (pre-transcript sessions),
+                // never a failure.
+                ContentUnavailableView {
+                    Label("No transcript", systemImage: "text.bubble")
+                } description: {
+                    Text("No output was recorded for this session.")
+                }
+            } else {
+                LazyVStack(alignment: .leading, spacing: 6) {
+                    ForEach(lines) { line in
+                        TranscriptLineView(line: line)
+                    }
+                }
+            }
+            if let streamError {
+                Label(streamError, systemImage: "bolt.horizontal.circle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .task(id: session.id) { await follow() }
+    }
+
+    private func follow() async {
+        lines = []
+        streamError = nil
+        var since: Int64 = 0
+        while !Task.isCancelled {
+            do {
+                for try await line in model.client.transcriptStream(
+                    sessionId: session.id, since: since)
+                {
+                    lines.append(line)
+                    since = line.seq + 1
+                    streamError = nil
+                }
+            } catch is CancellationError {
+                return
+            } catch let error as APIError where error.status == 404 {
+                // Pre-transcript server or vanished session — that's the
+                // empty state, not a failure.
+                return
+            } catch {
+                streamError = error.localizedDescription
+            }
+            // Stream closed. Keep tailing only if the session may still emit.
+            let current = model.session(session.id) ?? session
+            if current.completedAt != nil {
+                return
+            }
+            try? await Task.sleep(for: .seconds(3))
+        }
+    }
+}
+
+/// One transcript line. stdout lines are Claude Code stream-json records —
+/// parsed leniently into readable blocks; anything unparseable (and all
+/// stderr) renders as raw monospaced text so nothing is ever hidden.
+struct TranscriptLineView: View {
+    let line: TranscriptLine
+
+    var body: some View {
+        switch TranscriptRecord(line) {
+        case .assistantBlocks(let blocks):
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                AssistantBlockView(block: block)
+            }
+        case .toolResult(let summary, let isError):
+            DisclosureGroup {
+                Text(summary)
+                    .font(.caption.monospaced())
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } label: {
+                Label(
+                    isError ? "tool error" : "tool result",
+                    systemImage: isError ? "xmark.circle" : "arrow.turn.down.right")
+                .font(.caption)
+                .foregroundStyle(isError ? .red : .secondary)
+            }
+        case .systemInit(let model):
+            Label(model.map { "session started · \($0)" } ?? "session started",
+                  systemImage: "power")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .result(let summary):
+            Label(summary, systemImage: "flag.checkered")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+                .padding(.top, 4)
+        case .raw:
+            Text(line.line)
+                .font(.caption.monospaced())
+                .foregroundStyle(line.stream == .stderr ? .orange : .secondary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+struct AssistantBlockView: View {
+    let block: AssistantBlock
+
+    var body: some View {
+        switch block {
+        case .text(let text):
+            Text(text)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        case .thinking(let text):
+            DisclosureGroup {
+                Text(text)
+                    .font(.callout.italic())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } label: {
+                Label("Thinking", systemImage: "brain")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        case .toolUse(let name, let input):
+            DisclosureGroup {
+                Text(input)
+                    .font(.caption.monospaced())
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } label: {
+                Label(name, systemImage: "wrench.and.screwdriver")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.blue)
+            }
+        }
+    }
+}
+
+enum AssistantBlock {
+    case text(String)
+    case thinking(String)
+    case toolUse(name: String, input: String)
+}
+
+/// Lenient projection of one stream-json record. The schema belongs to
+/// Claude Code; anything unrecognized falls through to `.raw`.
+enum TranscriptRecord {
+    case assistantBlocks([AssistantBlock])
+    case toolResult(summary: String, isError: Bool)
+    case systemInit(model: String?)
+    case result(summary: String)
+    case raw
+
+    init(_ line: TranscriptLine) {
+        guard line.stream == .stdout,
+            let data = line.line.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let type = json["type"] as? String
+        else {
+            self = .raw
+            return
+        }
+
+        switch type {
+        case "assistant":
+            let content = (json["message"] as? [String: Any])?["content"] as? [[String: Any]] ?? []
+            let blocks: [AssistantBlock] = content.compactMap { block in
+                switch block["type"] as? String {
+                case "text":
+                    return (block["text"] as? String).map(AssistantBlock.text)
+                case "thinking":
+                    return (block["thinking"] as? String).map(AssistantBlock.thinking)
+                case "tool_use":
+                    let name = block["name"] as? String ?? "tool"
+                    let input = Self.compactJSON(block["input"]) ?? ""
+                    return .toolUse(name: name, input: input)
+                default:
+                    return nil
+                }
+            }
+            self = blocks.isEmpty ? .raw : .assistantBlocks(blocks)
+        case "user":
+            let content = (json["message"] as? [String: Any])?["content"] as? [[String: Any]] ?? []
+            guard let result = content.first(where: { $0["type"] as? String == "tool_result" })
+            else {
+                self = .raw
+                return
+            }
+            let isError = result["is_error"] as? Bool ?? false
+            let summary = Self.flattenToolResult(result["content"]) ?? "(empty result)"
+            self = .toolResult(summary: summary, isError: isError)
+        case "system":
+            self = .systemInit(model: json["model"] as? String)
+        case "result":
+            var parts: [String] = [json["subtype"] as? String ?? "result"]
+            if let turns = json["num_turns"] as? Int { parts.append("\(turns) turns") }
+            if let cost = json["total_cost_usd"] as? Double {
+                parts.append(String(format: "$%.2f", cost))
+            }
+            if let ms = json["duration_ms"] as? Int {
+                parts.append(Duration.milliseconds(ms).formatted(
+                    .units(allowed: [.hours, .minutes, .seconds], width: .abbreviated)))
+            }
+            self = .result(summary: parts.joined(separator: " · "))
+        default:
+            self = .raw
+        }
+    }
+
+    private static func flattenToolResult(_ content: Any?) -> String? {
+        if let text = content as? String { return text }
+        if let blocks = content as? [[String: Any]] {
+            let texts = blocks.compactMap { $0["text"] as? String }
+            if !texts.isEmpty { return texts.joined(separator: "\n") }
+        }
+        return compactJSON(content)
+    }
+
+    private static func compactJSON(_ value: Any?) -> String? {
+        guard let value, JSONSerialization.isValidJSONObject(value),
+            let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+        else { return value.map { "\($0)" } }
+        return String(data: data, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
Client-side absorption of #757 / #765 / #767, per the updated `docs/clients.md`.

## Transcripts (#767)
- `TranscriptView` tails `GET /sessions/{id}/transcript/stream`, subscribed **only while session detail is open** (`.task(id:)` tears down on close/switch) — transcript lines never touch the main event loop, honoring the event-volume design.
- One SSE connection does catch-up + live via the server's replay-then-live semantics; reconnects resume at `last_seq + 1` (inclusive `since`).
- Chat-style rendering with a lenient stream-json parser: assistant text prominent; thinking, `tool_use` (inputs), `tool_result` as collapsed disclosures; `result` footer (turns · cost · duration). Unrecognized records, stderr, and `[tasks]` cap/drop markers render as raw monospaced lines — nothing is hidden.
- Empty transcript renders as "no output recorded", never a failure; a 404 from a pre-transcript server is treated the same.

## Usage
`Session.usage` decodes with every field optional; session detail shows cost / turns / tokens-in / tokens-out / cached badges when present.

## Stale tasks (#765)
Nothing to remove — the app never had client-side filtering and now renders the reconciled `/tasks` default verbatim. The new `task_gh_state_changed` event is handled for free by the refetch-on-any-event loop.

## Queued-but-shipped legibility
Task rows show a purple `closed` chip (last-poll tooltip) beside the pipeline state when `gh_state=closed` — for the rows implemented outside the pipeline until Builder v0 lands.

## Verification (no mocks)
Scratch `tasks serve` built from current main, rows seeded into its real SQLite, the app's actual `Models.swift`+`TasksClient.swift` compiled into a CLI probe: `/tasks` hides `closed+new` / keeps `closed+queued`; usage decodes; transcript catch-up returns all lines with `since` inclusive; SSE replays the backlog in order; unknown session surfaces the server's real 404 message. Decoder config untouched for #763's fixture tests.