### PR TITLE
App: four-section IA — Tasks / Queue / Activity / Chat

### DIFF
--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -13,6 +13,23 @@ final class AppModel {
     var specs: [Spec] = []
     var specQueue: [SpecQueueItem] = []
     var mode: Mode?
+    /// Recent event log, newest first, for the Activity feed.
+    var events: [ActivityEvent] = []
+    /// Highest event seq the user has seen in Activity; drives the unread
+    /// divider and the sidebar badge. Persisted so "while you were away"
+    /// survives relaunch.
+    var lastSeenSeq: Int64 = UserDefaults.standard.object(forKey: "lastSeenSeq") as? Int64 ?? 0
+
+    var unreadCount: Int {
+        events.filter { $0.seq > lastSeenSeq }.count
+    }
+
+    func markActivityRead() {
+        if let newest = events.first?.seq, newest > lastSeenSeq {
+            lastSeenSeq = newest
+            UserDefaults.standard.set(newest, forKey: "lastSeenSeq")
+        }
+    }
 
     var connectionError: String?
     var lastRefreshed: Date?
@@ -51,16 +68,62 @@ final class AppModel {
         await refresh()
     }
 
-    /// Optimistic drag-reorder; the server's answer (or a refresh on failure)
-    /// is authoritative. Since #770 the reorder response is the same filtered
-    /// projection as GET /tasks, so applying it directly is safe.
-    func moveTasks(from source: IndexSet, to destination: Int) {
-        var reordered = tasks
-        reordered.move(fromOffsets: source, toOffset: destination)
-        tasks = reordered
+    /// One intent = one POST; the response is the updated task, and the
+    /// event-driven refresh reconciles the rest. Errors surface on the banner.
+    func queueTask(_ id: String) async {
+        await perform { try await self.client.queueTask(id) }
+    }
+
+    func dequeueTask(_ id: String) async {
+        await perform { try await self.client.dequeueTask(id) }
+    }
+
+    func scoutNow(_ id: String) async {
+        await perform { try await self.client.scoutNow(id) }
+    }
+
+    func setMode(_ mode: Mode) async {
+        do {
+            self.mode = try await client.setMode(mode)
+        } catch {
+            connectionError = error.localizedDescription
+        }
+    }
+
+    private func perform(_ op: @escaping () async throws -> TaskItem) async {
+        do {
+            let updated = try await op()
+            if let index = tasks.firstIndex(where: { $0.id == updated.id }) {
+                tasks[index] = updated
+            }
+            await refresh()
+        } catch {
+            connectionError = error.localizedDescription
+        }
+    }
+
+    /// Optimistic drag-reorder of the "Up next" group. Only `queued` tasks
+    /// carry meaning in the ranked order now, so the reorder POST sends
+    /// exactly their ids — everything else goes unranked, which is correct.
+    /// The response is the full filtered projection (#770) and replaces the
+    /// list directly.
+    func moveQueued(from source: IndexSet, to destination: Int) {
+        var upNext = tasks.filter { $0.state == .queued }
+        upNext.move(fromOffsets: source, toOffset: destination)
+        let order = upNext.map(\.id)
+        // Optimistic: re-sort the local list to match the new ranks.
+        let rank = Dictionary(uniqueKeysWithValues: order.enumerated().map { ($1, $0) })
+        tasks.sort { a, b in
+            switch (rank[a.id], rank[b.id]) {
+            case (let x?, let y?): return x < y
+            case (.some, nil): return true
+            case (nil, .some): return false
+            case (nil, nil): return false
+            }
+        }
         Task {
             do {
-                tasks = try await client.reorderQueue(reordered.map(\.id))
+                tasks = try await client.reorderQueue(order)
             } catch {
                 connectionError = error.localizedDescription
                 await refresh()
@@ -99,12 +162,14 @@ final class AppModel {
             async let specs = client.specs()
             async let specQueue = client.specQueue()
             async let mode = client.mode()
+            async let events = client.events()
             self.projects = try await projects
             self.tasks = try await tasks
             self.sessions = try await sessions
             self.specs = try await specs
             self.specQueue = try await specQueue
             self.mode = try await mode
+            self.events = try await events.sorted { $0.seq > $1.seq }
             connectionError = nil
             lastRefreshed = Date()
         } catch is CancellationError {

--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -1,15 +1,19 @@
 import SwiftUI
 
 enum NavSection: Hashable {
-    case review, queue, sessions
+    case tasks, queue, activity, chat
 }
 
 struct ContentView: View {
     @Environment(AppModel.self) private var model
     @State private var section: NavSection? = .queue
     @State private var selectedTask: TaskItem.ID?
-    @State private var selectedSpec: Spec.ID?
-    @State private var selectedSession: ScoutSession.ID?
+    @State private var selectedQueueTask: TaskItem.ID?
+    /// Events newer than this get the unread accent while Activity is open.
+    /// Captured from `lastSeenSeq` when the section is entered, then the model
+    /// marks everything read — so the accent survives the visit but the badge
+    /// clears.
+    @State private var unreadBoundary: Int64 = 0
 
     var body: some View {
         NavigationSplitView {
@@ -17,22 +21,44 @@ struct ContentView: View {
                 .navigationSplitViewColumnWidth(min: 150, ideal: 180)
         } content: {
             listColumn
-                .navigationSplitViewColumnWidth(min: 300, ideal: 380)
+                .navigationSplitViewColumnWidth(min: 320, ideal: 420)
         } detail: {
             detail
                 .frame(minWidth: 380)
         }
         .navigationTitle("Tasks")
         .navigationSubtitle(subtitle)
-        .toolbar {
-            ToolbarItem {
-                ModeBadge(mode: model.mode)
+        .toolbar { toolbarContent }
+        .onChange(of: section) { _, next in
+            if next == .activity {
+                unreadBoundary = model.lastSeenSeq
+                model.markActivityRead()
             }
-            ToolbarItem {
-                Button("Refresh", systemImage: "arrow.clockwise") {
-                    Task { await model.refresh() }
-                }
+        }
+    }
+
+    // MARK: Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItemGroup {
+            Button("Play", systemImage: "play.fill") {
+                Task { await model.setMode(.play) }
             }
+            .disabled(model.mode == .play)
+            .help(model.mode == .play ? "Dispatching is on" : "Start dispatching queued tasks")
+
+            Button("Pause", systemImage: "pause.fill") {
+                Task { await model.setMode(.pause) }
+            }
+            .disabled(model.mode == .pause)
+            .help("Stop starting new scouts (in-flight scouts finish)")
+        }
+        ToolbarItem {
+            Button("Refresh", systemImage: "arrow.clockwise") {
+                Task { await model.refresh() }
+            }
+            .help("Refetch everything")
         }
     }
 
@@ -40,18 +66,16 @@ struct ContentView: View {
 
     private var sidebar: some View {
         List(selection: $section) {
-            Section {
-                Label("Review", systemImage: "text.badge.checkmark")
-                    .badge(pendingReviewCount)
-                    .tag(NavSection.review)
-                Label("Queue", systemImage: "list.number")
-                    .badge(model.tasks.count)
-                    .tag(NavSection.queue)
-            }
-            Section {
-                Label("Sessions", systemImage: "terminal")
-                    .tag(NavSection.sessions)
-            }
+            Label("Tasks", systemImage: "tray.full")
+                .tag(NavSection.tasks)
+            Label("Queue", systemImage: "list.number")
+                .badge(queuedWork.count)
+                .tag(NavSection.queue)
+            Label("Activity", systemImage: "waveform.path.ecg")
+                .badge(model.unreadCount)
+                .tag(NavSection.activity)
+            Label("Chat", systemImage: "bubble.left.and.bubble.right")
+                .tag(NavSection.chat)
         }
         .listStyle(.sidebar)
         .safeAreaInset(edge: .bottom, spacing: 0) {
@@ -61,8 +85,8 @@ struct ContentView: View {
         }
     }
 
-    private var pendingReviewCount: Int {
-        model.specQueue.filter { $0.status == .pendingReview }.count
+    private var queuedWork: [TaskItem] {
+        model.tasks.filter { $0.state.isQueuedWork }
     }
 
     // MARK: List column
@@ -70,53 +94,88 @@ struct ContentView: View {
     @ViewBuilder
     private var listColumn: some View {
         switch section {
-        case .review, nil:
-            List(selection: $selectedSpec) {
-                if model.specs.isEmpty {
-                    emptyRow("No specs produced yet")
-                }
-                ForEach(reviewOrdered) { spec in
-                    SpecRow(
-                        spec: spec,
-                        entry: model.queueEntry(forSpec: spec.id),
-                        task: model.task(spec.taskId))
-                }
-            }
-            .navigationTitle("Review")
-        case .queue:
-            List(selection: $selectedTask) {
-                if model.tasks.isEmpty {
-                    emptyRow("No tasks ingested yet")
-                }
-                ForEach(model.tasks) { task in
-                    TaskRow(task: task)
-                }
-                .onMove { source, destination in
-                    model.moveTasks(from: source, to: destination)
-                }
-            }
-            .navigationTitle("Queue")
-        case .sessions:
-            List(selection: $selectedSession) {
-                if model.sessions.isEmpty {
-                    emptyRow("No scouts have run")
-                }
-                ForEach(model.sessions.sorted { $0.startedAt > $1.startedAt }) { session in
-                    SessionRow(session: session, task: model.task(session.taskId))
-                }
-            }
-            .navigationTitle("Sessions")
+        case .tasks:
+            TasksTable(selection: $selectedTask)
+        case .queue, nil:
+            queueList
+        case .activity:
+            ActivityFeed(unreadBoundary: unreadBoundary)
+        case .chat:
+            ContentUnavailableView(
+                "No orchestrator yet",
+                systemImage: "bubble.left.and.bubble.right",
+                description: Text("The orchestrator session ships next — this is where you'll talk to it."))
         }
     }
 
-    /// Pending review floats to the top; everything else newest-first.
-    private var reviewOrdered: [Spec] {
-        model.specs.sorted { a, b in
-            let aPending = model.queueEntry(forSpec: a.id)?.status == .pendingReview
-            let bPending = model.queueEntry(forSpec: b.id)?.status == .pendingReview
-            if aPending != bPending { return aPending }
-            return a.createdAt > b.createdAt
+    /// The queue, grouped in attention order: verdicts you owe, work running
+    /// now, work up next (reorderable), and approved specs parked for a
+    /// builder.
+    private var queueList: some View {
+        List(selection: $selectedQueueTask) {
+            let needsYou = tasksIn(.inReview)
+            let running = tasksIn(.scouting)
+            let upNext = tasksIn(.queued)
+            let readyToBuild = tasksIn(.readyToBuild)
+
+            if queuedWork.isEmpty {
+                Text("Nothing queued — pick tasks up from the Tasks list")
+                    .foregroundStyle(.tertiary)
+                    .font(.callout)
+            }
+            if !needsYou.isEmpty {
+                Section("Needs you") {
+                    ForEach(needsYou) { task in
+                        QueueRow(task: task, accessory: .complexity(latestSpec(for: task)?.complexity))
+                    }
+                }
+            }
+            if !running.isEmpty {
+                Section("Running") {
+                    ForEach(running) { task in
+                        QueueRow(task: task, accessory: .elapsed(runningSession(for: task)?.startedAt))
+                    }
+                }
+            }
+            if !upNext.isEmpty {
+                Section("Up next") {
+                    ForEach(upNext) { task in
+                        QueueRow(task: task, accessory: .none)
+                            .contextMenu {
+                                Button("Scout Now") { Task { await model.scoutNow(task.id) } }
+                                Button("Remove from Queue") { Task { await model.dequeueTask(task.id) } }
+                            }
+                    }
+                    .onMove { source, destination in
+                        model.moveQueued(from: source, to: destination)
+                    }
+                }
+            }
+            if !readyToBuild.isEmpty {
+                Section("Ready to build") {
+                    ForEach(readyToBuild) { task in
+                        QueueRow(task: task, accessory: .complexity(latestSpec(for: task)?.complexity))
+                    }
+                }
+            }
         }
+        .navigationTitle("Queue")
+    }
+
+    private func tasksIn(_ state: TaskState) -> [TaskItem] {
+        model.tasks.filter { $0.state == state }
+    }
+
+    private func latestSpec(for task: TaskItem) -> Spec? {
+        model.specs
+            .filter { $0.taskId == task.id }
+            .max { $0.createdAt < $1.createdAt }
+    }
+
+    private func runningSession(for task: TaskItem) -> ScoutSession? {
+        model.sessions
+            .filter { $0.taskId == task.id && $0.status == .running }
+            .max { $0.startedAt < $1.startedAt }
     }
 
     // MARK: Detail
@@ -124,27 +183,48 @@ struct ContentView: View {
     @ViewBuilder
     private var detail: some View {
         switch section {
-        case .review, nil:
-            if let id = selectedSpec, let spec = model.spec(id) {
-                SpecDetailView(
-                    spec: spec,
-                    entry: model.queueEntry(forSpec: spec.id),
-                    task: model.task(spec.taskId))
-            } else {
-                noSelection("Select a spec to review")
-            }
-        case .queue:
+        case .tasks:
             if let id = selectedTask, let task = model.task(id) {
                 TaskDetailView(task: task)
             } else {
                 noSelection("Select a task")
             }
-        case .sessions:
-            if let id = selectedSession, let session = model.session(id) {
-                SessionDetailView(session: session, task: model.task(session.taskId))
-            } else {
-                noSelection("Select a session")
+        case .queue, nil:
+            queueDetail
+        case .activity:
+            noSelection("The feed is the whole story")
+        case .chat:
+            noSelection("")
+        }
+    }
+
+    /// The detail pane follows the task's state: a spec awaiting a verdict
+    /// shows the spec + review form, a running scout shows its live session,
+    /// anything else shows the task itself.
+    @ViewBuilder
+    private var queueDetail: some View {
+        if let id = selectedQueueTask, let task = model.task(id) {
+            switch task.state {
+            case .inReview, .readyToBuild:
+                if let spec = latestSpec(for: task) {
+                    SpecDetailView(
+                        spec: spec,
+                        entry: model.queueEntry(forSpec: spec.id),
+                        task: task)
+                } else {
+                    TaskDetailView(task: task)
+                }
+            case .scouting:
+                if let session = runningSession(for: task) {
+                    SessionDetailView(session: session, task: task)
+                } else {
+                    TaskDetailView(task: task)
+                }
+            default:
+                TaskDetailView(task: task)
             }
+        } else {
+            noSelection("Select queued work")
         }
     }
 
@@ -156,88 +236,223 @@ struct ContentView: View {
         model.projects.isEmpty
             ? "no projects" : model.projects.map(\.slug).joined(separator: " · ")
     }
+}
 
-    private func emptyRow(_ text: String) -> some View {
-        Text(text)
-            .foregroundStyle(.tertiary)
-            .font(.callout)
+// MARK: - Tasks table
+
+/// Linear-style table over every open issue. Backlog rows are plain — state
+/// only shows once work exists. Right-click is the golden path in.
+struct TasksTable: View {
+    @Environment(AppModel.self) private var model
+    @Binding var selection: TaskItem.ID?
+
+    var body: some View {
+        Table(model.tasks, selection: $selection) {
+            TableColumn("#") { task in
+                Text("\(task.ghIssueNumber)")
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 40, ideal: 48, max: 60)
+
+            TableColumn("Title") { task in
+                Text(task.title).lineLimit(1)
+            }
+
+            TableColumn("Labels") { task in
+                Text(task.labels.joined(separator: ", "))
+                    .lineLimit(1)
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 60, ideal: 120)
+
+            TableColumn("State") { task in
+                if task.state != .backlog {
+                    StatusBadge(text: task.state.display, color: task.state.color)
+                }
+            }
+            .width(min: 80, ideal: 110)
+
+            TableColumn("Updated") { task in
+                Text(task.updatedAt.formatted(.relative(presentation: .named)))
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 80, ideal: 110)
+        }
+        .contextMenu(forSelectionType: TaskItem.ID.self) { ids in
+            if let id = ids.first, let task = model.task(id) {
+                taskActions(task)
+            }
+        }
+        .navigationTitle("Tasks")
+    }
+
+    @ViewBuilder
+    private func taskActions(_ task: TaskItem) -> some View {
+        if task.state == .backlog {
+            Button("Add to Queue") { Task { await model.queueTask(task.id) } }
+            Button("Scout Now") { Task { await model.scoutNow(task.id) } }
+        }
+        if task.state == .queued {
+            Button("Scout Now") { Task { await model.scoutNow(task.id) } }
+            Button("Remove from Queue") { Task { await model.dequeueTask(task.id) } }
+        }
+        if let url = githubURL(for: task) {
+            Divider()
+            Link("Open on GitHub", destination: url)
+        }
+    }
+
+    private func githubURL(for task: TaskItem) -> URL? {
+        guard let project = model.projects.first(where: { $0.id == task.projectId }) else {
+            return nil
+        }
+        return URL(string: "https://github.com/\(project.slug)/issues/\(task.ghIssueNumber)")
     }
 }
 
-// MARK: - Rows
+// MARK: - Queue rows
 
-struct TaskRow: View {
+struct QueueRow: View {
+    enum Accessory {
+        case none
+        case complexity(Complexity?)
+        case elapsed(Date?)
+    }
+
     let task: TaskItem
+    let accessory: Accessory
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             VStack(alignment: .leading, spacing: 1) {
                 Text(task.title)
                     .lineLimit(2)
-                HStack(spacing: 4) {
-                    Text("#\(task.ghIssueNumber)")
-                        .monospaced()
-                    if !task.labels.isEmpty {
-                        Text("· " + task.labels.joined(separator: " · "))
-                            .lineLimit(1)
-                    }
+                Text("#\(task.ghIssueNumber)")
+                    .monospaced()
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            switch accessory {
+            case .none:
+                EmptyView()
+            case .complexity(let complexity):
+                if let complexity {
+                    Text(complexity.wire)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
+            case .elapsed(let start):
+                if let start {
+                    ElapsedTimeText(since: start)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+/// Live-updating elapsed time — scouts run 20+ minutes, and a wall clock
+/// beats a spinner that looks hung.
+struct ElapsedTimeText: View {
+    let since: Date
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            Text(elapsed(at: context.date))
+                .monospacedDigit()
                 .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-            Spacer()
-            // A closed issue on a non-terminal task usually means the work
-            // shipped outside the pipeline — make that legible.
-            if task.ghState == .closed {
-                StatusBadge(text: "closed", color: .purple)
-                    .help("GitHub issue is closed (as of the last poll)")
-            }
-            StatusBadge(text: task.state.wire, color: task.state.color)
+                .foregroundStyle(.blue)
         }
-        .padding(.vertical, 2)
+    }
+
+    private func elapsed(at now: Date) -> String {
+        let seconds = max(0, Int(now.timeIntervalSince(since)))
+        return String(format: "%d:%02d", seconds / 60, seconds % 60)
     }
 }
 
-struct SpecRow: View {
-    let spec: Spec
-    let entry: SpecQueueItem?
-    let task: TaskItem?
+// MARK: - Activity feed
+
+struct ActivityFeed: View {
+    @Environment(AppModel.self) private var model
+    let unreadBoundary: Int64
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            VStack(alignment: .leading, spacing: 1) {
-                Text(task?.title ?? spec.taskId)
-                    .lineLimit(2)
-                Text("\(spec.complexity.wire) · \(spec.createdAt.formatted(.relative(presentation: .named)))")
-                    .font(.caption)
+        List(model.events) { event in
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Circle()
+                    .fill(event.seq > unreadBoundary ? Color.accentColor : .clear)
+                    .frame(width: 6, height: 6)
+                Image(systemName: icon(for: event.kind))
                     .foregroundStyle(.secondary)
+                    .frame(width: 16)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(describe(event))
+                        .lineLimit(2)
+                    Text(event.timestamp.formatted(.relative(presentation: .named)))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
             }
-            Spacer()
-            if let entry {
-                StatusBadge(text: entry.status.wire, color: entry.status.color)
-            }
+            .padding(.vertical, 1)
         }
-        .padding(.vertical, 2)
+        .navigationTitle("Activity")
     }
-}
 
-struct SessionRow: View {
-    let session: ScoutSession
-    let task: TaskItem?
-
-    var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            VStack(alignment: .leading, spacing: 1) {
-                Text(task?.title ?? session.taskId)
-                    .lineLimit(2)
-                Text(session.startedAt.formatted(.relative(presentation: .named)))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer()
-            StatusBadge(text: session.status.wire, color: session.status.color)
+    private func icon(for kind: String) -> String {
+        switch kind {
+        case "task_ingested": "tray.and.arrow.down"
+        case "task_state_changed": "arrow.right.circle"
+        case "task_gh_state_changed": "link.circle"
+        case "session_started": "play.circle"
+        case "session_completed": "checkmark.circle"
+        case "spec_created": "doc.text"
+        case "spec_queue_status_changed": "text.badge.checkmark"
+        case "queue_reordered", "spec_queue_reordered": "arrow.up.arrow.down"
+        case "mode_changed": "playpause"
+        case "note": "text.bubble"
+        case "project_added": "folder.badge.plus"
+        default: "circle"
         }
-        .padding(.vertical, 2)
+    }
+
+    private func describe(_ event: ActivityEvent) -> String {
+        let title = event.taskId.flatMap { model.task($0)?.title }
+        switch event.kind {
+        case "task_ingested":
+            return "Ingested \(title ?? "a task")"
+        case "task_state_changed":
+            let change = [event.from, event.to].compactMap(\.self)
+                .map { $0.replacingOccurrences(of: "_", with: " ") }
+                .joined(separator: " → ")
+            return "\(title ?? "Task"): \(change)"
+        case "task_gh_state_changed":
+            return "\(title ?? "A task") was \(event.to ?? "changed") on GitHub"
+        case "session_started":
+            return "Scout started on \(title ?? "a task")"
+        case "session_completed":
+            return "Scout finished on \(title ?? "a task")"
+        case "spec_created":
+            return "Spec produced for \(title ?? "a task")"
+        case "spec_queue_status_changed":
+            let verdict = (event.to ?? "updated").replacingOccurrences(of: "_", with: " ")
+            return "Spec \(verdict)"
+        case "queue_reordered":
+            return "Queue reordered"
+        case "spec_queue_reordered":
+            return "Spec queue reordered"
+        case "mode_changed":
+            return "Mode: \(event.from ?? "?") → \(event.to ?? "?")"
+        case "note":
+            return event.message ?? "Note"
+        case "project_added":
+            return "Project added"
+        default:
+            return event.kind.replacingOccurrences(of: "_", with: " ")
+        }
     }
 }
 
@@ -270,7 +485,7 @@ struct StatusBadge: View {
     let color: Color
 
     var body: some View {
-        Text(text.replacingOccurrences(of: "_", with: " "))
+        Text(text)
             .font(.caption.weight(.medium))
             .padding(.horizontal, 7)
             .padding(.vertical, 2)
@@ -279,41 +494,18 @@ struct StatusBadge: View {
     }
 }
 
-struct ModeBadge: View {
-    let mode: Mode?
-
-    var body: some View {
-        Label(mode?.wire ?? "unknown", systemImage: icon)
-            .foregroundStyle(color)
-            .labelStyle(.titleAndIcon)
-    }
-
-    private var icon: String {
-        switch mode {
-        case .play: "play.circle.fill"
-        case .pause: "pause.circle.fill"
-        case .stop: "stop.circle.fill"
-        case .unknown, nil: "questionmark.circle"
-        }
-    }
-
-    private var color: Color {
-        switch mode {
-        case .play: .green
-        case .pause: .yellow
-        case .stop: .red
-        case .unknown, nil: .secondary
-        }
-    }
-}
-
 extension TaskState {
+    var display: String {
+        wire.replacingOccurrences(of: "_", with: " ")
+    }
+
     var color: Color {
         switch self {
-        case .new: .gray
-        case .scouting: .blue
-        case .specReady: .purple
+        case .backlog: .gray
         case .queued: .orange
+        case .scouting: .blue
+        case .inReview: .purple
+        case .readyToBuild: .teal
         case .done: .green
         case .rejected: .red
         case .unknown: .secondary

--- a/app/Tasks/Models.swift
+++ b/app/Tasks/Models.swift
@@ -67,16 +67,19 @@ enum GhState: WireEnum {
     }
 }
 
+/// One state per stage (docs/clients.md): backlog is the inert issue mirror;
+/// everything from queued onward is explicitly picked-up work.
 enum TaskState: WireEnum {
-    case new, scouting, specReady, queued, done, rejected
+    case backlog, queued, scouting, inReview, readyToBuild, done, rejected
     case unknown(String)
 
     init(wire: String) {
         switch wire {
-        case "new": self = .new
-        case "scouting": self = .scouting
-        case "spec_ready": self = .specReady
+        case "backlog": self = .backlog
         case "queued": self = .queued
+        case "scouting": self = .scouting
+        case "in_review": self = .inReview
+        case "ready_to_build": self = .readyToBuild
         case "done": self = .done
         case "rejected": self = .rejected
         default: self = .unknown(wire)
@@ -85,13 +88,22 @@ enum TaskState: WireEnum {
 
     var wire: String {
         switch self {
-        case .new: "new"
-        case .scouting: "scouting"
-        case .specReady: "spec_ready"
+        case .backlog: "backlog"
         case .queued: "queued"
+        case .scouting: "scouting"
+        case .inReview: "in_review"
+        case .readyToBuild: "ready_to_build"
         case .done: "done"
         case .rejected: "rejected"
         case .unknown(let raw): raw
+        }
+    }
+
+    /// Whether the task is picked-up work (anything past backlog and not dead).
+    var isQueuedWork: Bool {
+        switch self {
+        case .queued, .scouting, .inReview, .readyToBuild: true
+        default: false
         }
     }
 }
@@ -301,4 +313,43 @@ enum Mode: WireEnum {
 
 struct ModeResponse: Decodable {
     let mode: Mode
+}
+
+/// One event-log entry, decoded leniently for the Activity feed: `kind` plus
+/// whatever identifiers the payload carries. Unknown kinds render as-is.
+struct ActivityEvent: Decodable, Identifiable, Hashable {
+    let seq: Int64
+    let timestamp: Date
+    let kind: String
+    let taskId: String?
+    let sessionId: String?
+    let specId: String?
+    let from: String?
+    let to: String?
+    let source: String?
+    let message: String?
+
+    var id: Int64 { seq }
+
+    enum CodingKeys: String, CodingKey {
+        case seq, timestamp, payload
+    }
+    enum PayloadKeys: String, CodingKey {
+        case kind, taskId, sessionId, specId, from, to, source, message
+    }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        seq = try c.decode(Int64.self, forKey: .seq)
+        timestamp = try c.decode(Date.self, forKey: .timestamp)
+        let p = try c.nestedContainer(keyedBy: PayloadKeys.self, forKey: .payload)
+        kind = try p.decodeIfPresent(String.self, forKey: .kind) ?? "unknown"
+        taskId = try? p.decodeIfPresent(String.self, forKey: .taskId)
+        sessionId = try? p.decodeIfPresent(String.self, forKey: .sessionId)
+        specId = try? p.decodeIfPresent(String.self, forKey: .specId)
+        from = try? p.decodeIfPresent(String.self, forKey: .from)
+        to = try? p.decodeIfPresent(String.self, forKey: .to)
+        source = try? p.decodeIfPresent(String.self, forKey: .source)
+        message = try? p.decodeIfPresent(String.self, forKey: .message)
+    }
 }

--- a/app/Tasks/TasksClient.swift
+++ b/app/Tasks/TasksClient.swift
@@ -36,6 +36,35 @@ struct TasksClient: Sendable {
         return response.mode
     }
 
+    func setMode(_ mode: Mode) async throws -> Mode {
+        let response: ModeResponse = try await post("mode", body: ["mode": mode.wire])
+        return response.mode
+    }
+
+    /// Recent events, newest last. `since` is inclusive.
+    func events(since: Int64? = nil, limit: Int = 200) async throws -> [ActivityEvent] {
+        var query = [URLQueryItem(name: "limit", value: String(limit))]
+        if let since {
+            query.append(URLQueryItem(name: "since", value: String(since)))
+        }
+        return try await get("events", query: query)
+    }
+
+    /// backlog -> queued, appended at the end of the ranked order.
+    func queueTask(_ taskId: String) async throws -> TaskItem {
+        try await postEmpty("tasks/\(taskId)/queue")
+    }
+
+    /// queued -> backlog, rank cleared.
+    func dequeueTask(_ taskId: String) async throws -> TaskItem {
+        try await postEmpty("tasks/\(taskId)/dequeue")
+    }
+
+    /// Queue at the front; next dispatch tick picks it up (cap still applies).
+    func scoutNow(_ taskId: String) async throws -> TaskItem {
+        try await postEmpty("tasks/\(taskId)/scout")
+    }
+
     /// Sets manual_rank 1..n in the given order; unlisted tasks go unranked.
     /// Returns the full re-sorted queue.
     func reorderQueue(_ taskIds: [String]) async throws -> [TaskItem] {
@@ -123,6 +152,14 @@ struct TasksClient: Sendable {
             }
             continuation.onTermination = { _ in reader.cancel() }
         }
+    }
+
+    private func postEmpty<T: Decodable>(_ path: String) async throws -> T {
+        var request = URLRequest(url: baseURL.appending(path: path))
+        request.httpMethod = "POST"
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try Self.checkOK(response, body: data)
+        return try Self.makeDecoder().decode(T.self, from: data)
     }
 
     private func post<T: Decodable>(_ path: String, body: some Encodable & Sendable)


### PR DESCRIPTION
- Tasks: Linear-style Table over every open issue. Backlog rows are plain
  (no status theater); right-click is the golden path in: Add to Queue,
  Scout Now, Open on GitHub.
- Queue: only picked-up work, grouped in attention order — Needs you
  (in_review, detail pane shows the spec + review form), Running (live
  elapsed timer), Up next (drag-reorderable; reorder POST sends exactly the
  queued ids), Ready to build. Detail follows the task's state.
- Activity: the event feed, humanized per kind, with a persisted unread
  marker (badge + accent dots for "while you were away").
- Chat: placeholder until the orchestrator ships.
- Toolbar: native play/pause action icons replacing the custom mode badge.
- Models updated to the new lifecycle vocabulary (backlog/queued/scouting/
  in_review/ready_to_build) from #772.
