### PR TITLE
Fix event-log vocabulary + app loading resilience

### DIFF
--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -154,28 +154,49 @@ final class AppModel {
         }
     }
 
+    /// Every fetch stands alone: one failing endpoint surfaces on the banner
+    /// but must not blank the six that succeeded.
     func refresh() async {
+        let c = client
+        async let projects = Self.attempt { try await c.projects() }
+        async let tasks = Self.attempt { try await c.tasks() }
+        async let sessions = Self.attempt { try await c.sessions() }
+        async let specs = Self.attempt { try await c.specs() }
+        async let specQueue = Self.attempt { try await c.specQueue() }
+        async let mode = Self.attempt { try await c.mode() }
+        async let events = Self.attempt { try await c.events() }
+
+        var firstError: String?
+        func apply<T>(_ result: Result<T, any Error>?, _ assign: (T) -> Void) {
+            switch result {
+            case .success(let value): assign(value)
+            case .failure(let error):
+                if firstError == nil { firstError = error.localizedDescription }
+            case nil: break
+            }
+        }
+        apply(await projects) { self.projects = $0 }
+        apply(await tasks) { self.tasks = $0 }
+        apply(await sessions) { self.sessions = $0 }
+        apply(await specs) { self.specs = $0 }
+        apply(await specQueue) { self.specQueue = $0 }
+        apply(await mode) { self.mode = $0 }
+        apply(await events) { self.events = $0.sorted { $0.seq > $1.seq } }
+
+        connectionError = firstError
+        lastRefreshed = Date()
+    }
+
+    /// Nil on cancellation (mid-teardown — not an error, not a result).
+    private nonisolated static func attempt<T: Sendable>(
+        _ op: @Sendable () async throws -> T
+    ) async -> Result<T, any Error>? {
         do {
-            async let projects = client.projects()
-            async let tasks = client.tasks()
-            async let sessions = client.sessions()
-            async let specs = client.specs()
-            async let specQueue = client.specQueue()
-            async let mode = client.mode()
-            async let events = client.events()
-            self.projects = try await projects
-            self.tasks = try await tasks
-            self.sessions = try await sessions
-            self.specs = try await specs
-            self.specQueue = try await specQueue
-            self.mode = try await mode
-            self.events = try await events.sorted { $0.seq > $1.seq }
-            connectionError = nil
-            lastRefreshed = Date()
+            return .success(try await op())
         } catch is CancellationError {
-            return
+            return nil
         } catch {
-            connectionError = error.localizedDescription
+            return .failure(error)
         }
     }
 }

--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -93,6 +93,19 @@ struct ContentView: View {
 
     @ViewBuilder
     private var listColumn: some View {
+        if model.lastRefreshed == nil && model.connectionError == nil {
+            ContentUnavailableView {
+                ProgressView()
+            } description: {
+                Text("Connecting to the tasks server…")
+            }
+        } else {
+            sectionList
+        }
+    }
+
+    @ViewBuilder
+    private var sectionList: some View {
         switch section {
         case .tasks:
             TasksTable(selection: $selectedTask)

--- a/crates/tasks/migrations/0006_event_vocabulary.sql
+++ b/crates/tasks/migrations/0006_event_vocabulary.sql
@@ -1,0 +1,26 @@
+-- 0005 renamed the task-state vocabulary but only remapped tasks.state; the
+-- event log still holds task_state_changed payloads speaking the old one, and
+-- the server refuses to deserialize its own history (GET /events -> 500).
+--
+-- Rewriting the log is safe here: this is a vocabulary rename of our own
+-- data, not a change to what happened. json_set targets exactly the affected
+-- keys of exactly the affected kind, so free-text fields (notes) are never
+-- touched. Old `queued` maps to `ready_to_build` per 0005's table.
+UPDATE events SET payload = json_set(payload, '$.from', 'backlog')
+    WHERE json_extract(payload, '$.kind') = 'task_state_changed'
+      AND json_extract(payload, '$.from') = 'new';
+UPDATE events SET payload = json_set(payload, '$.to', 'backlog')
+    WHERE json_extract(payload, '$.kind') = 'task_state_changed'
+      AND json_extract(payload, '$.to') = 'new';
+UPDATE events SET payload = json_set(payload, '$.from', 'in_review')
+    WHERE json_extract(payload, '$.kind') = 'task_state_changed'
+      AND json_extract(payload, '$.from') = 'spec_ready';
+UPDATE events SET payload = json_set(payload, '$.to', 'in_review')
+    WHERE json_extract(payload, '$.kind') = 'task_state_changed'
+      AND json_extract(payload, '$.to') = 'spec_ready';
+UPDATE events SET payload = json_set(payload, '$.from', 'ready_to_build')
+    WHERE json_extract(payload, '$.kind') = 'task_state_changed'
+      AND json_extract(payload, '$.from') = 'queued';
+UPDATE events SET payload = json_set(payload, '$.to', 'ready_to_build')
+    WHERE json_extract(payload, '$.kind') = 'task_state_changed'
+      AND json_extract(payload, '$.to') = 'queued';


### PR DESCRIPTION
Migration 0005 remapped tasks.state but not the event log: old
task_state_changed payloads still said new/spec_ready/queued, and the server
refused to deserialize its own history (GET /events -> 500 "unknown variant
`new`"). Migration 0006 rewrites exactly those payload keys via json_set —
free-text fields are untouched, and DBs that haven't run 0005 yet apply both
in one startup, so there is no window where mixed vocabularies coexist.

App: one failing endpoint no longer blanks the whole refresh — each fetch
stands alone, successes apply, the first failure surfaces on the banner. And
the first load shows a connecting state instead of empty lists.
