### PR TITLE
Fix drag-reorder flooding the queue with hidden closed tasks

### DIFF
--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -51,19 +51,22 @@ final class AppModel {
         await refresh()
     }
 
-    /// Optimistic drag-reorder; the server's answer (or a refresh on failure)
-    /// is authoritative.
+    /// Optimistic drag-reorder. The response body is deliberately discarded:
+    /// POST /queue/reorder returns the *unfiltered* task list, which is not
+    /// the queue projection GET /tasks serves — consuming it floods the list
+    /// with hidden closed tasks mid-gesture. GET /tasks stays the single
+    /// source of truth; refresh() reconciles either way.
     func moveTasks(from source: IndexSet, to destination: Int) {
         var reordered = tasks
         reordered.move(fromOffsets: source, toOffset: destination)
         tasks = reordered
         Task {
             do {
-                tasks = try await client.reorderQueue(reordered.map(\.id))
+                _ = try await client.reorderQueue(reordered.map(\.id))
             } catch {
                 connectionError = error.localizedDescription
-                await refresh()
             }
+            await refresh()
         }
     }
 

--- a/crates/tasks/src/server.rs
+++ b/crates/tasks/src/server.rs
@@ -204,12 +204,15 @@ struct ReorderQueue {
     task_ids: Vec<TaskId>,
 }
 
+/// Returns the same projection as the default `GET /tasks` — a client applies
+/// the response in place of its list, so handing back the unfiltered variant
+/// here would resurrect the closed-intake rows the default read hides.
 async fn reorder_queue(
     State(store): State<Arc<Store>>,
     Json(body): Json<ReorderQueue>,
 ) -> ApiResult<Json<Vec<Task>>> {
     store.set_queue_order(&body.task_ids).await?;
-    Ok(Json(store.list_tasks().await?))
+    Ok(Json(store.list_active_tasks().await?))
 }
 
 // --- sessions ---
@@ -722,6 +725,28 @@ mod tests {
             .collect();
         assert_eq!(all.len(), 3);
         assert!(all.contains(&closed_new.id));
+
+        // The reorder response is the same projection as the default read — a
+        // client swaps it in for its list, so the unfiltered variant here
+        // would resurrect the hidden closed-intake rows.
+        let reordered: Vec<TaskId> = http
+            .post(format!("{base}/queue/reorder"))
+            .json(&serde_json::json!({ "task_ids": [open_new.id] }))
+            .send()
+            .await
+            .unwrap()
+            .json::<Vec<Task>>()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        assert!(reordered.contains(&open_new.id));
+        assert!(reordered.contains(&closed_spec_ready.id));
+        assert!(
+            !reordered.contains(&closed_new.id),
+            "reorder must not resurrect hidden closed tasks"
+        );
     }
 
     #[tokio::test]

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -34,7 +34,7 @@ No auth, loopback only — don't build a login flow.
 | UI action | Call | Semantics |
 | --- | --- | --- |
 | Add a repo | `POST /projects` `{"repo_owner","repo_name"}` | 201 with the project; 400 if it already exists |
-| Reorder task queue (drag & drop) | `POST /queue/reorder` `{"task_ids":[...]}` | **Full order, front to back.** Ranks are rewritten 1..N transactionally; any task not listed becomes unranked and sorts after all ranked tasks (then priority desc, then ingested_at). Send the complete on-screen order after every drop. |
+| Reorder task queue (drag & drop) | `POST /queue/reorder` `{"task_ids":[...]}` | **Full order, front to back.** Ranks are rewritten 1..N transactionally; any task not listed becomes unranked and sorts after all ranked tasks (then priority desc, then ingested_at). Send the complete on-screen order after every drop. The response is the same projection as the default `GET /tasks` (closed intake hidden), so it can replace the client's list directly. |
 | Reorder spec queue | `POST /spec-queue/reorder` `{"spec_ids":[...]}` | Same full-order semantics |
 | Review a spec | `POST /spec-queue/{spec_id}/review` `{"status","feedback"?}` | `status` ∈ `approved` \| `needs_revision` \| `rejected` — the three verdicts a reviewer may deliver. `approved` → spec enters the queue for the Builder; `needs_revision` → the task goes back to `new` and will be re-scouted; `rejected` → dead end. `feedback` is free text; include it for `needs_revision` (it's the reviewer's message to the next scout). |
 | Play / pause / stop | `POST /mode` `{"mode":"play"\|"pause"\|"stop"}` | Gates **new** work only. A mode change never interrupts a scout in flight — reflect that in the UI (pausing ≠ cancelling; show in-flight sessions still running). |


### PR DESCRIPTION
POST /queue/reorder returns the unfiltered task list, but GET /tasks
defaults to the filtered queue projection (#765). Consuming the reorder
response body therefore replaced the 9-row queue with all 32 rows mid-
gesture — resurrected closed+new tasks and a 23-row animated insertion
that read as duplication.

The app now discards the reorder response and refetches GET /tasks,
which stays the single source of truth for the queue. Server-side fix
(reorder returning the filtered projection) reported separately.
