### PR TITLE
Fix drag-reorder flooding the queue with hidden closed tasks

### DIFF
--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -51,19 +51,22 @@ final class AppModel {
         await refresh()
     }
 
-    /// Optimistic drag-reorder; the server's answer (or a refresh on failure)
-    /// is authoritative.
+    /// Optimistic drag-reorder. The response body is deliberately discarded:
+    /// POST /queue/reorder returns the *unfiltered* task list, which is not
+    /// the queue projection GET /tasks serves — consuming it floods the list
+    /// with hidden closed tasks mid-gesture. GET /tasks stays the single
+    /// source of truth; refresh() reconciles either way.
     func moveTasks(from source: IndexSet, to destination: Int) {
         var reordered = tasks
         reordered.move(fromOffsets: source, toOffset: destination)
         tasks = reordered
         Task {
             do {
-                tasks = try await client.reorderQueue(reordered.map(\.id))
+                _ = try await client.reorderQueue(reordered.map(\.id))
             } catch {
                 connectionError = error.localizedDescription
-                await refresh()
             }
+            await refresh()
         }
     }
 


### PR DESCRIPTION
Dragging a queue row replaced the visible 9-task list with the unfiltered 32-task list: `POST /queue/reorder` returns `store.list_tasks()` (unfiltered, [server.rs:212](../blob/main/crates/tasks/src/server.rs#L212)) while `GET /tasks` defaults to `list_active_tasks()` (#765). Applying the response body — as clients.md's "apply the response optimistically" suggests — resurrected hidden `closed+new` rows, and the 23-row animated insertion mid-gesture presented as duplicate rows.

App-side fix: keep the optimistic local order, discard the reorder response body, and refetch `GET /tasks` — the queue's single projection — to reconcile.

Server-side follow-up (not in this PR): `reorder_queue` should return the same filtered projection as the default `GET /tasks`, so every client can safely apply write responses per clients.md.