### PR TITLE
Hide concluded work behind closed issues from the default /tasks listing

### DIFF
--- a/crates/tasks/src/server.rs
+++ b/crates/tasks/src/server.rs
@@ -825,12 +825,25 @@ mod tests {
         let open_new = insert_task(&store, &project, 1, 0).await;
         let closed_new = insert_task(&store, &project, 2, 0).await;
         let closed_spec_ready = insert_task(&store, &project, 3, 0).await;
+        let retired = insert_task(&store, &project, 4, 0).await;
+        let open_rejected = insert_task(&store, &project, 5, 0).await;
         store
-            .reconcile_closed_issues(&project.id, &[open_new.gh_issue_number])
+            .reconcile_closed_issues(
+                &project.id,
+                &[open_new.gh_issue_number, open_rejected.gh_issue_number],
+            )
             .await
             .unwrap();
         store
             .update_task_state(&closed_spec_ready.id, TaskState::InReview)
+            .await
+            .unwrap();
+        store
+            .update_task_state(&retired.id, TaskState::Done)
+            .await
+            .unwrap();
+        store
+            .update_task_state(&open_rejected.id, TaskState::Rejected)
             .await
             .unwrap();
         let base = spawn(store.clone()).await;
@@ -850,9 +863,17 @@ mod tests {
         assert!(visible.contains(&open_new.id));
         assert!(
             visible.contains(&closed_spec_ready.id),
-            "work that reached a spec stays visible"
+            "in-flight work stays visible even with the issue closed"
         );
         assert!(!visible.contains(&closed_new.id));
+        assert!(
+            !visible.contains(&retired.id),
+            "concluded work behind a closed issue is history, not the working set"
+        );
+        assert!(
+            visible.contains(&open_rejected.id),
+            "a terminal task on a still-open issue is a pending decision, so it shows"
+        );
 
         let all: Vec<TaskId> = http
             .get(format!("{base}/tasks?all=true"))
@@ -865,8 +886,9 @@ mod tests {
             .into_iter()
             .map(|t| t.id)
             .collect();
-        assert_eq!(all.len(), 3);
+        assert_eq!(all.len(), 5);
         assert!(all.contains(&closed_new.id));
+        assert!(all.contains(&retired.id));
 
         // The reorder response is the same projection as the default read — a
         // client swaps it in for its list, so the unfiltered variant here

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -210,22 +210,28 @@ impl Store {
         rows.into_iter().map(task_from_row).collect()
     }
 
-    /// [`Self::list_tasks`] minus pure intake noise: tasks whose issue is closed
-    /// on GitHub and that never left `new`.
+    /// [`Self::list_tasks`] minus rows whose story is over: tasks whose issue
+    /// is closed on GitHub and that are either untouched intake noise
+    /// (`backlog`) or work already concluded (`done` / `rejected` — closure
+    /// -derived retirement's output).
     ///
-    /// Anything further along the pipeline stays visible whatever GitHub thinks
-    /// of the issue — in-flight and historical work must not vanish from a
-    /// client's list because someone closed the issue behind it. Ordering is
-    /// identical to [`Self::list_tasks`].
+    /// Everything in between stays visible whatever GitHub thinks of the
+    /// issue — in-flight work must not vanish from a client's list because
+    /// someone closed the issue behind it; the poller will retire it properly.
+    /// A terminal task whose issue is still *open* also stays visible: it is
+    /// the "close the issue or re-queue?" decision surface. Full history is
+    /// [`Self::list_tasks`] (`GET /tasks?all=true`). Ordering is identical.
     pub async fn list_active_tasks(&self) -> Result<Vec<Task>, StoreError> {
         let rows = sqlx::query(
             "SELECT id, project_id, gh_issue_number, title, body, labels, gh_state, \
              state, priority, manual_rank, dispatch_attempts, ingested_at, updated_at \
-             FROM tasks WHERE NOT (gh_state = ? AND state = ?) \
+             FROM tasks WHERE NOT (gh_state = ? AND state IN (?, ?, ?)) \
              ORDER BY manual_rank IS NULL, manual_rank, priority DESC, ingested_at",
         )
         .bind(GhState::Closed.as_str())
         .bind(TaskState::Backlog.as_str())
+        .bind(TaskState::Done.as_str())
+        .bind(TaskState::Rejected.as_str())
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter().map(task_from_row).collect()

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -52,12 +52,13 @@ the server only.
 - `GET /tasks` — already in queue order; render it as-is, don't re-sort.
   Task: `{id, project_id, gh_issue_number, title, body, labels, gh_state,
   state, priority, manual_rank, dispatch_attempts, ingested_at, updated_at}`.
-  By default the list **omits tasks with `gh_state: "closed"` and
-  `state: "backlog"`** — issues that were closed on GitHub before any work started,
-  i.e. pure intake noise. Every other task stays visible whatever its
-  `gh_state`, so in-flight and historical work never disappears from the list
-  because someone closed the issue behind it. `GET /tasks?all=true` returns
-  every row including the closed intake. Ordering is identical either way.
+  By default the list **omits tasks whose issue is closed on GitHub and whose
+  state is `backlog`, `done`, or `rejected`** — closed-before-any-work intake
+  noise, and work already concluded (closure-derived retirement's output).
+  In-flight work stays visible whatever its `gh_state` (the poller retires it
+  properly), and a `done`/`rejected` task whose issue is still *open* also
+  shows — that's the "close the issue or re-queue?" decision surface.
+  `GET /tasks?all=true` returns every row. Ordering is identical either way.
 - `GET /sessions` / `GET /sessions/{id}` — scout runs.
 - `GET /specs` / `GET /specs/{id}` — `spec_markdown` is the deliverable;
   render it as Markdown. Also carries `files_touched`, `complexity`,


### PR DESCRIPTION
Retirement's output (done/rejected + gh-closed) is history, not the
working set — it now joins closed backlog intake behind ?all=true. A
terminal task whose issue is still open stays visible: it's the 'close
the issue or re-queue?' decision surface.
