### PR TITLE
Task lifecycle: explicit queue membership, one state per stage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,12 @@ implementation.
   open-closed, labels). Query at decision time. Persist only Tasks-owned
   state plus append-only decisions keyed to immutable SHAs. GitHub writes go
   through the server, never through agents.
-- **Manual queue is human-authoritative.** `tasks.manual_rank` is set only via
-  the API; the GitHub poller must never write it.
+- **Manual queue is human-authoritative, and queue membership is explicit.**
+  `tasks.manual_rank` is set only via the API; the GitHub poller must never
+  write it. Ingested issues land in `backlog` and are never dispatched — only
+  explicitly queued tasks (`POST /tasks/{id}/queue` or `/scout`) reach a
+  Scout, and picked-up work stays picked up (failures and `needs_revision`
+  return to `queued`, not `backlog`).
 - **Dependency direction:** `crates/vm-pool/*` are pure infrastructure and
   must never depend on tasks crates. App vocabulary enters vm-pool only
   through the `AppProtocol` generic (see `crates/tasks-protocol`). vm-pool

--- a/crates/tasks/migrations/0005_task_lifecycle.sql
+++ b/crates/tasks/migrations/0005_task_lifecycle.sql
@@ -1,0 +1,12 @@
+-- Task lifecycle rename: one state per stage, queue membership is explicit.
+--
+--   new        -> backlog        (ingested, not picked up; never dispatched)
+--   spec_ready -> in_review      (spec produced, awaiting a verdict)
+--   queued     -> ready_to_build (approved spec parked for a Builder run)
+--
+-- `queued` is re-purposed to mean "explicitly added to the scout queue"; no
+-- existing row carries that meaning, so the old value must be remapped first.
+-- scouting / done / rejected are unchanged.
+UPDATE tasks SET state = 'ready_to_build' WHERE state = 'queued';
+UPDATE tasks SET state = 'backlog'        WHERE state = 'new';
+UPDATE tasks SET state = 'in_review'      WHERE state = 'spec_ready';

--- a/crates/tasks/src/models.rs
+++ b/crates/tasks/src/models.rs
@@ -106,15 +106,22 @@ impl GhState {
 /// Where a task sits in our Diamond 1 pipeline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// One state per task, one list per state. `Backlog` is not work — it's the
+/// ingested mirror of the repo's open issues. Everything from `Queued` onward
+/// is work a human explicitly picked up, and it *stays* picked up: scout
+/// failures and `needs_revision` verdicts return to `Queued`, never `Backlog`.
 pub enum TaskState {
-    /// Just ingested from GitHub.
-    New,
+    /// Ingested from GitHub, untouched. Shown in the Tasks table, never queued
+    /// or dispatched.
+    Backlog,
+    /// Explicitly picked up; in the scout queue, ordered by `manual_rank`.
+    Queued,
     /// A Scout is actively exploring.
     Scouting,
-    /// A Spec has been produced and awaits orchestrator review.
-    SpecReady,
-    /// Spec approved and sitting in the queue, waiting for Builder (out of scope this PR).
-    Queued,
+    /// A spec has been produced and awaits a review verdict.
+    InReview,
+    /// Spec approved; parked until a Builder run consumes it.
+    ReadyToBuild,
     /// Completed through the pipeline.
     Done,
     /// Rejected and won't be pursued.
@@ -124,10 +131,11 @@ pub enum TaskState {
 impl TaskState {
     pub fn as_str(&self) -> &'static str {
         match self {
-            TaskState::New => "new",
-            TaskState::Scouting => "scouting",
-            TaskState::SpecReady => "spec_ready",
+            TaskState::Backlog => "backlog",
             TaskState::Queued => "queued",
+            TaskState::Scouting => "scouting",
+            TaskState::InReview => "in_review",
+            TaskState::ReadyToBuild => "ready_to_build",
             TaskState::Done => "done",
             TaskState::Rejected => "rejected",
         }
@@ -135,10 +143,11 @@ impl TaskState {
 
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
-            "new" => Some(TaskState::New),
-            "scouting" => Some(TaskState::Scouting),
-            "spec_ready" => Some(TaskState::SpecReady),
+            "backlog" => Some(TaskState::Backlog),
             "queued" => Some(TaskState::Queued),
+            "scouting" => Some(TaskState::Scouting),
+            "in_review" => Some(TaskState::InReview),
+            "ready_to_build" => Some(TaskState::ReadyToBuild),
             "done" => Some(TaskState::Done),
             "rejected" => Some(TaskState::Rejected),
             _ => None,

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -547,18 +547,18 @@ async fn top_up(
 }
 
 /// The next task to scout: queue order (which [`Store::list_tasks`] already
-/// applies), state `New`, still open on GitHub, not in flight, not past the
+/// applies), state `Queued` (explicitly picked up), still open on GitHub, not in flight, not past the
 /// attempt cap.
 ///
 /// A task at the cap is rejected the moment it gets there, so the attempt
 /// filter here is belt-and-braces: it also covers rows an older build (or a
-/// crash between the increment and the rejection) left `New` at three strikes.
+/// crash between the increment and the rejection) left `Queued` at three strikes.
 async fn next_dispatchable(
     store: &Store,
     skip: &HashSet<TaskId>,
 ) -> Result<Option<(Task, Project)>, StoreError> {
     for task in store.list_tasks().await? {
-        if task.state != TaskState::New
+        if task.state != TaskState::Queued
             || task.gh_state == GhState::Closed
             || skip.contains(&task.id)
             || task.dispatch_attempts >= MAX_DISPATCH_ATTEMPTS

--- a/crates/tasks/src/scout.rs
+++ b/crates/tasks/src/scout.rs
@@ -89,7 +89,7 @@ impl Scout {
     /// allocate VM, run scout, persist spec, deallocate VM.
     ///
     /// On success, returns the persisted [`Spec`]. Task state is advanced to
-    /// `SpecReady` and a spec-queue entry is created with status
+    /// `InReview` and a spec-queue entry is created with status
     /// `PendingReview`.
     pub async fn dispatch(&self, task: Task, target: &ScoutTarget) -> Result<Spec, ScoutError> {
         info!(task_id = %task.id, "scout dispatch starting");
@@ -314,7 +314,7 @@ impl Scout {
         self.store.upsert_spec_queue_entry(&queue).await?;
 
         self.store
-            .update_task_state(&task.id, TaskState::SpecReady)
+            .update_task_state(&task.id, TaskState::InReview)
             .await?;
         // A spec proves the task is dispatchable, so its past failures stop
         // counting: a later `needs_revision` re-scout starts from zero strikes.
@@ -345,7 +345,7 @@ impl Scout {
             .append_event(EventPayload::TaskStateChanged {
                 task_id: task.id.clone(),
                 from: TaskState::Scouting,
-                to: TaskState::SpecReady,
+                to: TaskState::InReview,
             })
             .await?;
 
@@ -369,10 +369,10 @@ impl Scout {
             )
             .await?;
 
-        // Back to New so another scout can retry. The orchestrator enforces
-        // the re-explore attempt cap.
+        // Back to Queued — a failure doesn't un-pick the work; the dispatcher
+        // retries it in queue order, up to the attempt cap.
         self.store
-            .update_task_state(&task.id, TaskState::New)
+            .update_task_state(&task.id, TaskState::Queued)
             .await?;
 
         self.store
@@ -386,7 +386,7 @@ impl Scout {
             .append_event(EventPayload::TaskStateChanged {
                 task_id: task.id.clone(),
                 from: TaskState::Scouting,
-                to: TaskState::New,
+                to: TaskState::Queued,
             })
             .await?;
         warn!(task_id = %task.id, %vm_id, reason, "scout failed");
@@ -759,7 +759,7 @@ mod tests {
             body: "The issue body.".into(),
             labels: vec![],
             gh_state: crate::models::GhState::Open,
-            state: TaskState::New,
+            state: TaskState::Backlog,
             priority: 0,
             manual_rank: None,
             dispatch_attempts: 0,

--- a/crates/tasks/src/server.rs
+++ b/crates/tasks/src/server.rs
@@ -92,6 +92,9 @@ pub fn router(store: Arc<Store>) -> Router {
         .route("/projects", get(list_projects).post(create_project))
         .route("/tasks", get(list_tasks))
         .route("/tasks/{task_id}", get(get_task))
+        .route("/tasks/{task_id}/queue", post(queue_task))
+        .route("/tasks/{task_id}/dequeue", post(dequeue_task))
+        .route("/tasks/{task_id}/scout", post(scout_task_now))
         .route("/sessions", get(list_sessions))
         .route("/sessions/{session_id}", get(get_session))
         .route("/sessions/{session_id}/transcript", get(list_transcript))
@@ -197,6 +200,33 @@ async fn get_task(
         .await?
         .map(Json)
         .ok_or_else(|| ApiError::NotFound(format!("task {id}")))
+}
+
+/// Pick a backlog task up into the scout queue (appended at the end).
+async fn queue_task(
+    State(store): State<Arc<Store>>,
+    Path(task_id): Path<String>,
+) -> ApiResult<Json<Task>> {
+    Ok(Json(store.queue_task(&TaskId::from_raw(task_id)).await?))
+}
+
+/// Return a queued (not yet running) task to the backlog.
+async fn dequeue_task(
+    State(store): State<Arc<Store>>,
+    Path(task_id): Path<String>,
+) -> ApiResult<Json<Task>> {
+    Ok(Json(store.dequeue_task(&TaskId::from_raw(task_id)).await?))
+}
+
+/// "Scout now": queue the task at the front. The dispatch loop picks it up on
+/// its next tick; the concurrency cap still applies.
+async fn scout_task_now(
+    State(store): State<Arc<Store>>,
+    Path(task_id): Path<String>,
+) -> ApiResult<Json<Task>> {
+    Ok(Json(
+        store.push_task_to_front(&TaskId::from_raw(task_id)).await?,
+    ))
 }
 
 #[derive(Debug, Deserialize)]
@@ -528,7 +558,7 @@ mod tests {
             body: "body".into(),
             labels: vec![],
             gh_state: GhState::Open,
-            state: TaskState::New,
+            state: TaskState::Backlog,
             priority,
             manual_rank: None,
             dispatch_attempts: 0,
@@ -623,6 +653,118 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn queue_membership_over_http() {
+        let (store, project) = store_with_project().await;
+        let a = insert_task(&store, &project, 1, 0).await;
+        let b = insert_task(&store, &project, 2, 0).await;
+        let base = spawn(store.clone()).await;
+        let http = reqwest::Client::new();
+
+        // Pick up a, then b: ranks append in order.
+        let a1: Task = http
+            .post(format!("{base}/tasks/{}/queue", a.id))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(a1.state, TaskState::Queued);
+        assert_eq!(a1.manual_rank, Some(1));
+        let b1: Task = http
+            .post(format!("{base}/tasks/{}/queue", b.id))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(b1.manual_rank, Some(2));
+
+        // Queueing a non-backlog task is a 400.
+        let resp = http
+            .post(format!("{base}/tasks/{}/queue", a.id))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+
+        // Scout-now on a backlog task queues it at the front, shifting others.
+        let c = insert_task(&store, &project, 3, 0).await;
+        let c1: Task = http
+            .post(format!("{base}/tasks/{}/scout", c.id))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(c1.state, TaskState::Queued);
+        assert_eq!(c1.manual_rank, Some(1));
+        let order: Vec<TaskId> = store
+            .list_tasks()
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|t| t.manual_rank.is_some())
+            .map(|t| t.id)
+            .collect();
+        assert_eq!(order, vec![c.id.clone(), a.id.clone(), b.id.clone()]);
+
+        // Dequeue returns to backlog and clears the rank.
+        let b2: Task = http
+            .post(format!("{base}/tasks/{}/dequeue", b.id))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(b2.state, TaskState::Backlog);
+        assert_eq!(b2.manual_rank, None);
+
+        // Dequeuing work that's past Queued is a 400; unknown ids are 404.
+        store
+            .update_task_state(&c.id, TaskState::Scouting)
+            .await
+            .unwrap();
+        let resp = http
+            .post(format!("{base}/tasks/{}/dequeue", c.id))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+        let resp = http
+            .post(format!("{base}/tasks/nonexistent/queue"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+
+        // Scout-now on an already-queued task re-fronts it without a
+        // duplicate state-change event.
+        let a2: Task = http
+            .post(format!("{base}/tasks/{}/scout", a.id))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(a2.manual_rank, Some(1));
+        let queue_events = store
+            .events_since(0)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|e| {
+                matches!(&e.payload, EventPayload::TaskStateChanged { task_id, to: TaskState::Queued, .. } if *task_id == a.id)
+            })
+            .count();
+        assert_eq!(queue_events, 1, "re-fronting must not re-announce pickup");
+    }
+
+    #[tokio::test]
     async fn queue_reorder_roundtrip_and_ordering() {
         let (store, project) = store_with_project().await;
         let high = insert_task(&store, &project, 1, 100).await;
@@ -688,7 +830,7 @@ mod tests {
             .await
             .unwrap();
         store
-            .update_task_state(&closed_spec_ready.id, TaskState::SpecReady)
+            .update_task_state(&closed_spec_ready.id, TaskState::InReview)
             .await
             .unwrap();
         let base = spawn(store.clone()).await;
@@ -801,7 +943,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .state,
-            TaskState::Queued
+            TaskState::ReadyToBuild
         );
 
         http.post(format!("{base}/spec-queue/{}/review", revise_spec.id))
@@ -816,7 +958,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .state,
-            TaskState::New
+            TaskState::Queued
         );
 
         http.post(format!("{base}/spec-queue/{}/review", rejected_spec.id))

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -225,7 +225,7 @@ impl Store {
              ORDER BY manual_rank IS NULL, manual_rank, priority DESC, ingested_at",
         )
         .bind(GhState::Closed.as_str())
-        .bind(TaskState::New.as_str())
+        .bind(TaskState::Backlog.as_str())
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter().map(task_from_row).collect()
@@ -279,6 +279,146 @@ impl Store {
         })
         .await?;
         Ok(())
+    }
+
+    /// Pick a backlog task up into the scout queue, appending it at the end of
+    /// the ranked order. The only door from `Backlog` into the pipeline.
+    ///
+    /// Emits the `TaskStateChanged` event itself so every caller gets the same
+    /// audit trail. Returns the updated task.
+    pub async fn queue_task(&self, id: &TaskId) -> Result<Task, StoreError> {
+        let mut tx = self.pool.begin().await?;
+        let task = self
+            .require_task_state(&mut tx, id, TaskState::Backlog)
+            .await?;
+        let next_rank: i64 =
+            sqlx::query("SELECT COALESCE(MAX(manual_rank), 0) + 1 AS r FROM tasks")
+                .fetch_one(&mut *tx)
+                .await?
+                .try_get("r")?;
+        sqlx::query("UPDATE tasks SET state = ?, manual_rank = ?, updated_at = ? WHERE id = ?")
+            .bind(TaskState::Queued.as_str())
+            .bind(next_rank)
+            .bind(Utc::now().to_rfc3339())
+            .bind(id.as_str())
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+
+        self.append_event(EventPayload::TaskStateChanged {
+            task_id: id.clone(),
+            from: task.state,
+            to: TaskState::Queued,
+        })
+        .await?;
+        self.get_task(id)
+            .await?
+            .ok_or_else(|| StoreError::NotFound(format!("task {id}")))
+    }
+
+    /// Put a queued (not yet running) task back in the backlog, clearing its
+    /// rank. Work past `Queued` can't be un-picked — cancel or review it
+    /// through the pipeline instead.
+    pub async fn dequeue_task(&self, id: &TaskId) -> Result<Task, StoreError> {
+        let mut tx = self.pool.begin().await?;
+        let task = self
+            .require_task_state(&mut tx, id, TaskState::Queued)
+            .await?;
+        sqlx::query("UPDATE tasks SET state = ?, manual_rank = NULL, updated_at = ? WHERE id = ?")
+            .bind(TaskState::Backlog.as_str())
+            .bind(Utc::now().to_rfc3339())
+            .bind(id.as_str())
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+
+        self.append_event(EventPayload::TaskStateChanged {
+            task_id: id.clone(),
+            from: task.state,
+            to: TaskState::Backlog,
+        })
+        .await?;
+        self.get_task(id)
+            .await?
+            .ok_or_else(|| StoreError::NotFound(format!("task {id}")))
+    }
+
+    /// "Scout now": queue the task (from `Backlog` or already `Queued`) at the
+    /// FRONT of the ranked order, shifting everything else down one. The
+    /// dispatch loop picks it up on its next tick; the concurrency cap still
+    /// applies — this jumps the queue, it does not bypass it.
+    pub async fn push_task_to_front(&self, id: &TaskId) -> Result<Task, StoreError> {
+        let mut tx = self.pool.begin().await?;
+        let task = self
+            .get_task_in_tx(&mut tx, id)
+            .await?
+            .ok_or_else(|| StoreError::NotFound(format!("task {id}")))?;
+        if !matches!(task.state, TaskState::Backlog | TaskState::Queued) {
+            return Err(StoreError::Invalid(format!(
+                "task {id} is {}, only backlog or queued tasks can be scouted now",
+                task.state.as_str()
+            )));
+        }
+        sqlx::query("UPDATE tasks SET manual_rank = manual_rank + 1 WHERE manual_rank IS NOT NULL")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("UPDATE tasks SET state = ?, manual_rank = 1, updated_at = ? WHERE id = ?")
+            .bind(TaskState::Queued.as_str())
+            .bind(Utc::now().to_rfc3339())
+            .bind(id.as_str())
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+
+        if task.state == TaskState::Backlog {
+            self.append_event(EventPayload::TaskStateChanged {
+                task_id: id.clone(),
+                from: TaskState::Backlog,
+                to: TaskState::Queued,
+            })
+            .await?;
+        }
+        self.get_task(id)
+            .await?
+            .ok_or_else(|| StoreError::NotFound(format!("task {id}")))
+    }
+
+    /// Fetch a task inside a transaction and require an exact state, mapping
+    /// the mismatch to [`StoreError::Invalid`] (a 400 at the API).
+    async fn require_task_state(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        id: &TaskId,
+        expected: TaskState,
+    ) -> Result<Task, StoreError> {
+        let task = self
+            .get_task_in_tx(tx, id)
+            .await?
+            .ok_or_else(|| StoreError::NotFound(format!("task {id}")))?;
+        if task.state != expected {
+            return Err(StoreError::Invalid(format!(
+                "task {id} is {}, expected {}",
+                task.state.as_str(),
+                expected.as_str()
+            )));
+        }
+        Ok(task)
+    }
+
+    async fn get_task_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        id: &TaskId,
+    ) -> Result<Option<Task>, StoreError> {
+        let row = sqlx::query(
+            "SELECT id, project_id, gh_issue_number, title, body, labels, gh_state, \
+             state, priority, manual_rank, dispatch_attempts, ingested_at, updated_at \
+             FROM tasks WHERE id = ?",
+        )
+        .bind(id.as_str())
+        .fetch_optional(&mut **tx)
+        .await?;
+        row.map(task_from_row).transpose()
     }
 
     /// Upsert a task from a GitHub issue.
@@ -339,7 +479,7 @@ impl Store {
             body: issue.body,
             labels: issue.labels,
             gh_state: issue.state,
-            state: TaskState::New,
+            state: TaskState::Backlog,
             priority: 0,
             manual_rank: None,
             dispatch_attempts: 0,
@@ -706,8 +846,10 @@ impl Store {
             .await?;
         }
         if !orphaned_tasks.is_empty() {
+            // Back to `Queued`, not `Backlog`: a crash doesn't un-pick work a
+            // human put in the queue.
             sqlx::query("UPDATE tasks SET state = ?, updated_at = ? WHERE state = ?")
-                .bind(TaskState::New.as_str())
+                .bind(TaskState::Queued.as_str())
                 .bind(now.to_rfc3339())
                 .bind(TaskState::Scouting.as_str())
                 .execute(&mut *tx)
@@ -732,7 +874,7 @@ impl Store {
             self.append_event(EventPayload::TaskStateChanged {
                 task_id,
                 from: TaskState::Scouting,
-                to: TaskState::New,
+                to: TaskState::Queued,
             })
             .await?;
         }
@@ -916,8 +1058,9 @@ impl Store {
     /// `Rejected`. `PendingReview` and `Blocked` are states the system assigns,
     /// not verdicts a reviewer can render, and are rejected as invalid.
     ///
-    /// Task side effects: approved → `Queued`, rejected → `Rejected`,
-    /// needs revision → back to `New` so it can be scouted again.
+    /// Task side effects: approved → `ReadyToBuild`, rejected → `Rejected`,
+    /// needs revision → back to `Queued` so it re-scouts without losing its
+    /// place as picked-up work.
     pub async fn review_spec(
         &self,
         spec_id: &SpecId,
@@ -925,9 +1068,9 @@ impl Store {
         feedback: Option<String>,
     ) -> Result<SpecQueueEntry, StoreError> {
         let next_task_state = match status {
-            SpecQueueStatus::Approved => TaskState::Queued,
+            SpecQueueStatus::Approved => TaskState::ReadyToBuild,
             SpecQueueStatus::Rejected => TaskState::Rejected,
-            SpecQueueStatus::NeedsRevision => TaskState::New,
+            SpecQueueStatus::NeedsRevision => TaskState::Queued,
             SpecQueueStatus::PendingReview | SpecQueueStatus::Blocked => {
                 return Err(StoreError::Invalid(format!(
                     "{} is not a review outcome",
@@ -1252,7 +1395,7 @@ mod tests {
             body: "Do the thing".into(),
             labels: vec!["bug".into(), "p0".into()],
             gh_state: GhState::Open,
-            state: TaskState::New,
+            state: TaskState::Backlog,
             priority: 10,
             manual_rank: None,
             dispatch_attempts: 0,
@@ -1363,7 +1506,7 @@ mod tests {
         let task = outcome.into_inner();
         assert_eq!(task.gh_issue_number, 7);
         assert_eq!(task.title, "Fix the thing");
-        assert_eq!(task.state, TaskState::New);
+        assert_eq!(task.state, TaskState::Backlog);
         assert_eq!(task.priority, 0);
 
         // Verify persistence
@@ -1902,7 +2045,7 @@ mod tests {
             store.insert_task(t).await.unwrap();
         }
         store
-            .update_task_state(&closed_in_flight.id, TaskState::SpecReady)
+            .update_task_state(&closed_in_flight.id, TaskState::InReview)
             .await
             .unwrap();
 
@@ -2111,13 +2254,13 @@ mod tests {
         for id in [&orphaned.id, &sessionless.id] {
             assert_eq!(
                 store.get_task(id).await.unwrap().unwrap().state,
-                TaskState::New,
+                TaskState::Queued,
                 "task {id}"
             );
         }
         assert_eq!(
             store.get_task(&untouched.id).await.unwrap().unwrap().state,
-            TaskState::New
+            TaskState::Backlog
         );
         // A completed session and its task are none of reconciliation's business.
         assert_eq!(
@@ -2127,7 +2270,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .state,
-            TaskState::New
+            TaskState::Backlog
         );
         assert_eq!(
             store
@@ -2157,7 +2300,7 @@ mod tests {
                 payloads.contains(&EventPayload::TaskStateChanged {
                     task_id: id.clone(),
                     from: TaskState::Scouting,
-                    to: TaskState::New,
+                    to: TaskState::Queued,
                 }),
                 "no TaskStateChanged for {id}"
             );
@@ -2255,7 +2398,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn review_spec_approve_queues_task() {
+    async fn review_spec_approve_readies_task_for_build() {
         let store = Store::open_in_memory().await.unwrap();
         let (task, spec) = seed_spec(&store, 1).await;
 
@@ -2271,7 +2414,7 @@ mod tests {
         assert_eq!(loaded, entry);
         assert_eq!(
             store.get_task(&task.id).await.unwrap().unwrap().state,
-            TaskState::Queued
+            TaskState::ReadyToBuild
         );
     }
 
@@ -2296,7 +2439,7 @@ mod tests {
 
         let (revise_task, revise_spec) = seed_spec(&store, 2).await;
         store
-            .update_task_state(&revise_task.id, TaskState::SpecReady)
+            .update_task_state(&revise_task.id, TaskState::InReview)
             .await
             .unwrap();
         store
@@ -2314,7 +2457,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .state,
-            TaskState::New
+            TaskState::Queued
         );
     }
 
@@ -2339,6 +2482,10 @@ mod tests {
     async fn review_spec_emits_events() {
         let store = Store::open_in_memory().await.unwrap();
         let (task, spec) = seed_spec(&store, 1).await;
+        store
+            .update_task_state(&task.id, TaskState::InReview)
+            .await
+            .unwrap();
 
         store
             .review_spec(&spec.id, SpecQueueStatus::Approved, None)
@@ -2359,8 +2506,8 @@ mod tests {
         }));
         assert!(payloads.contains(&EventPayload::TaskStateChanged {
             task_id: task.id.clone(),
-            from: TaskState::New,
-            to: TaskState::Queued,
+            from: TaskState::InReview,
+            to: TaskState::ReadyToBuild,
         }));
     }
 
@@ -2454,7 +2601,7 @@ mod tests {
         store
             .append_event(EventPayload::TaskStateChanged {
                 task_id: task_id.clone(),
-                from: TaskState::New,
+                from: TaskState::Queued,
                 to: TaskState::Scouting,
             })
             .await

--- a/crates/tasks/tests/run.rs
+++ b/crates/tasks/tests/run.rs
@@ -123,7 +123,7 @@ async fn poll_ingests_issues_once_and_tracks_closures() {
     assert_eq!(ingested, 2);
     let tasks = store.list_tasks().await.unwrap();
     assert_eq!(tasks.len(), 2);
-    assert!(tasks.iter().all(|t| t.state == TaskState::New));
+    assert!(tasks.iter().all(|t| t.state == TaskState::Backlog));
     let ingest_events = store
         .events_since(0)
         .await
@@ -144,7 +144,7 @@ async fn poll_ingests_issues_once_and_tracks_closures() {
         .find(|t| t.gh_issue_number == 1)
         .expect("task for issue 1");
     assert_eq!(closed.gh_state, GhState::Closed);
-    assert_eq!(closed.state, TaskState::New, "our state is ours to set");
+    assert_eq!(closed.state, TaskState::Backlog, "our state is ours to set");
     assert_eq!(
         closed.id,
         tasks
@@ -222,7 +222,7 @@ async fn poll_closes_tasks_whose_issues_left_the_open_set() {
             .find(|t| t.gh_issue_number == number)
             .unwrap_or_else(|| panic!("task for issue {number}"));
         assert_eq!(task.gh_state, expected, "issue {number}");
-        assert_eq!(task.state, TaskState::New, "our state is ours to set");
+        assert_eq!(task.state, TaskState::Backlog, "our state is ours to set");
         assert_eq!(task.id, id_of(number), "same row, not a re-ingest");
     }
     assert_eq!(project.id, after[0].project_id);
@@ -358,7 +358,7 @@ async fn dispatch_loop_survives_a_missing_vm_pool() {
     assert!(store.list_sessions().await.unwrap().is_empty());
     assert_eq!(
         store.get_task(&task.id).await.unwrap().unwrap().state,
-        TaskState::New,
+        TaskState::Queued,
         "an undispatchable task stays queued"
     );
 
@@ -452,7 +452,7 @@ async fn insert_task_with_gh_state(
         body: format!("body of {title}"),
         labels: vec![],
         gh_state,
-        state: TaskState::New,
+        state: TaskState::Queued,
         priority: 0,
         manual_rank: None,
         dispatch_attempts: 0,
@@ -487,6 +487,12 @@ async fn dispatch_loop_follows_queue_order_and_skips_closed_issues() {
     let three = insert_task(&store, &project, 3, "three").await;
     // Closed upstream: never worth a scout, whatever its rank.
     let closed = insert_task_with_gh_state(&store, &project, 4, "closed", GhState::Closed).await;
+    // Backlog: ingested but never picked up — invisible to the dispatcher.
+    let backlog = insert_task(&store, &project, 5, "backlog").await;
+    store
+        .update_task_state(&backlog.id, TaskState::Backlog)
+        .await
+        .unwrap();
 
     // Human-curated order, deliberately not insertion order.
     store
@@ -524,7 +530,7 @@ async fn dispatch_loop_follows_queue_order_and_skips_closed_issues() {
 
     for task in [&three, &one, &two] {
         let stored = store.get_task(&task.id).await.unwrap().unwrap();
-        assert_eq!(stored.state, TaskState::SpecReady, "task {}", task.id);
+        assert_eq!(stored.state, TaskState::InReview, "task {}", task.id);
     }
     let specs = store.list_specs().await.unwrap();
     assert!(specs.iter().all(|s| s.content.contains("## Spec")));
@@ -533,8 +539,14 @@ async fn dispatch_loop_follows_queue_order_and_skips_closed_issues() {
     let stored_closed = store.get_task(&closed.id).await.unwrap().unwrap();
     assert_eq!(
         stored_closed.state,
-        TaskState::New,
+        TaskState::Queued,
         "a closed issue must never be scouted"
+    );
+    let stored_backlog = store.get_task(&backlog.id).await.unwrap().unwrap();
+    assert_eq!(
+        stored_backlog.state,
+        TaskState::Backlog,
+        "backlog work is never dispatched — queue membership is explicit"
     );
 }
 
@@ -566,7 +578,7 @@ async fn pause_blocks_new_dispatches() {
     );
     assert_eq!(
         store.get_task(&second.id).await.unwrap().unwrap().state,
-        TaskState::New
+        TaskState::Queued
     );
 
     // Resuming picks the queued task straight up.
@@ -743,7 +755,7 @@ async fn startup_reconciles_orphaned_work_before_dispatch() {
     );
     assert_eq!(
         store.get_task(&task.id).await.unwrap().unwrap().state,
-        TaskState::New,
+        TaskState::Queued,
         "the stranded task is back in the queue"
     );
 
@@ -764,7 +776,7 @@ async fn startup_reconciles_orphaned_work_before_dispatch() {
         .unwrap();
 
     let stored = store.get_task(&task.id).await.unwrap().unwrap();
-    assert_eq!(stored.state, TaskState::SpecReady);
+    assert_eq!(stored.state, TaskState::InReview);
     assert_eq!(
         stored.dispatch_attempts, 0,
         "a crashed server is not the task's fault"
@@ -848,7 +860,7 @@ async fn a_hung_scout_times_out_and_frees_its_slot() {
                 EventPayload::TaskStateChanged {
                     task_id,
                     from: TaskState::Scouting,
-                    to: TaskState::New
+                    to: TaskState::Queued
                 } if *task_id == hung.id
             )
         })

--- a/crates/tasks/tests/scout.rs
+++ b/crates/tasks/tests/scout.rs
@@ -47,7 +47,7 @@ async fn insert_project_and_task(store: &Store, title: &str, body: &str) -> (Pro
         body: body.into(),
         labels: vec!["test".into()],
         gh_state: GhState::Open,
-        state: TaskState::New,
+        state: TaskState::Queued,
         priority: 0,
         manual_rank: None,
         dispatch_attempts: 0,
@@ -110,7 +110,7 @@ async fn scout_dispatch_end_to_end_produces_spec() {
     assert!(spec.files_touched.iter().any(|f| f == "src/stub.rs"));
 
     let stored_task = store.get_task(&task.id).await.unwrap().unwrap();
-    assert_eq!(stored_task.state, TaskState::SpecReady);
+    assert_eq!(stored_task.state, TaskState::InReview);
 
     let stored_spec = store.get_spec(&spec.id).await.unwrap().unwrap();
     assert_eq!(stored_spec.task_id, task.id);
@@ -139,8 +139,8 @@ async fn scout_dispatch_end_to_end_produces_spec() {
             _ => None,
         })
         .collect();
-    assert!(state_changes.contains(&(TaskState::New, TaskState::Scouting)));
-    assert!(state_changes.contains(&(TaskState::Scouting, TaskState::SpecReady)));
+    assert!(state_changes.contains(&(TaskState::Queued, TaskState::Scouting)));
+    assert!(state_changes.contains(&(TaskState::Scouting, TaskState::InReview)));
 }
 
 #[tokio::test]
@@ -197,7 +197,7 @@ async fn two_scouts_dispatch_concurrently() {
     assert!(spec_b.content.contains("## Spec"));
     for t in [&task_a, &task_b] {
         let stored = store.get_task(&t.id).await.unwrap().unwrap();
-        assert_eq!(stored.state, TaskState::SpecReady, "task {}", t.id);
+        assert_eq!(stored.state, TaskState::InReview, "task {}", t.id);
     }
 }
 
@@ -239,8 +239,8 @@ async fn scout_dispatch_failure_resets_task_to_new() {
     let stored_task = store.get_task(&task.id).await.unwrap().unwrap();
     assert_eq!(
         stored_task.state,
-        TaskState::New,
-        "failed scout should reset task to New for retry"
+        TaskState::Queued,
+        "failed scout should return the task to Queued for retry"
     );
 }
 
@@ -304,7 +304,7 @@ async fn re_scout_after_needs_revision_receives_the_review() {
 
     // Re-dispatch: the task is back in `New`.
     let requeued = store.get_task(&task.id).await.unwrap().unwrap();
-    assert_eq!(requeued.state, TaskState::New);
+    assert_eq!(requeued.state, TaskState::Queued);
     let second = scout.dispatch(requeued, &target).await.expect("second");
 
     assert!(
@@ -390,7 +390,7 @@ async fn a_scout_that_never_reports_back_times_out() {
     );
     assert_eq!(
         store.get_task(&task.id).await.unwrap().unwrap().state,
-        TaskState::New
+        TaskState::Queued
     );
 
     // Cancellation is deallocation: the VM must be gone, or the slot leaks.

--- a/crates/tasks/tests/transcript.rs
+++ b/crates/tasks/tests/transcript.rs
@@ -38,7 +38,7 @@ async fn insert_project_and_task(store: &Store) -> (Project, Task) {
         body: "Do the thing".into(),
         labels: vec![],
         gh_state: GhState::Open,
-        state: TaskState::New,
+        state: TaskState::Queued,
         priority: 0,
         manual_rank: None,
         dispatch_attempts: 0,

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -36,7 +36,10 @@ No auth, loopback only — don't build a login flow.
 | Add a repo | `POST /projects` `{"repo_owner","repo_name"}` | 201 with the project; 400 if it already exists |
 | Reorder task queue (drag & drop) | `POST /queue/reorder` `{"task_ids":[...]}` | **Full order, front to back.** Ranks are rewritten 1..N transactionally; any task not listed becomes unranked and sorts after all ranked tasks (then priority desc, then ingested_at). Send the complete on-screen order after every drop. The response is the same projection as the default `GET /tasks` (closed intake hidden), so it can replace the client's list directly. |
 | Reorder spec queue | `POST /spec-queue/reorder` `{"spec_ids":[...]}` | Same full-order semantics |
-| Review a spec | `POST /spec-queue/{spec_id}/review` `{"status","feedback"?}` | `status` ∈ `approved` \| `needs_revision` \| `rejected` — the three verdicts a reviewer may deliver. `approved` → spec enters the queue for the Builder; `needs_revision` → the task goes back to `new` and will be re-scouted; `rejected` → dead end. `feedback` is free text; include it for `needs_revision` (it's the reviewer's message to the next scout). |
+| Pick up a task | `POST /tasks/{task_id}/queue` | `backlog` → `queued`, appended at the end of the ranked order. 400 unless the task is `backlog`. The only door from the backlog into the pipeline — scouts dispatch **only** queued tasks. |
+| Un-pick a task | `POST /tasks/{task_id}/dequeue` | `queued` → `backlog`, rank cleared. 400 once work has started (past `queued`). |
+| Scout now | `POST /tasks/{task_id}/scout` | Queue the task (from `backlog` or `queued`) at the **front**, shifting everything else down. The dispatch loop picks it up on its next tick; the concurrency cap still applies — it jumps the queue, it doesn't bypass it. |
+| Review a spec | `POST /spec-queue/{spec_id}/review` `{"status","feedback"?}` | `status` ∈ `approved` \| `needs_revision` \| `rejected`. `approved` → task `ready_to_build`; `needs_revision` → task returns to `queued` for a re-scout (feedback reaches the next scout's prompt); `rejected` → dead end. |
 | Play / pause / stop | `POST /mode` `{"mode":"play"\|"pause"\|"stop"}` | Gates **new** work only. A mode change never interrupts a scout in flight — reflect that in the UI (pausing ≠ cancelling; show in-flight sessions still running). |
 
 Everything else is read-only. There is deliberately no
@@ -50,7 +53,7 @@ the server only.
   Task: `{id, project_id, gh_issue_number, title, body, labels, gh_state,
   state, priority, manual_rank, dispatch_attempts, ingested_at, updated_at}`.
   By default the list **omits tasks with `gh_state: "closed"` and
-  `state: "new"`** — issues that were closed on GitHub before any work started,
+  `state: "backlog"`** — issues that were closed on GitHub before any work started,
   i.e. pure intake noise. Every other task stays visible whatever its
   `gh_state`, so in-flight and historical work never disappears from the list
   because someone closed the issue behind it. `GET /tasks?all=true` returns
@@ -114,8 +117,12 @@ touch `append_event`. Apply the same rule to anything similar you add later.
 
 All enums are snake_case strings on the wire:
 
-- `Task.state`: `new` → `scouting` → `spec_ready` → `queued` → `done`, with
-  `rejected` as the terminal failure state.
+- `Task.state`: `backlog` (ingested, inert — the Tasks table) → `queued`
+  (explicitly picked up — the Queue, ordered by `manual_rank`) → `scouting` →
+  `in_review` (spec awaits a verdict) → `ready_to_build` (approved, parked
+  for a Builder) → `done`, with `rejected` as the terminal failure state.
+  Scout failures and `needs_revision` verdicts return to `queued`, never
+  `backlog` — picked-up work stays picked up.
 - `Session.status`: `running`, `scout_succeeded`, `scout_failed`, `cancelled`.
 - `SpecQueueEntry.status`: `pending_review`, `approved`, `needs_revision`,
   `blocked`, `rejected` (only the three verdict values are accepted by the
@@ -159,7 +166,7 @@ view).
   `rejected` with a dispatcher `note` explaining why; on server startup,
   orphaned `running` sessions become `scout_failed`
   (`exit_reason: "orphaned by server restart"`) and stuck `scouting` tasks
-  return to `new` — clients just see the normal events.
+  return to `queued` — clients just see the normal events.
 - **Re-scout feedback loop** (next branch): `needs_revision` feedback will be
   fed into the next scout's prompt. No API change expected; the review call
   you make today is already the right hook.


### PR DESCRIPTION
TaskState becomes backlog -> queued -> scouting -> in_review ->
ready_to_build -> done/rejected (migration 0005 remaps new/spec_ready/queued
rows). The old vocabulary conflated "ingested from GitHub" with "work we
chose to do", and `queued` meant "approved awaiting builder", not "in the
queue".

Queue membership is now explicit: ingested issues land in `backlog` and the
dispatcher only ever dispatches `queued` tasks. Three new endpoints:

- POST /tasks/{id}/queue   backlog -> queued, appended at the end
- POST /tasks/{id}/dequeue queued -> backlog, rank cleared
- POST /tasks/{id}/scout   queue at the FRONT (from backlog or queued);
                           next dispatch tick picks it up, concurrency cap
                           still applies

Picked-up work stays picked up: scout failures, needs_revision verdicts, and
startup reconciliation all return tasks to `queued`, never `backlog`.
Approved specs park at `ready_to_build`. GET /tasks default filter now hides
closed+backlog. docs/clients.md and CLAUDE.md updated.
