### PR TITLE
Closure-derived retirement: closed issues retire picked-up work

### DIFF
--- a/crates/tasks/src/github.rs
+++ b/crates/tasks/src/github.rs
@@ -13,6 +13,7 @@ use crate::models::GhState;
 
 const DEFAULT_BASE_URL: &str = "https://api.github.com/graphql";
 const PAGE_SIZE: u32 = 100;
+const CLOSE_INFO_BATCH: usize = 50;
 
 #[derive(Debug, Error)]
 pub enum GhError {
@@ -33,6 +34,15 @@ pub struct GhIssue {
     pub labels: Vec<String>,
     pub state: GhState,
     pub updated_at: DateTime<Utc>,
+}
+
+/// How a specific issue looks right now — state plus GitHub's close reason
+/// (`stateReason`: COMPLETED, NOT_PLANNED, DUPLICATE, ...). Fetched at
+/// decision time and never persisted; GitHub owns these facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueCloseInfo {
+    pub state: GhState,
+    pub state_reason: Option<String>,
 }
 
 pub struct GitHubClient {
@@ -72,6 +82,99 @@ impl GitHubClient {
         }
         debug!(owner, name, count = issues.len(), "fetched open issues");
         Ok(issues)
+    }
+
+    /// Look up state + close reason for specific issue numbers, batched via
+    /// GraphQL aliases. Issues that don't resolve (deleted, converted to a
+    /// discussion, transferred) are simply absent from the returned map.
+    ///
+    /// GitHub answers an unresolvable alias with a null node *and* an errors
+    /// entry, so unlike [`Self::list_open_issues`] this tolerates errors as
+    /// long as `data.repository` came back — otherwise one dead number would
+    /// poison the whole batch.
+    pub async fn issue_close_info(
+        &self,
+        owner: &str,
+        name: &str,
+        numbers: &[u64],
+    ) -> Result<std::collections::HashMap<u64, IssueCloseInfo>, GhError> {
+        let mut out = std::collections::HashMap::new();
+        for chunk in numbers.chunks(CLOSE_INFO_BATCH) {
+            let fields: String = chunk
+                .iter()
+                .map(|n| format!("i{n}: issue(number: {n}) {{ number state stateReason }}\n"))
+                .collect();
+            let query = format!(
+                "query($owner: String!, $name: String!) {{\n\
+                   repository(owner: $owner, name: $name) {{\n{fields}}}\n}}"
+            );
+            let body = serde_json::json!({
+                "query": query,
+                "variables": { "owner": owner, "name": name },
+            });
+
+            let resp: serde_json::Value = self
+                .http
+                .post(&self.base_url)
+                .bearer_auth(&self.token)
+                .header("Accept", "application/json")
+                .json(&body)
+                .send()
+                .await?
+                .error_for_status()?
+                .json()
+                .await?;
+
+            let repository = resp.pointer("/data/repository").filter(|v| !v.is_null());
+            let Some(repository) = repository else {
+                if let Some(errs) = resp.get("errors").and_then(|e| e.as_array()) {
+                    let msg = errs
+                        .iter()
+                        .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    return Err(GhError::GraphQl(msg));
+                }
+                return Err(GhError::Shape("repository is null".into()));
+            };
+            let nodes = repository
+                .as_object()
+                .ok_or_else(|| GhError::Shape("repository is not an object".into()))?;
+
+            for (alias, node) in nodes {
+                if node.is_null() {
+                    warn!(alias, "issue did not resolve; leaving it out");
+                    continue;
+                }
+                let number = node
+                    .get("number")
+                    .and_then(|n| n.as_u64())
+                    .ok_or_else(|| GhError::Shape(format!("{alias}: number missing")))?;
+                let state = match node.get("state").and_then(|s| s.as_str()) {
+                    Some("OPEN") => GhState::Open,
+                    _ => GhState::Closed,
+                };
+                let state_reason = node
+                    .get("stateReason")
+                    .and_then(|r| r.as_str())
+                    .map(str::to_owned);
+                out.insert(
+                    number,
+                    IssueCloseInfo {
+                        state,
+                        state_reason,
+                    },
+                );
+            }
+        }
+        debug!(
+            owner,
+            name,
+            asked = numbers.len(),
+            resolved = out.len(),
+            "fetched issue close info"
+        );
+        Ok(out)
     }
 
     async fn fetch_page(
@@ -372,6 +475,62 @@ mod tests {
 
         let client = GitHubClient::with_base_url("token", url);
         let err = client.list_open_issues("own", "repo").await.unwrap_err();
+        match err {
+            GhError::GraphQl(msg) => assert!(msg.contains("Bad credentials")),
+            other => panic!("expected GraphQl error, got {other:?}"),
+        }
+    }
+
+    /// GitHub answers an unresolvable issue alias with a null node plus an
+    /// errors entry; the resolvable siblings in the same batch must survive.
+    #[tokio::test]
+    async fn issue_close_info_parses_aliases_and_tolerates_dead_numbers() {
+        let responses = vec![json!({
+            "data": {
+                "repository": {
+                    "i1": {"number": 1, "state": "CLOSED", "stateReason": "COMPLETED"},
+                    "i2": {"number": 2, "state": "CLOSED", "stateReason": "NOT_PLANNED"},
+                    "i3": {"number": 3, "state": "OPEN", "stateReason": null},
+                    "i4": null,
+                }
+            },
+            "errors": [{"message": "Could not resolve to an Issue with the number of 4."}]
+        })];
+        let (url, _q, _h) = spawn_fake(responses).await;
+
+        let client = GitHubClient::with_base_url("token", url);
+        let info = client
+            .issue_close_info("own", "repo", &[1, 2, 3, 4])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            info.get(&1),
+            Some(&IssueCloseInfo {
+                state: GhState::Closed,
+                state_reason: Some("COMPLETED".into()),
+            })
+        );
+        assert_eq!(
+            info.get(&2).and_then(|i| i.state_reason.as_deref()),
+            Some("NOT_PLANNED")
+        );
+        assert_eq!(info.get(&3).map(|i| i.state), Some(GhState::Open));
+        assert!(!info.contains_key(&4), "dead number stays absent");
+    }
+
+    #[tokio::test]
+    async fn issue_close_info_fails_when_data_is_absent() {
+        let responses = vec![json!({
+            "errors": [{"message": "Bad credentials"}]
+        })];
+        let (url, _q, _h) = spawn_fake(responses).await;
+
+        let client = GitHubClient::with_base_url("token", url);
+        let err = client
+            .issue_close_info("own", "repo", &[1])
+            .await
+            .unwrap_err();
         match err {
             GhError::GraphQl(msg) => assert!(msg.contains("Bad credentials")),
             other => panic!("expected GraphQl error, got {other:?}"),

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -410,6 +410,52 @@ pub async fn poll_once(store: &Store, github: &GitHubClient) -> Result<usize, St
                 })
                 .await?;
         }
+
+        // Closure-derived retirement: issue closure IS the "done" signal for
+        // picked-up work — there is no manual mark-done. The close *reason* is
+        // GitHub-owned, so it's queried here at decision time, never persisted.
+        let retirable = store.list_retirable_tasks(&project.id).await?;
+        if retirable.is_empty() {
+            continue;
+        }
+        let numbers: Vec<u64> = retirable.iter().map(|t| t.gh_issue_number).collect();
+        let info = match github
+            .issue_close_info(&project.repo_owner, &project.repo_name, &numbers)
+            .await
+        {
+            Ok(info) => info,
+            Err(e) => {
+                warn!(error = %e, "fetching close reasons failed; retiring next poll");
+                continue;
+            }
+        };
+        for task in retirable {
+            let to = match info.get(&task.gh_issue_number) {
+                // Reopened between the open-set fetch and this lookup; the
+                // next poll's upsert refreshes gh_state and it flows again.
+                Some(i) if i.state == GhState::Open => continue,
+                Some(i) => match i.state_reason.as_deref() {
+                    Some("NOT_PLANNED") | Some("DUPLICATE") => TaskState::Rejected,
+                    _ => TaskState::Done,
+                },
+                // Deleted / converted to a discussion — it is never coming
+                // back as an issue, so the work is concluded either way.
+                None => {
+                    warn!(
+                        issue = task.gh_issue_number,
+                        "issue no longer resolvable; retiring as done"
+                    );
+                    TaskState::Done
+                }
+            };
+            if let Some(retired) = store.retire_task(&task.id, to).await? {
+                info!(
+                    issue = retired.gh_issue_number,
+                    to = to.as_str(),
+                    "issue closed upstream; retired its task"
+                );
+            }
+        }
     }
     Ok(ingested)
 }
@@ -694,6 +740,7 @@ fn clone_url(config: &Config, project: &Project) -> String {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
+    use serde_json::{Value, json};
 
     use super::*;
     use crate::models::ProjectId;
@@ -752,6 +799,163 @@ mod tests {
         assert_eq!(
             clone_url(&config, &project()),
             "file:///srv/repos/iamnbutler/tasks.git"
+        );
+    }
+
+    /// Fake GraphQL endpoint that pops canned responses in request order —
+    /// poll_once issues the open-issues query first, then (if anything is
+    /// retirable) the close-info query.
+    async fn spawn_fake_github(responses: Vec<Value>) -> String {
+        use axum::{Router, extract::State, response::Json, routing::post};
+        use std::sync::Mutex;
+
+        let queue = Arc::new(Mutex::new(responses));
+        let app = Router::new()
+            .route(
+                "/graphql",
+                post(
+                    move |State(q): State<Arc<Mutex<Vec<Value>>>>, _body: String| async move {
+                        let resp = {
+                            let mut g = q.lock().unwrap();
+                            if g.is_empty() {
+                                json!({"data": {"repository": {"issues": {
+                                    "pageInfo": {"hasNextPage": false, "endCursor": null},
+                                    "nodes": []}}}})
+                            } else {
+                                g.remove(0)
+                            }
+                        };
+                        Json(resp)
+                    },
+                ),
+            )
+            .with_state(queue);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/graphql", listener.local_addr().unwrap());
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        url
+    }
+
+    async fn seed_task(store: &Store, project: &Project, number: u64, state: TaskState) -> Task {
+        let now = Utc::now();
+        let task = Task {
+            id: TaskId::new(),
+            project_id: project.id.clone(),
+            gh_issue_number: number,
+            title: format!("issue {number}"),
+            body: String::new(),
+            labels: vec![],
+            gh_state: GhState::Open,
+            state,
+            priority: 0,
+            manual_rank: (state == TaskState::Queued).then_some(1),
+            dispatch_attempts: 0,
+            ingested_at: now,
+            updated_at: now,
+        };
+        store.insert_task(&task).await.unwrap();
+        task
+    }
+
+    /// The whole closure-derived retirement path: issues vanish from the open
+    /// set, the poller queries their close reason at decision time, and
+    /// picked-up work concludes as done/rejected — while a scout in flight and
+    /// untouched backlog rows are left alone.
+    #[tokio::test]
+    async fn poll_once_retires_picked_up_work_when_issues_close() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = project();
+        store.insert_project(&project).await.unwrap();
+
+        let queued = seed_task(&store, &project, 1, TaskState::Queued).await;
+        let in_review = seed_task(&store, &project, 2, TaskState::InReview).await;
+        let ready = seed_task(&store, &project, 3, TaskState::ReadyToBuild).await;
+        let scouting = seed_task(&store, &project, 4, TaskState::Scouting).await;
+        let backlog = seed_task(&store, &project, 5, TaskState::Backlog).await;
+
+        let url = spawn_fake_github(vec![
+            // Poll: the repository has no open issues left.
+            json!({"data": {"repository": {"issues": {
+                "pageInfo": {"hasNextPage": false, "endCursor": null},
+                "nodes": []}}}}),
+            // Close-info lookup for the three retirable tasks. Issue 3 no
+            // longer resolves (deleted / converted) -> retired as done anyway.
+            json!({
+                "data": {"repository": {
+                    "i1": {"number": 1, "state": "CLOSED", "stateReason": "COMPLETED"},
+                    "i2": {"number": 2, "state": "CLOSED", "stateReason": "NOT_PLANNED"},
+                    "i3": null,
+                }},
+                "errors": [{"message": "Could not resolve to an Issue with the number of 3."}]
+            }),
+        ])
+        .await;
+        let github = GitHubClient::with_base_url("token", url);
+
+        poll_once(&store, &github).await.unwrap();
+
+        let state_of = async |id: &TaskId| store.get_task(id).await.unwrap().unwrap();
+        let queued = state_of(&queued.id).await;
+        assert_eq!(queued.state, TaskState::Done);
+        assert_eq!(queued.manual_rank, None, "retirement frees the queue slot");
+        assert_eq!(state_of(&in_review.id).await.state, TaskState::Rejected);
+        assert_eq!(state_of(&ready.id).await.state, TaskState::Done);
+        assert_eq!(
+            state_of(&scouting.id).await.state,
+            TaskState::Scouting,
+            "a scout in flight is not interrupted; it retires from in_review next poll"
+        );
+        assert_eq!(state_of(&backlog.id).await.state, TaskState::Backlog);
+
+        let payloads: Vec<EventPayload> = store
+            .events_since(0)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.payload)
+            .collect();
+        assert!(payloads.contains(&EventPayload::TaskStateChanged {
+            task_id: queued.id.clone(),
+            from: TaskState::Queued,
+            to: TaskState::Done,
+        }));
+        assert!(payloads.contains(&EventPayload::TaskStateChanged {
+            task_id: in_review.id,
+            from: TaskState::InReview,
+            to: TaskState::Rejected,
+        }));
+    }
+
+    /// A failed close-reason lookup must not strand the candidates — they stay
+    /// picked up and the next poll tries again.
+    #[tokio::test]
+    async fn poll_once_leaves_retirement_for_next_poll_when_lookup_fails() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = project();
+        store.insert_project(&project).await.unwrap();
+        let task = seed_task(&store, &project, 1, TaskState::InReview).await;
+
+        let url = spawn_fake_github(vec![
+            json!({"data": {"repository": {"issues": {
+                "pageInfo": {"hasNextPage": false, "endCursor": null},
+                "nodes": []}}}}),
+            json!({"errors": [{"message": "Bad credentials"}]}),
+        ])
+        .await;
+        let github = GitHubClient::with_base_url("token", url);
+
+        poll_once(&store, &github).await.unwrap();
+
+        let after = store.get_task(&task.id).await.unwrap().unwrap();
+        assert_eq!(after.state, TaskState::InReview, "still a candidate");
+        assert_eq!(
+            after.gh_state,
+            GhState::Closed,
+            "closure was still recorded"
+        );
+        assert_eq!(
+            store.list_retirable_tasks(&project.id).await.unwrap().len(),
+            1
         );
     }
 }

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -549,6 +549,87 @@ impl Store {
         Ok(closed)
     }
 
+    /// Tasks whose GitHub issue is closed but whose Tasks-owned state still
+    /// says the work is picked up: `queued`, `in_review`, or `ready_to_build`.
+    ///
+    /// These are the closure-derived retirement candidates — issue closure IS
+    /// the "done" signal, there is no manual mark-done. `scouting` is
+    /// deliberately excluded: a scout in flight runs to completion, lands the
+    /// task in `in_review`, and the next poll retires it from there. The list
+    /// is not limited to issues closed *this* poll, so rows that predate this
+    /// mechanism (or that a failed reason-lookup skipped) self-heal on any
+    /// later pass.
+    pub async fn list_retirable_tasks(
+        &self,
+        project_id: &ProjectId,
+    ) -> Result<Vec<Task>, StoreError> {
+        let rows = sqlx::query(
+            "SELECT id, project_id, gh_issue_number, title, body, labels, gh_state, \
+             state, priority, manual_rank, dispatch_attempts, ingested_at, updated_at \
+             FROM tasks WHERE project_id = ? AND gh_state = ? AND state IN (?, ?, ?) \
+             ORDER BY ingested_at",
+        )
+        .bind(project_id.as_str())
+        .bind(GhState::Closed.as_str())
+        .bind(TaskState::Queued.as_str())
+        .bind(TaskState::InReview.as_str())
+        .bind(TaskState::ReadyToBuild.as_str())
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(task_from_row).collect()
+    }
+
+    /// Retire a picked-up task because its GitHub issue was closed. `to` is
+    /// `Done` (closed as completed) or `Rejected` (closed as not-planned /
+    /// duplicate) — nothing else is a retirement.
+    ///
+    /// Re-checks inside the transaction that the task is still a retirement
+    /// candidate ([`Self::list_retirable_tasks`]'s criteria); if the state
+    /// moved or the issue reopened in the meantime, returns `Ok(None)` and
+    /// writes nothing. Clears `manual_rank` so retired work frees its queue
+    /// slot, and emits [`EventPayload::TaskStateChanged`].
+    pub async fn retire_task(
+        &self,
+        id: &TaskId,
+        to: TaskState,
+    ) -> Result<Option<Task>, StoreError> {
+        if !matches!(to, TaskState::Done | TaskState::Rejected) {
+            return Err(StoreError::Invalid(format!(
+                "{} is not a retirement state",
+                to.as_str()
+            )));
+        }
+
+        let mut tx = self.pool.begin().await?;
+        let task = self
+            .get_task_in_tx(&mut tx, id)
+            .await?
+            .ok_or_else(|| StoreError::NotFound(format!("task {id}")))?;
+        let retirable = task.gh_state == GhState::Closed
+            && matches!(
+                task.state,
+                TaskState::Queued | TaskState::InReview | TaskState::ReadyToBuild
+            );
+        if !retirable {
+            return Ok(None);
+        }
+        sqlx::query("UPDATE tasks SET state = ?, manual_rank = NULL, updated_at = ? WHERE id = ?")
+            .bind(to.as_str())
+            .bind(Utc::now().to_rfc3339())
+            .bind(id.as_str())
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+
+        self.append_event(EventPayload::TaskStateChanged {
+            task_id: id.clone(),
+            from: task.state,
+            to,
+        })
+        .await?;
+        self.get_task(id).await
+    }
+
     pub async fn update_task_state(&self, id: &TaskId, state: TaskState) -> Result<(), StoreError> {
         let now = Utc::now().to_rfc3339();
         let result = sqlx::query("UPDATE tasks SET state = ?, updated_at = ? WHERE id = ?")
@@ -2925,5 +3006,121 @@ mod tests {
             .unwrap();
         let back = store.get_session(&session.id).await.unwrap().unwrap();
         assert_eq!(back.usage, Some(usage));
+    }
+
+    #[tokio::test]
+    async fn retirable_listing_is_closed_and_picked_up_only() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+
+        let mut wanted = Vec::new();
+        for (number, state, gh_state) in [
+            (1, TaskState::Queued, GhState::Closed),
+            (2, TaskState::InReview, GhState::Closed),
+            (3, TaskState::ReadyToBuild, GhState::Closed),
+            // Not candidates: still open, never picked up, mid-scout, or done.
+            (4, TaskState::Queued, GhState::Open),
+            (5, TaskState::Backlog, GhState::Closed),
+            (6, TaskState::Scouting, GhState::Closed),
+            (7, TaskState::Done, GhState::Closed),
+        ] {
+            let mut task = sample_task(&project.id);
+            task.gh_issue_number = number;
+            task.state = state;
+            task.gh_state = gh_state;
+            store.insert_task(&task).await.unwrap();
+            if number <= 3 {
+                wanted.push(task.id);
+            }
+        }
+
+        let mut got: Vec<TaskId> = store
+            .list_retirable_tasks(&project.id)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        got.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        wanted.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        assert_eq!(got, wanted);
+    }
+
+    #[tokio::test]
+    async fn retire_task_concludes_the_work_and_frees_its_queue_slot() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+
+        let mut task = sample_task(&project.id);
+        task.state = TaskState::Queued;
+        task.gh_state = GhState::Closed;
+        task.manual_rank = Some(3);
+        store.insert_task(&task).await.unwrap();
+
+        let retired = store
+            .retire_task(&task.id, TaskState::Done)
+            .await
+            .unwrap()
+            .expect("task was retirable");
+        assert_eq!(retired.state, TaskState::Done);
+        assert_eq!(retired.manual_rank, None);
+
+        let payloads: Vec<EventPayload> = store
+            .events_since(0)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.payload)
+            .collect();
+        assert!(payloads.contains(&EventPayload::TaskStateChanged {
+            task_id: task.id.clone(),
+            from: TaskState::Queued,
+            to: TaskState::Done,
+        }));
+    }
+
+    /// Retirement is a no-op (not an error) when the decision-time re-check
+    /// fails: the issue reopened, or the state moved on.
+    #[tokio::test]
+    async fn retire_task_declines_when_no_longer_a_candidate() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+
+        let mut reopened = sample_task(&project.id);
+        reopened.state = TaskState::InReview;
+        reopened.gh_state = GhState::Open;
+        store.insert_task(&reopened).await.unwrap();
+        assert!(
+            store
+                .retire_task(&reopened.id, TaskState::Done)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let mut scouting = sample_task(&project.id);
+        scouting.gh_issue_number = 43;
+        scouting.state = TaskState::Scouting;
+        scouting.gh_state = GhState::Closed;
+        store.insert_task(&scouting).await.unwrap();
+        assert!(
+            store
+                .retire_task(&scouting.id, TaskState::Rejected)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Neither attempt left a trace.
+        assert!(store.events_since(0).await.unwrap().is_empty());
+
+        let err = store
+            .retire_task(&reopened.id, TaskState::Backlog)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StoreError::Invalid(_)));
     }
 }

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -123,6 +123,14 @@ All enums are snake_case strings on the wire:
   for a Builder) → `done`, with `rejected` as the terminal failure state.
   Scout failures and `needs_revision` verdicts return to `queued`, never
   `backlog` — picked-up work stays picked up.
+- There is no "mark done" endpoint, deliberately: **closing the GitHub issue
+  is the done signal.** When a picked-up task's issue closes, the next poll
+  retires it — `queued`/`in_review`/`ready_to_build` become `done` (or
+  `rejected` if the issue was closed as not-planned / duplicate), the task's
+  `manual_rank` clears, and a normal `task_state_changed` event fires. A
+  `scouting` task is left to finish first and retires from `in_review` on the
+  following poll. Clients shouldn't offer a complete/done action; link to the
+  issue instead.
 - `Session.status`: `running`, `scout_succeeded`, `scout_failed`, `cancelled`.
 - `SpecQueueEntry.status`: `pending_review`, `approved`, `needs_revision`,
   `blocked`, `rejected` (only the three verdict values are accepted by the


### PR DESCRIPTION
There is no manual mark-done — **closing the GitHub issue is the done signal**.

Each poll, after absence reconciliation, tasks that are gh-closed but still picked up (`queued` / `in_review` / `ready_to_build`) have their close reason queried at decision time (GraphQL `stateReason`, never persisted, per the sync rule):

- `COMPLETED` (or anything else) → `done`
- `NOT_PLANNED` / `DUPLICATE` → `rejected`
- unresolvable number (deleted / converted to discussion) → `done` with a warn

Retirement clears `manual_rank` so the queue slot frees up, emits the normal `task_state_changed` event, and re-checks candidacy inside the transaction (a reopen or state move in the race window is a silent no-op). `scouting` is deliberately excluded: a scout in flight finishes, lands `in_review`, and retires on the following poll. A failed reason lookup leaves candidates for the next pass, and the candidate scan isn't limited to this poll's closures — pre-existing residue (#759/#760/#762 rows) self-heals on the first poll after deploy.

Tests: aliased-query parsing incl. dead numbers, store retire/decline paths, and two end-to-end `poll_once` runs against a fake GraphQL server.