### PR TITLE
build.rs: rerun on migrations/ changes

### DIFF
--- a/crates/tasks/build.rs
+++ b/crates/tasks/build.rs
@@ -1,0 +1,6 @@
+// sqlx::migrate! embeds ./migrations at compile time; without this, adding a
+// migration file alone doesn't dirty the crate and a cached binary ships
+// without it (which happened with 0006).
+fn main() {
+    println!("cargo:rerun-if-changed=migrations");
+}


### PR DESCRIPTION
sqlx::migrate! embeds the migrations dir at compile time, but a new .sql file
alone doesn't dirty the crate — 0006 shipped in source and the cached binary
ran without it. Standard sqlx rerun-if-changed hint.
