### PR TITLE
Builder v0: consume approved specs into one branch and PR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/builder-supervisor",
     "crates/scout-supervisor",
     "crates/tasks",
     "crates/tasks-protocol",
@@ -43,6 +44,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 axum = "0.8"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tempfile = "3"
+base64 = "0.22"
 
 dirs = "6"
 

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,11 @@
 
 LINUX_TARGET := aarch64-unknown-linux-gnu
 SCOUT_BIN := target/$(LINUX_TARGET)/release/scout-supervisor
+BUILDER_BIN := target/$(LINUX_TARGET)/release/builder-supervisor
 VM_SUPERVISOR_BIN := target/$(LINUX_TARGET)/release/supervisor
 
-.PHONY: check-toolchain scout-supervisor-linux vm-supervisor-linux \
-        image-base image-agent image-scout images
+.PHONY: check-toolchain scout-supervisor-linux builder-supervisor-linux \
+        vm-supervisor-linux image-base image-agent image-scout image-builder images
 
 check-toolchain:
 	@which $(LINUX_TARGET)-gcc >/dev/null || { echo "missing cross linker: brew install messense/macos-cross-toolchains/aarch64-unknown-linux-gnu"; exit 1; }
@@ -17,6 +18,9 @@ check-toolchain:
 
 scout-supervisor-linux: check-toolchain
 	cargo build --release --target $(LINUX_TARGET) -p scout-supervisor
+
+builder-supervisor-linux: check-toolchain
+	cargo build --release --target $(LINUX_TARGET) -p builder-supervisor
 
 vm-supervisor-linux: check-toolchain
 	cargo build --release --target $(LINUX_TARGET) -p vm-pool-supervisor
@@ -35,4 +39,10 @@ image-scout: image-agent scout-supervisor-linux
 	container build -t agent:v1 images/scout
 	rm -f images/scout/scout-supervisor
 
-images: image-scout
+# The Builder image (BUILDER_IMAGE default).
+image-builder: image-agent builder-supervisor-linux
+	cp $(BUILDER_BIN) images/builder/builder-supervisor
+	container build -t builder:v1 images/builder
+	rm -f images/builder/builder-supervisor
+
+images: image-scout image-builder

--- a/crates/builder-supervisor/Cargo.toml
+++ b/crates/builder-supervisor/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "builder-supervisor"
+description = "PID 1 binary running inside a Builder VM. Clones a repo at full depth, drives the agent, ships the branch back as a git bundle."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "builder-supervisor"
+path = "src/main.rs"
+
+[dependencies]
+tokio.workspace = true
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+vm-pool-protocol.workspace = true
+tasks-protocol.workspace = true
+uuid.workspace = true
+base64.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/builder-supervisor/src/main.rs
+++ b/crates/builder-supervisor/src/main.rs
@@ -114,7 +114,15 @@ async fn main() -> Result<()> {
                     }),
             } => {
                 let tx = evt_tx.clone();
-                run_build(&build_id, &repo_clone_url, &base_branch, &branch, &prompt, tx).await;
+                run_build(
+                    &build_id,
+                    &repo_clone_url,
+                    &base_branch,
+                    &branch,
+                    &prompt,
+                    tx,
+                )
+                .await;
             }
             VmCommand::App {
                 payload: TaskCommand::Scout(_),
@@ -177,7 +185,12 @@ async fn run_build(
 
     // Full-depth clone — see the module doc. This is the single easiest way to
     // break branch egress while everything else still passes.
-    if let Err(e) = git(&workdir, &["clone", "--branch", base_branch, repo_clone_url, "."]).await {
+    if let Err(e) = git(
+        &workdir,
+        &["clone", "--branch", base_branch, repo_clone_url, "."],
+    )
+    .await
+    {
         fail!("clone: {e}");
     }
     // Identity for the sweep commit; a bare clone has none configured.
@@ -233,7 +246,9 @@ async fn run_build(
     if let Err(e) = git(&workdir, &["add", "-A"]).await {
         fail!("sweep add: {e}");
     }
-    let staged = git(&workdir, &["diff", "--cached", "--quiet"]).await.is_err();
+    let staged = git(&workdir, &["diff", "--cached", "--quiet"])
+        .await
+        .is_err();
     if staged
         && let Err(e) = git(
             &workdir,

--- a/crates/builder-supervisor/src/main.rs
+++ b/crates/builder-supervisor/src/main.rs
@@ -1,0 +1,419 @@
+//! builder-supervisor: PID 1 binary that runs inside a Builder VM.
+//!
+//! Protocol: speaks JSON-lines over stdin/stdout using vm-pool's
+//! VmCommand/VmEvent envelopes with [`TasksProtocol`] payloads. Answers only
+//! the `build` role; a `scout` command is refused with a terminal `Failed` —
+//! that refusal is the supervisor half of the Scout/Builder barrier.
+//!
+//! On [`BuildCommand::Start`]:
+//!   1. Creates a workdir
+//!   2. Clones the repo at `base_branch` — at FULL depth: `git bundle` refuses
+//!      to package history out of a shallow repository, and the branch (not a
+//!      text artifact) is this supervisor's deliverable
+//!   3. Records the base commit SHA, checks out the HOST-chosen `branch`
+//!      (the server pushes it, so the server names it)
+//!   4. Writes the prompt to `PROMPT.md` and pipes it to the agent's stdin
+//!   5. Runs the configured agent command, streaming stdout/stderr as Progress
+//!   6. Reads `SUMMARY.md` (optional PR prose), then removes both artifacts
+//!      from the worktree and sweeps everything else the agent left
+//!      uncommitted into a final commit — losing a build to a forgotten
+//!      `git commit` is a bad failure mode
+//!   7. `head == base` → `Failed` (the analogue of a scout's missing SPEC.md);
+//!      otherwise emits `Completed` with a base64 thin bundle of
+//!      `base_sha..branch`
+//!
+//! No credential ever needs to enter this VM for egress: the bundle rides the
+//! event stream and the server pushes with its own token.
+//!
+//! The agent command is configured via `BUILDER_AGENT_CMD` (tokens
+//! space-separated; no shell expansion). Default: `claude --print`.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use anyhow::{Context, Result};
+use base64::Engine as _;
+use tasks_protocol::{
+    BuildCommand, BuildEvent, LogStream, MAX_BUNDLE_BASE64_BYTES, TaskCommand, TaskEvent,
+    TasksProtocol,
+};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
+use vm_pool_protocol::{VmCommand, VmEvent};
+
+type TaskVmCommand = VmCommand<TasksProtocol>;
+type TaskVmEvent = VmEvent<TasksProtocol>;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string()))
+        .init();
+    info!("builder-supervisor starting");
+
+    let (evt_tx, mut evt_rx) = mpsc::channel::<TaskVmEvent>(128);
+
+    let writer = tokio::spawn(async move {
+        let mut stdout = tokio::io::stdout();
+        while let Some(event) = evt_rx.recv().await {
+            if let Err(e) = write_event(&mut stdout, &event).await {
+                error!("failed to write event: {e}");
+                break;
+            }
+        }
+    });
+
+    evt_tx.send(VmEvent::Ready).await.ok();
+
+    let stdin = tokio::io::stdin();
+    let mut reader = BufReader::new(stdin);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) => {
+                info!("stdin closed, shutting down");
+                break;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                error!("stdin read error: {e}");
+                break;
+            }
+        }
+
+        let command: TaskVmCommand = match serde_json::from_str(line.trim()) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("invalid command line ({e}): {}", line.trim());
+                continue;
+            }
+        };
+
+        match command {
+            VmCommand::Ping => {
+                evt_tx.send(VmEvent::Pong).await.ok();
+            }
+            VmCommand::Shutdown => {
+                info!("shutdown requested");
+                evt_tx.send(VmEvent::Shutdown).await.ok();
+                break;
+            }
+            VmCommand::App {
+                payload:
+                    TaskCommand::Build(BuildCommand::Start {
+                        build_id,
+                        repo_clone_url,
+                        base_branch,
+                        branch,
+                        prompt,
+                    }),
+            } => {
+                let tx = evt_tx.clone();
+                run_build(&build_id, &repo_clone_url, &base_branch, &branch, &prompt, tx).await;
+            }
+            VmCommand::App {
+                payload: TaskCommand::Scout(_),
+            } => {
+                warn!("received a scout command; this VM is a builder");
+                emit(
+                    &evt_tx,
+                    BuildEvent::Failed {
+                        reason: "this VM is a builder; refusing a scout command".into(),
+                    },
+                )
+                .await;
+            }
+        }
+    }
+
+    drop(evt_tx);
+    let _ = writer.await;
+    info!("builder-supervisor exiting");
+    Ok(())
+}
+
+async fn write_event(stdout: &mut tokio::io::Stdout, event: &TaskVmEvent) -> Result<()> {
+    let json = serde_json::to_string(event)?;
+    stdout.write_all(json.as_bytes()).await?;
+    stdout.write_all(b"\n").await?;
+    stdout.flush().await?;
+    Ok(())
+}
+
+async fn emit(tx: &mpsc::Sender<TaskVmEvent>, event: BuildEvent) {
+    let _ = tx
+        .send(VmEvent::App {
+            payload: TaskEvent::Build(event),
+        })
+        .await;
+}
+
+/// Run the Builder workflow. Every failure path emits `Failed` and returns.
+async fn run_build(
+    build_id: &str,
+    repo_clone_url: &str,
+    base_branch: &str,
+    branch: &str,
+    prompt: &str,
+    tx: mpsc::Sender<TaskVmEvent>,
+) {
+    macro_rules! fail {
+        ($($arg:tt)*) => {{
+            emit(&tx, BuildEvent::Failed { reason: format!($($arg)*) }).await;
+            return;
+        }};
+    }
+
+    let workdir = match make_workdir(build_id) {
+        Ok(w) => w,
+        Err(e) => fail!("workdir: {e}"),
+    };
+    debug!(build_id, workdir = %workdir.display(), "build workdir created");
+
+    // Full-depth clone — see the module doc. This is the single easiest way to
+    // break branch egress while everything else still passes.
+    if let Err(e) = git(&workdir, &["clone", "--branch", base_branch, repo_clone_url, "."]).await {
+        fail!("clone: {e}");
+    }
+    // Identity for the sweep commit; a bare clone has none configured.
+    for args in [
+        ["config", "user.email", "builder@tasks.invalid"].as_slice(),
+        ["config", "user.name", "Tasks Builder"].as_slice(),
+    ] {
+        if let Err(e) = git(&workdir, args).await {
+            fail!("git config: {e}");
+        }
+    }
+
+    let base_sha = match git_stdout(&workdir, &["rev-parse", "HEAD"]).await {
+        Ok(sha) => sha,
+        Err(e) => fail!("rev-parse: {e}"),
+    };
+
+    if let Err(e) = git(&workdir, &["checkout", "-b", branch]).await {
+        fail!("branch: {e}");
+    }
+    emit(
+        &tx,
+        BuildEvent::Started {
+            base_sha: base_sha.clone(),
+        },
+    )
+    .await;
+
+    if let Err(e) = tokio::fs::write(workdir.join("PROMPT.md"), prompt).await {
+        fail!("prompt write: {e}");
+    }
+
+    let exit_code = match run_agent(&workdir, prompt, tx.clone()).await {
+        Ok(code) => code,
+        Err(e) => fail!("agent: {e}"),
+    };
+    emit(&tx, BuildEvent::ImplementationFinished { exit_code }).await;
+
+    // SUMMARY.md is read before the artifact cleanup removes it. Optional:
+    // missing prose does not fail a build — the code is the deliverable.
+    let summary = tokio::fs::read_to_string(workdir.join("SUMMARY.md"))
+        .await
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    // Remove the artifacts from the worktree, then sweep. `git add -A` stages
+    // the removals as deletions if the agent committed them, alongside any
+    // implementation work the agent left uncommitted.
+    for artifact in ["PROMPT.md", "SUMMARY.md"] {
+        let _ = tokio::fs::remove_file(workdir.join(artifact)).await;
+    }
+    if let Err(e) = git(&workdir, &["add", "-A"]).await {
+        fail!("sweep add: {e}");
+    }
+    let staged = git(&workdir, &["diff", "--cached", "--quiet"]).await.is_err();
+    if staged
+        && let Err(e) = git(
+            &workdir,
+            &["commit", "-m", "Sweep: work the agent left uncommitted"],
+        )
+        .await
+    {
+        fail!("sweep commit: {e}");
+    }
+
+    let head_sha = match git_stdout(&workdir, &["rev-parse", "HEAD"]).await {
+        Ok(sha) => sha,
+        Err(e) => fail!("rev-parse head: {e}"),
+    };
+    if head_sha == base_sha {
+        fail!("agent produced no commits (head == base)");
+    }
+
+    let files_touched = match git_stdout(
+        &workdir,
+        &["diff", "--name-only", &format!("{base_sha}..{head_sha}")],
+    )
+    .await
+    {
+        Ok(out) => out.lines().map(str::to_string).collect(),
+        Err(e) => {
+            warn!("could not compute files_touched: {e}");
+            Vec::new()
+        }
+    };
+
+    // Thin bundle with base_sha as its prerequisite, carrying the branch ref
+    // the server will fetch by name.
+    let bundle_path = workdir.join(".git").join("egress.bundle");
+    if let Err(e) = git(
+        &workdir,
+        &[
+            "bundle",
+            "create",
+            &bundle_path.display().to_string(),
+            &format!("{base_sha}..refs/heads/{branch}"),
+        ],
+    )
+    .await
+    {
+        fail!("bundle: {e}");
+    }
+    let bundle_bytes = match tokio::fs::read(&bundle_path).await {
+        Ok(b) => b,
+        Err(e) => fail!("bundle read: {e}"),
+    };
+    let bundle_base64 = base64::engine::general_purpose::STANDARD.encode(&bundle_bytes);
+    if bundle_base64.len() > MAX_BUNDLE_BASE64_BYTES {
+        fail!(
+            "bundle too large: {} bytes encoded (cap {})",
+            bundle_base64.len(),
+            MAX_BUNDLE_BASE64_BYTES
+        );
+    }
+
+    emit(
+        &tx,
+        BuildEvent::Completed {
+            base_sha,
+            head_sha,
+            bundle_base64,
+            summary,
+            files_touched,
+        },
+    )
+    .await;
+}
+
+fn make_workdir(build_id: &str) -> Result<PathBuf> {
+    let base = std::env::var("BUILDER_WORKDIR_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir());
+    let dir = base.join(format!(
+        "build-{build_id}-{}",
+        &Uuid::new_v4().simple().to_string()[..8]
+    ));
+    std::fs::create_dir_all(&dir).context("create workdir")?;
+    Ok(dir)
+}
+
+async fn git(workdir: &Path, args: &[&str]) -> Result<()> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(workdir)
+        .output()
+        .await
+        .with_context(|| format!("spawn git {}", args.first().unwrap_or(&"")))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git {} exited with {}: {}",
+            args.join(" "),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+async fn git_stdout(workdir: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(workdir)
+        .output()
+        .await
+        .with_context(|| format!("spawn git {}", args.first().unwrap_or(&"")))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git {} exited with {}: {}",
+            args.join(" "),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+async fn run_agent(workdir: &Path, prompt: &str, tx: mpsc::Sender<TaskVmEvent>) -> Result<i32> {
+    let cmd_str = std::env::var("BUILDER_AGENT_CMD").unwrap_or_else(|_| "claude --print".into());
+    let mut parts = cmd_str.split_whitespace();
+    let prog = parts.next().context("BUILDER_AGENT_CMD is empty")?;
+    let args: Vec<&str> = parts.collect();
+    info!(?prog, ?args, workdir = %workdir.display(), "running agent");
+
+    let mut child = Command::new(prog)
+        .args(&args)
+        .current_dir(workdir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawn agent")?;
+
+    let mut stdin = child.stdin.take().context("agent stdin")?;
+    let prompt_owned = prompt.to_string();
+    tokio::spawn(async move {
+        let _ = stdin.write_all(prompt_owned.as_bytes()).await;
+        let _ = stdin.write_all(b"\n").await;
+        let _ = stdin.flush().await;
+        drop(stdin);
+    });
+
+    let stdout = child.stdout.take().context("agent stdout")?;
+    let stderr = child.stderr.take().context("agent stderr")?;
+
+    let tx_out = tx.clone();
+    let stdout_task = tokio::spawn(async move {
+        let mut r = BufReader::new(stdout).lines();
+        while let Ok(Some(line)) = r.next_line().await {
+            emit(
+                &tx_out,
+                BuildEvent::Progress {
+                    stream: LogStream::Stdout,
+                    line,
+                },
+            )
+            .await;
+        }
+    });
+    let tx_err = tx;
+    let stderr_task = tokio::spawn(async move {
+        let mut r = BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = r.next_line().await {
+            emit(
+                &tx_err,
+                BuildEvent::Progress {
+                    stream: LogStream::Stderr,
+                    line,
+                },
+            )
+            .await;
+        }
+    });
+
+    let status = child.wait().await.context("wait for agent")?;
+    let _ = stdout_task.await;
+    let _ = stderr_task.await;
+    Ok(status.code().unwrap_or(-1))
+}

--- a/crates/builder-supervisor/tests/fixtures/stub-builder-agent.sh
+++ b/crates/builder-supervisor/tests/fixtures/stub-builder-agent.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Minimal stand-in for `claude --print` used in builder integration tests.
+#
+# Reads the prompt from stdin, commits an implementation file (like a
+# well-behaved agent), leaves a second file UNCOMMITTED (exercising the
+# sweep), and writes SUMMARY.md for the PR body. Exits 0.
+
+set -e
+
+PROMPT=$(cat)
+echo "[stub-builder] starting in $(pwd)"
+echo "[stub-builder] prompt was: $PROMPT" >&2
+
+mkdir -p src
+printf 'pub fn built() {}\n' > src/built.rs
+git add src/built.rs
+git commit -q -m "Implement the spec"
+
+# Left uncommitted on purpose — the supervisor's sweep must catch it.
+printf 'forgotten\n' > src/forgotten.rs
+
+FIRST_LINE=$(printf '%s' "$PROMPT" | head -1)
+cat > SUMMARY.md <<EOF
+Implemented per spec. Prompt began: $FIRST_LINE
+EOF
+
+echo "[stub-builder] done"

--- a/crates/builder-supervisor/tests/integration.rs
+++ b/crates/builder-supervisor/tests/integration.rs
@@ -10,7 +10,9 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use base64::Engine as _;
-use tasks_protocol::{BuildCommand, BuildEvent, ScoutCommand, TaskCommand, TaskEvent, TasksProtocol};
+use tasks_protocol::{
+    BuildCommand, BuildEvent, ScoutCommand, TaskCommand, TaskEvent, TasksProtocol,
+};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::time::timeout;

--- a/crates/builder-supervisor/tests/integration.rs
+++ b/crates/builder-supervisor/tests/integration.rs
@@ -1,0 +1,305 @@
+//! Integration tests for builder-supervisor.
+//!
+//! Spins up the real supervisor binary as a child process, points it at a
+//! real local git repo fixture, runs a stub agent as the "agent command", and
+//! verifies BuildEvents — including that the returned bundle actually
+//! reconstructs the branch in a scratch repo. No mocks.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use base64::Engine as _;
+use tasks_protocol::{BuildCommand, BuildEvent, ScoutCommand, TaskCommand, TaskEvent, TasksProtocol};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::time::timeout;
+use vm_pool_protocol::{VmCommand, VmEvent};
+
+type TVmCommand = VmCommand<TasksProtocol>;
+type TVmEvent = VmEvent<TasksProtocol>;
+
+async fn build_supervisor() -> PathBuf {
+    let output = Command::new("cargo")
+        .args(["build", "-p", "builder-supervisor", "--message-format=json"])
+        .output()
+        .await
+        .expect("cargo build");
+    assert!(
+        output.status.success(),
+        "builder-supervisor build failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .find_map(|msg| {
+            let reason = msg.get("reason")?.as_str()?;
+            let target_name = msg.get("target")?.get("name")?.as_str()?;
+            if reason == "compiler-artifact" && target_name == "builder-supervisor" {
+                Some(PathBuf::from(msg.get("executable")?.as_str()?))
+            } else {
+                None
+            }
+        })
+        .expect("builder-supervisor binary path in cargo output")
+}
+
+async fn run_git(dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .await
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+async fn make_fixture_repo(dir: &Path) -> PathBuf {
+    let repo = dir.join("fixture-repo");
+    tokio::fs::create_dir_all(&repo).await.unwrap();
+    run_git(&repo, &["init", "-b", "main"]).await;
+    run_git(&repo, &["config", "user.email", "test@example.com"]).await;
+    run_git(&repo, &["config", "user.name", "Test"]).await;
+    tokio::fs::write(repo.join("README.md"), "# fixture\n")
+        .await
+        .unwrap();
+    run_git(&repo, &["add", "."]).await;
+    run_git(&repo, &["commit", "-m", "init"]).await;
+    repo
+}
+
+fn fixture_agent() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("stub-builder-agent.sh")
+}
+
+struct SupervisorProc {
+    child: Child,
+    stdin: tokio::process::ChildStdin,
+    stdout_lines: tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
+}
+
+impl SupervisorProc {
+    async fn spawn(binary: &Path, agent_cmd: &str, workdir_root: &Path) -> Self {
+        let mut cmd = Command::new(binary);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .env("BUILDER_AGENT_CMD", agent_cmd)
+            .env("BUILDER_WORKDIR_ROOT", workdir_root);
+        let mut child = cmd.spawn().expect("spawn supervisor");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let stdout_lines = BufReader::new(stdout).lines();
+        Self {
+            child,
+            stdin,
+            stdout_lines,
+        }
+    }
+
+    async fn send(&mut self, cmd: TVmCommand) {
+        let json = serde_json::to_string(&cmd).unwrap();
+        self.stdin.write_all(json.as_bytes()).await.unwrap();
+        self.stdin.write_all(b"\n").await.unwrap();
+        self.stdin.flush().await.unwrap();
+    }
+
+    async fn recv(&mut self) -> TVmEvent {
+        let line = timeout(Duration::from_secs(30), self.stdout_lines.next_line())
+            .await
+            .expect("recv timeout")
+            .expect("stdout read")
+            .expect("stdout line");
+        serde_json::from_str(&line).expect("parse event")
+    }
+
+    async fn close(mut self) {
+        drop(self.stdin);
+        let _ = self.child.wait().await;
+    }
+}
+
+fn start(repo_url: String) -> TVmCommand {
+    VmCommand::App {
+        payload: TaskCommand::Build(BuildCommand::Start {
+            build_id: "build_1".into(),
+            repo_clone_url: repo_url,
+            base_branch: "main".into(),
+            branch: "build/build_1".into(),
+            prompt: "## Spec 1 of 1: do the thing".into(),
+        }),
+    }
+}
+
+/// Drain until a terminal event, asserting the lifecycle shape on the way.
+async fn drain(sup: &mut SupervisorProc) -> BuildEvent {
+    loop {
+        match sup.recv().await {
+            VmEvent::App {
+                payload: TaskEvent::Build(evt),
+            } => match evt {
+                BuildEvent::Started { .. }
+                | BuildEvent::Progress { .. }
+                | BuildEvent::ImplementationFinished { .. } => continue,
+                terminal @ (BuildEvent::Completed { .. } | BuildEvent::Failed { .. }) => {
+                    return terminal;
+                }
+            },
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn a_build_ships_a_bundle_that_reconstructs_the_branch() {
+    let binary = build_supervisor().await;
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = make_fixture_repo(tmp.path()).await;
+    let repo_url = format!("file://{}", repo.display());
+    let base_tip = run_git(&repo, &["rev-parse", "main"]).await;
+
+    let agent = fixture_agent();
+    let mut sup = SupervisorProc::spawn(&binary, agent.to_str().unwrap(), tmp.path()).await;
+    assert!(matches!(sup.recv().await, VmEvent::Ready));
+
+    sup.send(start(repo_url.clone())).await;
+
+    let (base_sha, head_sha, bundle_base64, summary, files) = match drain(&mut sup).await {
+        BuildEvent::Completed {
+            base_sha,
+            head_sha,
+            bundle_base64,
+            summary,
+            files_touched,
+        } => (base_sha, head_sha, bundle_base64, summary, files_touched),
+        other => panic!("expected Completed, got {other:?}"),
+    };
+
+    assert_eq!(base_sha, base_tip, "branch grew from the fixture tip");
+    assert_ne!(head_sha, base_sha);
+    // The committed file, the swept file — and neither artifact.
+    assert!(files.contains(&"src/built.rs".to_string()));
+    assert!(
+        files.contains(&"src/forgotten.rs".to_string()),
+        "the sweep must commit work the agent forgot: {files:?}"
+    );
+    assert!(!files.iter().any(|f| f == "PROMPT.md" || f == "SUMMARY.md"));
+    assert!(summary.expect("summary").contains("Implemented per spec"));
+
+    // The no-mock proof: unbundle into a scratch repo exactly as the server
+    // will, and the branch tip must be the reported head.
+    let scratch = tmp.path().join("scratch.git");
+    tokio::fs::create_dir_all(&scratch).await.unwrap();
+    run_git(&scratch, &["init", "--bare"]).await;
+    run_git(&scratch, &["fetch", &repo_url, "main:refs/heads/main"]).await;
+    let bundle_path = tmp.path().join("egress.bundle");
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(bundle_base64)
+        .expect("valid base64");
+    tokio::fs::write(&bundle_path, bytes).await.unwrap();
+    run_git(
+        &scratch,
+        &[
+            "fetch",
+            bundle_path.to_str().unwrap(),
+            "refs/heads/build/build_1:refs/heads/build/build_1",
+        ],
+    )
+    .await;
+    let tip = run_git(&scratch, &["rev-parse", "refs/heads/build/build_1"]).await;
+    assert_eq!(tip, head_sha, "bundle reconstructs the reported head");
+
+    // The sweep commit's tree contains the forgotten file.
+    let listing = run_git(&scratch, &["ls-tree", "-r", "--name-only", &tip]).await;
+    assert!(listing.contains("src/forgotten.rs"));
+    assert!(!listing.contains("PROMPT.md"));
+    assert!(!listing.contains("SUMMARY.md"));
+
+    sup.send(VmCommand::Shutdown).await;
+    sup.close().await;
+}
+
+/// An agent that runs fine but commits nothing produced no build. `head ==
+/// base` is the Builder's missing-SPEC.md.
+#[tokio::test]
+async fn an_empty_branch_is_a_failure() {
+    let binary = build_supervisor().await;
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = make_fixture_repo(tmp.path()).await;
+    let repo_url = format!("file://{}", repo.display());
+
+    let mut sup = SupervisorProc::spawn(&binary, "true", tmp.path()).await;
+    assert!(matches!(sup.recv().await, VmEvent::Ready));
+    sup.send(start(repo_url)).await;
+
+    match drain(&mut sup).await {
+        BuildEvent::Failed { reason } => {
+            assert!(reason.contains("no commits"), "reason: {reason}");
+        }
+        other => panic!("expected Failed, got {other:?}"),
+    }
+
+    sup.send(VmCommand::Shutdown).await;
+    sup.close().await;
+}
+
+#[tokio::test]
+async fn a_clone_error_fails_before_started() {
+    let binary = build_supervisor().await;
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut sup = SupervisorProc::spawn(&binary, "true", tmp.path()).await;
+    assert!(matches!(sup.recv().await, VmEvent::Ready));
+    sup.send(start("file:///nonexistent/repo".into())).await;
+
+    match sup.recv().await {
+        VmEvent::App {
+            payload: TaskEvent::Build(BuildEvent::Failed { reason }),
+        } => assert!(reason.contains("clone"), "reason: {reason}"),
+        other => panic!("expected Failed, got {other:?}"),
+    }
+
+    sup.send(VmCommand::Shutdown).await;
+    sup.close().await;
+}
+
+/// The wire barrier's supervisor half: a Scout command sent to a Builder VM
+/// is refused with a terminal Failed, never acted on.
+#[tokio::test]
+async fn a_scout_command_is_refused_not_acted_on() {
+    let binary = build_supervisor().await;
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut sup = SupervisorProc::spawn(&binary, "true", tmp.path()).await;
+    assert!(matches!(sup.recv().await, VmEvent::Ready));
+
+    sup.send(VmCommand::App {
+        payload: TaskCommand::Scout(ScoutCommand::Start {
+            task_id: "task_x".into(),
+            repo_clone_url: "file:///nowhere".into(),
+            base_branch: "main".into(),
+            prompt: "n/a".into(),
+        }),
+    })
+    .await;
+
+    match sup.recv().await {
+        VmEvent::App {
+            payload: TaskEvent::Build(BuildEvent::Failed { reason }),
+        } => assert!(reason.contains("builder"), "reason: {reason}"),
+        other => panic!("expected a refusal, got {other:?}"),
+    }
+
+    sup.send(VmCommand::Shutdown).await;
+    sup.close().await;
+}

--- a/crates/scout-supervisor/src/main.rs
+++ b/crates/scout-supervisor/src/main.rs
@@ -26,7 +26,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use anyhow::{Context, Result};
-use tasks_protocol::{LogStream, ScoutCommand, ScoutEvent, TasksProtocol};
+use tasks_protocol::{LogStream, ScoutCommand, ScoutEvent, TaskCommand, TaskEvent, TasksProtocol};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::mpsc;
@@ -101,15 +101,29 @@ async fn main() -> Result<()> {
             }
             VmCommand::App {
                 payload:
-                    ScoutCommand::Start {
+                    TaskCommand::Scout(ScoutCommand::Start {
                         task_id,
                         repo_clone_url,
                         base_branch,
                         prompt,
-                    },
+                    }),
             } => {
                 let tx = evt_tx.clone();
                 run_scout(&task_id, &repo_clone_url, &base_branch, &prompt, tx).await;
+            }
+            // The information barrier's last line: this VM is a Scout, and a
+            // Build command is answered with a terminal refusal, never acted on.
+            VmCommand::App {
+                payload: TaskCommand::Build(_),
+            } => {
+                warn!("received a build command; this VM is a scout");
+                emit(
+                    &evt_tx,
+                    ScoutEvent::Failed {
+                        reason: "this VM is a scout; refusing a build command".into(),
+                    },
+                )
+                .await;
             }
         }
     }
@@ -129,7 +143,11 @@ async fn write_event(stdout: &mut tokio::io::Stdout, event: &TaskVmEvent) -> Res
 }
 
 async fn emit(tx: &mpsc::Sender<TaskVmEvent>, event: ScoutEvent) {
-    let _ = tx.send(VmEvent::App { payload: event }).await;
+    let _ = tx
+        .send(VmEvent::App {
+            payload: TaskEvent::Scout(event),
+        })
+        .await;
 }
 
 /// Run the Scout workflow for a task.

--- a/crates/scout-supervisor/tests/integration.rs
+++ b/crates/scout-supervisor/tests/integration.rs
@@ -9,7 +9,9 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use tasks_protocol::{BuildCommand, ScoutCommand, ScoutEvent, TaskCommand, TaskEvent, TasksProtocol};
+use tasks_protocol::{
+    BuildCommand, ScoutCommand, ScoutEvent, TaskCommand, TaskEvent, TasksProtocol,
+};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::time::timeout;
@@ -198,7 +200,8 @@ async fn start_scout_completes_with_spec() {
                 saw_impl_finished = true;
             }
             VmEvent::App {
-                payload: TaskEvent::Scout(evt @ (ScoutEvent::Completed { .. } | ScoutEvent::Failed { .. })),
+                payload:
+                    TaskEvent::Scout(evt @ (ScoutEvent::Completed { .. } | ScoutEvent::Failed { .. })),
             } => {
                 completion = Some(evt);
             }

--- a/crates/scout-supervisor/tests/integration.rs
+++ b/crates/scout-supervisor/tests/integration.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
-use tasks_protocol::{ScoutCommand, ScoutEvent, TasksProtocol};
+use tasks_protocol::{BuildCommand, ScoutCommand, ScoutEvent, TaskCommand, TaskEvent, TasksProtocol};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::time::timeout;
@@ -165,12 +165,12 @@ async fn start_scout_completes_with_spec() {
     assert!(matches!(sup.recv().await, VmEvent::Ready));
 
     sup.send(VmCommand::App {
-        payload: ScoutCommand::Start {
+        payload: TaskCommand::Scout(ScoutCommand::Start {
             task_id: "task_42".into(),
             repo_clone_url: repo_url,
             base_branch: "main".into(),
             prompt: "Implement a stub function.".into(),
-        },
+        }),
     })
     .await;
 
@@ -181,24 +181,24 @@ async fn start_scout_completes_with_spec() {
     while completion.is_none() {
         match sup.recv().await {
             VmEvent::App {
-                payload: ScoutEvent::Started { branch },
+                payload: TaskEvent::Scout(ScoutEvent::Started { branch }),
             } => {
                 assert!(branch.starts_with("scout/task_42-"));
                 saw_started = true;
             }
             VmEvent::App {
-                payload: ScoutEvent::Progress { .. },
+                payload: TaskEvent::Scout(ScoutEvent::Progress { .. }),
             } => {
                 // fine
             }
             VmEvent::App {
-                payload: ScoutEvent::ImplementationFinished { exit_code },
+                payload: TaskEvent::Scout(ScoutEvent::ImplementationFinished { exit_code }),
             } => {
                 assert_eq!(exit_code, 0);
                 saw_impl_finished = true;
             }
             VmEvent::App {
-                payload: evt @ (ScoutEvent::Completed { .. } | ScoutEvent::Failed { .. }),
+                payload: TaskEvent::Scout(evt @ (ScoutEvent::Completed { .. } | ScoutEvent::Failed { .. })),
             } => {
                 completion = Some(evt);
             }
@@ -248,12 +248,12 @@ async fn start_scout_fails_if_agent_missing_spec() {
     assert!(matches!(sup.recv().await, VmEvent::Ready));
 
     sup.send(VmCommand::App {
-        payload: ScoutCommand::Start {
+        payload: TaskCommand::Scout(ScoutCommand::Start {
             task_id: "task_7".into(),
             repo_clone_url: repo_url,
             base_branch: "main".into(),
             prompt: "n/a".into(),
-        },
+        }),
     })
     .await;
 
@@ -261,7 +261,7 @@ async fn start_scout_fails_if_agent_missing_spec() {
     while failure.is_none() {
         match sup.recv().await {
             VmEvent::App {
-                payload: ScoutEvent::Failed { reason },
+                payload: TaskEvent::Scout(ScoutEvent::Failed { reason }),
             } => {
                 failure = Some(ScoutEvent::Failed { reason });
             }
@@ -290,23 +290,55 @@ async fn start_scout_fails_on_clone_error() {
     assert!(matches!(sup.recv().await, VmEvent::Ready));
 
     sup.send(VmCommand::App {
-        payload: ScoutCommand::Start {
+        payload: TaskCommand::Scout(ScoutCommand::Start {
             task_id: "task_bad".into(),
             repo_clone_url: "file:///nonexistent/repo".into(),
             base_branch: "main".into(),
             prompt: "n/a".into(),
-        },
+        }),
     })
     .await;
 
     // First event should be a Failed (clone error) — we should not see Started.
     match sup.recv().await {
         VmEvent::App {
-            payload: ScoutEvent::Failed { reason },
+            payload: TaskEvent::Scout(ScoutEvent::Failed { reason }),
         } => {
             assert!(reason.contains("clone"), "reason: {reason}");
         }
         other => panic!("expected Failed, got {other:?}"),
+    }
+
+    sup.send(VmCommand::Shutdown).await;
+    sup.close().await;
+}
+
+/// The wire barrier's supervisor half: a Build command sent to a Scout VM is
+/// refused with a terminal Failed, never acted on.
+#[tokio::test]
+async fn a_build_command_is_refused_not_acted_on() {
+    let binary = build_supervisor().await;
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut sup = SupervisorProc::spawn(&binary, "true", tmp.path()).await;
+    assert!(matches!(sup.recv().await, VmEvent::Ready));
+
+    sup.send(VmCommand::App {
+        payload: TaskCommand::Build(BuildCommand::Start {
+            build_id: "build_x".into(),
+            repo_clone_url: "file:///nowhere".into(),
+            base_branch: "main".into(),
+            branch: "build/build_x".into(),
+            prompt: "n/a".into(),
+        }),
+    })
+    .await;
+
+    match sup.recv().await {
+        VmEvent::App {
+            payload: TaskEvent::Scout(ScoutEvent::Failed { reason }),
+        } => assert!(reason.contains("scout"), "reason: {reason}"),
+        other => panic!("expected a refusal, got {other:?}"),
     }
 
     sup.send(VmCommand::Shutdown).await;

--- a/crates/tasks-protocol/src/lib.rs
+++ b/crates/tasks-protocol/src/lib.rs
@@ -1,9 +1,19 @@
-//! Protocol types shared between the `tasks` server and Scout VMs.
+//! Protocol types shared between the `tasks` server and its agent VMs.
 //!
-//! The server sends [`ScoutCommand`] messages (wrapped in `VmCommand<P>` by
-//! vm-pool) to a Scout VM's supervisor. The supervisor streams back
-//! [`ScoutEvent`] messages (wrapped in `VmEvent<P>`). Infrastructure-level
-//! traffic (Ping/Pong/Shutdown/Ready) is handled by vm-pool itself.
+//! The server sends [`TaskCommand`] messages (wrapped in `VmCommand<P>` by
+//! vm-pool) to a VM's supervisor. The supervisor streams back [`TaskEvent`]
+//! messages (wrapped in `VmEvent<P>`). Infrastructure-level traffic
+//! (Ping/Pong/Shutdown/Ready) is handled by vm-pool itself.
+//!
+//! # The role union
+//!
+//! A vm-pool `Service` is monomorphised over exactly one `AppProtocol`, so
+//! Scouts and Builders share one wire type, tagged by `role`:
+//! `{"role":"scout","kind":"start",...}`. Each supervisor binary answers only
+//! its own role and rejects the other with a terminal `Failed` event. This is
+//! the Scout/Builder information barrier at the wire: a Builder VM cannot be
+//! handed Scout traffic by accident, because the mismatch is a rejection at
+//! the supervisor, not a convention in the caller.
 
 use serde::{Deserialize, Serialize};
 use vm_pool_protocol::AppProtocol;
@@ -13,8 +23,24 @@ use vm_pool_protocol::AppProtocol;
 pub struct TasksProtocol;
 
 impl AppProtocol for TasksProtocol {
-    type Command = ScoutCommand;
-    type Event = ScoutEvent;
+    type Command = TaskCommand;
+    type Event = TaskEvent;
+}
+
+/// Role-tagged command union: everything the tasks server can send to a VM.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "role", rename_all = "snake_case")]
+pub enum TaskCommand {
+    Scout(ScoutCommand),
+    Build(BuildCommand),
+}
+
+/// Role-tagged event union: everything a VM can stream back.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "role", rename_all = "snake_case")]
+pub enum TaskEvent {
+    Scout(ScoutEvent),
+    Build(BuildEvent),
 }
 
 /// Commands the tasks server sends to a Scout VM.
@@ -60,6 +86,63 @@ pub enum ScoutEvent {
     Failed { reason: String },
 }
 
+/// Commands the tasks server sends to a Builder VM.
+///
+/// Like scouts, there is no cancel command — the host cancels a build by
+/// deallocating the VM.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BuildCommand {
+    /// Begin a build. The supervisor clones the repo at full depth, creates
+    /// `branch` (the *host* chooses the name — the host is what pushes it),
+    /// runs the agent with the provided prompt, sweeps any uncommitted work
+    /// into a final commit, and reports the commits back as a git bundle.
+    Start {
+        build_id: String,
+        repo_clone_url: String,
+        base_branch: String,
+        /// Branch the supervisor creates and the server later pushes.
+        branch: String,
+        /// The prompt the agent sees: concatenated approved spec markdown and
+        /// issue titles, rendered host-side. Nothing Scout-code-derived.
+        prompt: String,
+    },
+}
+
+/// Events a Builder VM streams back to the tasks server.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BuildEvent {
+    /// Supervisor cloned and branched; `base_sha` is the commit the branch
+    /// grew from (and the thin bundle's prerequisite).
+    Started { base_sha: String },
+    /// A stdout/stderr line from the agent process. Best-effort.
+    Progress { stream: LogStream, line: String },
+    /// Agent process finished; the sweep commit (if any) hasn't happened yet.
+    ImplementationFinished { exit_code: i32 },
+    /// Terminal success. `bundle_base64` is a *thin* `git bundle` of
+    /// `base_sha..head_sha` — the server unbundles, verifies the tip matches
+    /// `head_sha`, and pushes. Capped at [`MAX_BUNDLE_BASE64_BYTES`] encoded;
+    /// an oversized bundle is a `Failed`, not a truncation.
+    Completed {
+        base_sha: String,
+        head_sha: String,
+        bundle_base64: String,
+        /// SUMMARY.md if the agent wrote one — becomes the PR body. Missing
+        /// prose is not a failure; the code is the deliverable.
+        summary: Option<String>,
+        files_touched: Vec<String>,
+    },
+    /// Terminal failure. An empty branch (`head == base`) lands here — the
+    /// Builder analogue of a Scout's missing SPEC.md.
+    Failed { reason: String },
+}
+
+/// Hard cap on the base64-encoded bundle carried in [`BuildEvent::Completed`].
+/// Past this the supervisor fails the build loudly rather than shipping a
+/// blob that would dominate the JSON-lines transport.
+pub const MAX_BUNDLE_BASE64_BYTES: usize = 32 * 1024 * 1024;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LogStream {
@@ -72,38 +155,72 @@ mod tests {
     use super::*;
     use vm_pool_protocol::{ServiceCommand, ServiceEvent, VmCommand, VmEvent, VmId};
 
-    #[test]
-    fn scout_command_roundtrip() {
-        let cmd = ScoutCommand::Start {
-            task_id: "task_abc".into(),
-            repo_clone_url: "https://github.com/o/r.git".into(),
-            base_branch: "main".into(),
-            prompt: "## Issue\nFix the thing.".into(),
-        };
-        let json = serde_json::to_string(&cmd).unwrap();
-        assert!(json.contains("\"kind\":\"start\""));
-        let back: ScoutCommand = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, cmd);
-    }
-
-    #[test]
-    fn scout_event_roundtrip() {
-        let evt = ScoutEvent::Completed {
-            spec_markdown: "## Spec\nstuff".into(),
-            files_touched: vec!["src/lib.rs".into()],
-        };
-        let json = serde_json::to_string(&evt).unwrap();
-        let back: ScoutEvent = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, evt);
-    }
-
-    fn start_cmd() -> ScoutCommand {
-        ScoutCommand::Start {
+    fn start_cmd() -> TaskCommand {
+        TaskCommand::Scout(ScoutCommand::Start {
             task_id: "task_abc".into(),
             repo_clone_url: "https://github.com/o/r.git".into(),
             base_branch: "main".into(),
             prompt: "go".into(),
-        }
+        })
+    }
+
+    #[test]
+    fn scout_command_roundtrip_carries_both_tags() {
+        let cmd = start_cmd();
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("\"role\":\"scout\""));
+        assert!(json.contains("\"kind\":\"start\""));
+        let back: TaskCommand = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, cmd);
+    }
+
+    #[test]
+    fn build_command_roundtrip() {
+        let cmd = TaskCommand::Build(BuildCommand::Start {
+            build_id: "build_abc".into(),
+            repo_clone_url: "https://github.com/o/r.git".into(),
+            base_branch: "main".into(),
+            branch: "build/build_abc".into(),
+            prompt: "## Spec 1 of 1".into(),
+        });
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("\"role\":\"build\""));
+        let back: TaskCommand = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, cmd);
+    }
+
+    #[test]
+    fn build_event_roundtrip() {
+        let evt = TaskEvent::Build(BuildEvent::Completed {
+            base_sha: "a".repeat(40),
+            head_sha: "b".repeat(40),
+            bundle_base64: "AAAA".into(),
+            summary: Some("Did the thing.".into()),
+            files_touched: vec!["src/lib.rs".into()],
+        });
+        let json = serde_json::to_string(&evt).unwrap();
+        let back: TaskEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, evt);
+    }
+
+    /// The barrier is a deserialization error, not a convention: a scout
+    /// payload relabelled `build` does not decode into a BuildCommand.
+    #[test]
+    fn a_relabelled_scout_payload_does_not_cross_the_barrier() {
+        let scout = serde_json::to_string(&start_cmd()).unwrap();
+        let forged = scout.replace("\"role\":\"scout\"", "\"role\":\"build\"");
+        assert!(
+            serde_json::from_str::<TaskCommand>(&forged).is_err(),
+            "a scout start is not a build start"
+        );
+
+        let evt = TaskEvent::Scout(ScoutEvent::Completed {
+            spec_markdown: "## Spec".into(),
+            files_touched: vec![],
+        });
+        let json = serde_json::to_string(&evt).unwrap();
+        let forged = json.replace("\"role\":\"scout\"", "\"role\":\"build\"");
+        assert!(serde_json::from_str::<TaskEvent>(&forged).is_err());
     }
 
     #[test]
@@ -121,9 +238,9 @@ mod tests {
     fn service_event_composes() {
         let evt: ServiceEvent<TasksProtocol> = ServiceEvent::VmApp {
             vm_id: VmId::new("vm-abc"),
-            event: ScoutEvent::Started {
+            event: TaskEvent::Scout(ScoutEvent::Started {
                 branch: "scout/42-uuid".into(),
-            },
+            }),
         };
         let json = serde_json::to_string(&evt).unwrap();
         let back: ServiceEvent<TasksProtocol> = serde_json::from_str(&json).unwrap();
@@ -131,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn vm_command_wraps_scout_command() {
+    fn vm_command_wraps_task_command() {
         let wrapped: VmCommand<TasksProtocol> = VmCommand::App {
             payload: start_cmd(),
         };
@@ -141,11 +258,11 @@ mod tests {
     }
 
     #[test]
-    fn vm_event_wraps_scout_event() {
+    fn vm_event_wraps_task_event() {
         let wrapped: VmEvent<TasksProtocol> = VmEvent::App {
-            payload: ScoutEvent::Failed {
+            payload: TaskEvent::Scout(ScoutEvent::Failed {
                 reason: "clone timed out".into(),
-            },
+            }),
         };
         let json = serde_json::to_string(&wrapped).unwrap();
         let back: VmEvent<TasksProtocol> = serde_json::from_str(&json).unwrap();

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -29,6 +29,7 @@ vm-pool-client.workspace = true
 vm-pool-service.workspace = true
 vm-pool-manager.workspace = true
 tasks-protocol.workspace = true
+base64.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/tasks/migrations/0007_builds.sql
+++ b/crates/tasks/migrations/0007_builds.sql
@@ -1,0 +1,35 @@
+-- Builder v0: one serial run over a set of approved specs -> one branch, one
+-- PR. `build_specs` (not a builds.spec_id column) is the point: the model is
+-- set-shaped even though v0 usually carries one spec. `position` is the
+-- spec-queue order at request time.
+--
+-- Everything stored is Tasks-owned or immutable. `pr_number` is an
+-- identifier, never a state -- PR mergeability / checks / open-closed are
+-- GitHub's, queried at decision time.
+CREATE TABLE builds (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id),
+    vm_id TEXT,
+    branch TEXT NOT NULL,
+    base_branch TEXT NOT NULL,
+    base_sha TEXT,
+    head_sha TEXT,
+    pr_number INTEGER,
+    status TEXT NOT NULL DEFAULT 'queued',
+    summary TEXT,
+    files_touched TEXT NOT NULL DEFAULT '[]',
+    exit_reason TEXT,
+    created_at TEXT NOT NULL,
+    started_at TEXT,
+    completed_at TEXT
+);
+
+CREATE TABLE build_specs (
+    build_id TEXT NOT NULL REFERENCES builds(id) ON DELETE CASCADE,
+    spec_id TEXT NOT NULL REFERENCES specs(id),
+    position INTEGER NOT NULL,
+    PRIMARY KEY (build_id, spec_id)
+);
+
+CREATE INDEX idx_builds_status ON builds(status);
+CREATE INDEX idx_build_specs_spec ON build_specs(spec_id);

--- a/crates/tasks/src/builder.rs
+++ b/crates/tasks/src/builder.rs
@@ -1,0 +1,594 @@
+//! Builder dispatcher: drives one Diamond 2 run — a batch of approved specs
+//! into one branch and one PR.
+//!
+//! Given a claimed [`Build`], the dispatcher allocates a Builder VM, sends a
+//! [`BuildCommand::Start`] whose prompt is the concatenated spec markdown
+//! (and nothing Scout-code-derived — see [`render_prompt`], the barrier's
+//! last mile), streams back [`BuildEvent`]s, and *lands the branch itself*:
+//! the VM's commits arrive as a thin git bundle over the event stream, the
+//! server unbundles them into a scratch repo, verifies the tip, and pushes
+//! with its own credentials. No repo-write credential ever enters a VM, and
+//! the PR (the system's only GitHub write) is opened server-side.
+//!
+//! `dispatch` finalizes the build on every exit path; all the fallible work
+//! lives in `attempt`, so no `?` can leave a build `running`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use thiserror::Error;
+use tokio::process::Command;
+use tracing::{debug, info, warn};
+use vm_pool_client::{ClientError, ClientHandle, EventStream};
+use vm_pool_protocol::{ServiceEvent, VmConfig, VmId};
+
+use crate::github::{GhError, GitHubClient};
+use crate::models::{Build, Project, Spec, Task};
+use crate::protocol::{BuildCommand, BuildEvent, TaskCommand, TaskEvent, TasksProtocol};
+use crate::store::{Store, StoreError};
+
+#[derive(Debug, Error)]
+pub enum BuilderError {
+    #[error("store: {0}")]
+    Store(#[from] StoreError),
+    #[error("vm-pool client: {0}")]
+    Client(#[from] ClientError),
+    #[error("github: {0}")]
+    GitHub(#[from] GhError),
+    #[error("build failed: {0}")]
+    BuildFailed(String),
+    #[error("branch egress: {0}")]
+    Egress(String),
+    #[error("vm-pool event stream closed before completion")]
+    StreamClosed,
+    #[error("build timed out after {secs}s")]
+    Timeout { secs: u64 },
+}
+
+/// How this dispatcher boots a Builder VM.
+#[derive(Debug, Clone)]
+pub struct BuilderConfig {
+    /// Image reference to allocate from vm-pool, e.g. `"builder:v1"`.
+    pub image: String,
+    pub vm_config: VmConfig,
+    /// Wall-clock budget for one build, allocation included.
+    pub timeout: Duration,
+    /// Where per-build scratch repos live (removed after each build,
+    /// success or failure).
+    pub scratch_root: PathBuf,
+}
+
+pub struct Builder {
+    store: Arc<Store>,
+    client: ClientHandle<TasksProtocol>,
+    github: Arc<GitHubClient>,
+    config: BuilderConfig,
+}
+
+impl Builder {
+    pub fn new(
+        store: Arc<Store>,
+        client: ClientHandle<TasksProtocol>,
+        github: Arc<GitHubClient>,
+        config: BuilderConfig,
+    ) -> Self {
+        Self {
+            store,
+            client,
+            github,
+            config,
+        }
+    }
+
+    /// Run a claimed (`running`) build to a terminal state. Finalizes the
+    /// build row on every path and returns the finished build.
+    pub async fn dispatch(&self, build: Build, clone_url: &str) -> Result<Build, BuilderError> {
+        info!(build_id = %build.id, branch = %build.branch, "build dispatch starting");
+        match self.attempt(&build, clone_url).await {
+            Ok(done) => Ok(done),
+            Err(e) => {
+                let reason = redact(&format!("{e}"));
+                warn!(build_id = %build.id, reason, "build failed");
+                self.store.finalize_build_failed(&build.id, &reason).await?;
+                Err(e)
+            }
+        }
+    }
+
+    /// Everything that can fail. A `?` here lands in `dispatch`'s failure
+    /// finalization — nothing can leave the build `running`.
+    async fn attempt(&self, build: &Build, clone_url: &str) -> Result<Build, BuilderError> {
+        let started = Instant::now();
+        // Subscribe before allocating so no event for our VM can be missed.
+        let mut events = self.client.subscribe_events();
+
+        let batch = self.load_batch(build).await?;
+        let project = self
+            .store
+            .get_project(&build.project_id)
+            .await?
+            .ok_or_else(|| StoreError::NotFound(format!("project {}", build.project_id)))?;
+        let prompt = render_prompt(&batch);
+
+        let vm_id = self
+            .client
+            .allocate(&self.config.image, self.config.vm_config.clone())
+            .await?;
+        info!(%vm_id, build_id = %build.id, "allocated builder VM");
+        self.store.set_build_vm(&build.id, vm_id.as_str()).await?;
+
+        let send = self
+            .client
+            .send_to_vm(
+                &vm_id,
+                TaskCommand::Build(BuildCommand::Start {
+                    build_id: build.id.to_string(),
+                    repo_clone_url: clone_url.to_string(),
+                    base_branch: build.base_branch.clone(),
+                    branch: build.branch.clone(),
+                    prompt,
+                }),
+            )
+            .await;
+
+        // From here every path must deallocate, so the drain result is held
+        // rather than `?`'d.
+        let result = match send {
+            Ok(()) => {
+                let remaining = self.config.timeout.saturating_sub(started.elapsed());
+                match tokio::time::timeout(
+                    remaining,
+                    self.drain_build_events(&mut events, &vm_id, &build.id),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_elapsed) => Err(BuilderError::Timeout {
+                        secs: self.config.timeout.as_secs(),
+                    }),
+                }
+            }
+            Err(e) => Err(e.into()),
+        };
+
+        if let Err(e) = self.client.deallocate(&vm_id).await {
+            warn!(%vm_id, error = %e, "failed to deallocate builder VM");
+        }
+        let outcome = result?;
+
+        // Egress: unbundle, verify, push — then the PR.
+        self.land_branch(build, clone_url, &outcome).await?;
+        let (title, body) = pr_text(&batch, &outcome);
+        let pr_number = self
+            .github
+            .create_pull_request(
+                &project.repo_owner,
+                &project.repo_name,
+                &build.branch,
+                &build.base_branch,
+                &title,
+                &body,
+            )
+            .await?;
+        info!(build_id = %build.id, pr_number, "pull request opened");
+
+        Ok(self
+            .store
+            .finalize_build_succeeded(
+                &build.id,
+                &outcome.head_sha,
+                pr_number,
+                outcome.summary.as_deref(),
+                &outcome.files_touched,
+            )
+            .await?)
+    }
+
+    /// Load the batch's `(Spec, Task)` pairs in position order.
+    async fn load_batch(&self, build: &Build) -> Result<Vec<(Spec, Task)>, BuilderError> {
+        let mut batch = Vec::new();
+        for spec_id in self.store.build_spec_ids(&build.id).await? {
+            let spec = self
+                .store
+                .get_spec(&spec_id)
+                .await?
+                .ok_or_else(|| StoreError::NotFound(format!("spec {spec_id}")))?;
+            let task = self
+                .store
+                .get_task(&spec.task_id)
+                .await?
+                .ok_or_else(|| StoreError::NotFound(format!("task {}", spec.task_id)))?;
+            batch.push((spec, task));
+        }
+        if batch.is_empty() {
+            return Err(BuilderError::BuildFailed("build has no specs".into()));
+        }
+        Ok(batch)
+    }
+
+    /// Consume this dispatch's event subscription until its VM reports a
+    /// terminal Completed/Failed.
+    async fn drain_build_events(
+        &self,
+        events: &mut EventStream<TasksProtocol>,
+        target_vm: &VmId,
+        build_id: &crate::models::BuildId,
+    ) -> Result<BuildOutcome, BuilderError> {
+        loop {
+            let event = events.recv().await.ok_or(BuilderError::StreamClosed)?;
+            match event {
+                ServiceEvent::VmApp {
+                    vm_id,
+                    event: TaskEvent::Build(app),
+                } if &vm_id == target_vm => match app {
+                    BuildEvent::Started { base_sha } => {
+                        self.store.set_build_base_sha(build_id, &base_sha).await?;
+                    }
+                    BuildEvent::Progress { line, .. } => {
+                        debug!(build_id = %build_id, "{line}");
+                    }
+                    BuildEvent::ImplementationFinished { exit_code } => {
+                        info!(build_id = %build_id, exit_code, "builder agent finished");
+                    }
+                    BuildEvent::Completed {
+                        base_sha,
+                        head_sha,
+                        bundle_base64,
+                        summary,
+                        files_touched,
+                    } => {
+                        return Ok(BuildOutcome {
+                            base_sha,
+                            head_sha,
+                            bundle_base64,
+                            summary,
+                            files_touched,
+                        });
+                    }
+                    BuildEvent::Failed { reason } => {
+                        return Err(BuilderError::BuildFailed(reason));
+                    }
+                },
+                _other => {}
+            }
+        }
+    }
+
+    /// Unbundle the VM's commits into a per-build scratch repo, verify the
+    /// tip matches what the VM reported, and push the branch with the
+    /// server's credentials.
+    ///
+    /// The scratch repo fetches the base branch from the remote FIRST: the
+    /// bundle is thin, `base_sha` is its prerequisite, and the remote is
+    /// where that commit stays reachable even if the base branch has moved
+    /// on. Fetching it shallowly would reintroduce the shallow-repo problem
+    /// one layer down.
+    async fn land_branch(
+        &self,
+        build: &Build,
+        clone_url: &str,
+        outcome: &BuildOutcome,
+    ) -> Result<(), BuilderError> {
+        let scratch = self
+            .config
+            .scratch_root
+            .join(format!("scratch-{}", build.id));
+        tokio::fs::create_dir_all(&scratch)
+            .await
+            .map_err(|e| BuilderError::Egress(format!("scratch dir: {e}")))?;
+
+        let result = self.land_in(&scratch, build, clone_url, outcome).await;
+        if let Err(e) = tokio::fs::remove_dir_all(&scratch).await {
+            warn!(scratch = %scratch.display(), error = %e, "could not remove scratch repo");
+        }
+        result
+    }
+
+    async fn land_in(
+        &self,
+        scratch: &std::path::Path,
+        build: &Build,
+        clone_url: &str,
+        outcome: &BuildOutcome,
+    ) -> Result<(), BuilderError> {
+        let branch_ref = format!("refs/heads/{}", build.branch);
+        let base_ref = format!("refs/heads/{}", build.base_branch);
+
+        git(scratch, &["init", "--bare", "--initial-branch", "trunk"]).await?;
+        git(
+            scratch,
+            &["fetch", clone_url, &format!("{base_ref}:{base_ref}")],
+        )
+        .await?;
+
+        let bundle_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&outcome.bundle_base64)
+            .map_err(|e| BuilderError::Egress(format!("bundle base64: {e}")))?;
+        let bundle_path = scratch.join("egress.bundle");
+        tokio::fs::write(&bundle_path, bundle_bytes)
+            .await
+            .map_err(|e| BuilderError::Egress(format!("bundle write: {e}")))?;
+
+        git(
+            scratch,
+            &[
+                "fetch",
+                bundle_path.to_str().unwrap_or_default(),
+                &format!("{branch_ref}:{branch_ref}"),
+            ],
+        )
+        .await?;
+
+        // Verify the tip before pushing: a truncated or wrong bundle must not
+        // be pushed as if it were the build.
+        let tip = git_stdout(scratch, &["rev-parse", &branch_ref]).await?;
+        if tip != outcome.head_sha {
+            return Err(BuilderError::Egress(format!(
+                "bundle tip {tip} does not match the reported head {}",
+                outcome.head_sha
+            )));
+        }
+
+        git(
+            scratch,
+            &["push", clone_url, &format!("{branch_ref}:{branch_ref}")],
+        )
+        .await?;
+        info!(build_id = %build.id, branch = %build.branch, "branch pushed");
+        Ok(())
+    }
+}
+
+struct BuildOutcome {
+    #[allow(dead_code)] // verified VM-side; kept for symmetry / debugging
+    base_sha: String,
+    head_sha: String,
+    bundle_base64: String,
+    summary: Option<String>,
+    files_touched: Vec<String>,
+}
+
+async fn git(dir: &std::path::Path, args: &[&str]) -> Result<(), BuilderError> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .await
+        .map_err(|e| BuilderError::Egress(format!("spawn git: {e}")))?;
+    if !output.status.success() {
+        // git echoes URLs (credentials included) in most errors.
+        return Err(BuilderError::Egress(redact(&format!(
+            "git {} exited with {}: {}",
+            args.first().unwrap_or(&""),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))));
+    }
+    Ok(())
+}
+
+async fn git_stdout(dir: &std::path::Path, args: &[&str]) -> Result<String, BuilderError> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .await
+        .map_err(|e| BuilderError::Egress(format!("spawn git: {e}")))?;
+    if !output.status.success() {
+        return Err(BuilderError::Egress(redact(&format!(
+            "git {} exited with {}: {}",
+            args.first().unwrap_or(&""),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Strip credentials from URLs embedded in text — clone URLs carry
+/// `x-access-token:<token>@`, and git repeats the URL in its errors, which
+/// flow into `exit_reason`, the event log, and the API.
+///
+/// Credential-aware rather than naive: only the userinfo of a `scheme://`
+/// URL's authority is stripped. An `@` later in a path is left alone.
+pub fn redact(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(idx) = rest.find("://") {
+        let (before, after) = rest.split_at(idx + 3);
+        out.push_str(before);
+        // Authority runs to the first `/`, `?`, `#`, whitespace, or quote.
+        let authority_end = after
+            .find(['/', '?', '#', ' ', '\t', '\n', '\r', '\'', '"'])
+            .unwrap_or(after.len());
+        let authority = &after[..authority_end];
+        match authority.rfind('@') {
+            Some(at) => {
+                out.push_str("***@");
+                out.push_str(&authority[at + 1..]);
+            }
+            None => out.push_str(authority),
+        }
+        rest = &after[authority_end..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// The Builder prompt: concatenated spec markdown plus issue title/number.
+/// This function is the information barrier's last mile — it takes `(Spec,
+/// Task)` pairs and emits nothing Scout-code-derived. If anything else ever
+/// needs to reach a Builder, the argument has to be made here, and the answer
+/// should be no.
+fn render_prompt(batch: &[(Spec, Task)]) -> String {
+    let n = batch.len();
+    let mut out = format!(
+        "You are a Builder in the Double Diamond architecture.\n\n\
+         You are implementing {n} approved spec(s). Each was written by a Scout \
+         that already explored the work by implementing it once in a throwaway \
+         branch you cannot see — the spec is the distilled result. Trust its \
+         pitfalls; verify its claims against the code in front of you.\n\n"
+    );
+    for (i, (spec, task)) in batch.iter().enumerate() {
+        out.push_str(&format!(
+            "## Spec {idx} of {n}: {title} (#{num})\n\n{content}\n\n",
+            idx = i + 1,
+            title = task.title,
+            num = task.gh_issue_number,
+            content = spec.content.trim(),
+        ));
+    }
+    out.push_str(
+        "## Your job\n\n\
+         1. Implement every spec above, in order, as one coherent change in \
+         the cloned repo (cwd). You are on the right branch already.\n\
+         2. Run the project's tests / lint / typecheck — get them green.\n\
+         3. Commit your work with clear messages (a git identity is configured).\n\
+         4. Write `SUMMARY.md` in the repo root: one or two paragraphs \
+         describing the change, suitable as a pull request body.\n\
+         5. Do NOT push and do NOT open a PR — the server does both.\n",
+    );
+    out
+}
+
+/// PR title + body. Body prefers the agent's SUMMARY.md; falls back to the
+/// spec titles. Says `Implements #N`, not `Closes #N`: closing an issue is
+/// GitHub state that isn't ours to write.
+fn pr_text(batch: &[(Spec, Task)], outcome: &BuildOutcome) -> (String, String) {
+    let title = match batch {
+        [(_, task)] => task.title.clone(),
+        _ => format!(
+            "Build: {}",
+            batch
+                .iter()
+                .map(|(_, t)| format!("#{}", t.gh_issue_number))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    };
+
+    let mut body = match &outcome.summary {
+        Some(s) => s.clone(),
+        None => batch
+            .iter()
+            .map(|(_, t)| format!("- {} (#{})", t.title, t.gh_issue_number))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    };
+    body.push_str("\n\n");
+    for (_, task) in batch {
+        body.push_str(&format!("Implements #{}\n", task.gh_issue_number));
+    }
+    (title, body)
+}
+
+/// The clone URL a Builder VM uses — same construction as scouts.
+pub fn project_clone_url(base: &str, token: Option<&str>, project: &Project) -> String {
+    crate::run::clone_url_for(base, token, project)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{Complexity, GhState, ProjectId, SessionId, SpecId, TaskId, TaskState};
+    use chrono::Utc;
+
+    fn pair(n: u64, title: &str, content: &str) -> (Spec, Task) {
+        let task_id = TaskId::new();
+        (
+            Spec {
+                id: SpecId::new(),
+                session_id: SessionId::new(),
+                task_id: task_id.clone(),
+                content: content.into(),
+                complexity: Complexity::Simple,
+                files_touched: vec!["secret_scout_file.rs".into()],
+                created_at: Utc::now(),
+            },
+            Task {
+                id: task_id,
+                project_id: ProjectId::new(),
+                gh_issue_number: n,
+                title: title.into(),
+                body: "issue body".into(),
+                labels: vec![],
+                gh_state: GhState::Open,
+                state: TaskState::Building,
+                priority: 0,
+                manual_rank: None,
+                dispatch_attempts: 0,
+                ingested_at: Utc::now(),
+                updated_at: Utc::now(),
+            },
+        )
+    }
+
+    #[test]
+    fn the_prompt_is_specs_and_issue_identity_only() {
+        let batch = vec![
+            pair(7, "First thing", "## Spec: first\ndo it"),
+            pair(9, "Second thing", "## Spec: second\ndo that"),
+        ];
+        let prompt = render_prompt(&batch);
+
+        let first = prompt.find("## Spec 1 of 2: First thing (#7)").unwrap();
+        let second = prompt.find("## Spec 2 of 2: Second thing (#9)").unwrap();
+        let job = prompt.find("## Your job").unwrap();
+        assert!(first < second && second < job, "batch order preserved");
+        assert!(prompt.contains("do it") && prompt.contains("do that"));
+
+        // The barrier: nothing scout-run-derived leaks — not the files the
+        // scout touched, not the issue body (the spec subsumes it).
+        assert!(!prompt.contains("secret_scout_file.rs"));
+        assert!(!prompt.contains("issue body"));
+    }
+
+    #[test]
+    fn pr_text_prefers_the_summary_and_never_says_closes() {
+        let batch = vec![pair(7, "First thing", "spec"), pair(9, "Second", "spec")];
+        let outcome = BuildOutcome {
+            base_sha: "a".into(),
+            head_sha: "b".into(),
+            bundle_base64: String::new(),
+            summary: Some("Did both things.".into()),
+            files_touched: vec![],
+        };
+        let (title, body) = pr_text(&batch, &outcome);
+        assert_eq!(title, "Build: #7, #9");
+        assert!(body.starts_with("Did both things."));
+        assert!(body.contains("Implements #7"));
+        assert!(body.contains("Implements #9"));
+        assert!(!body.contains("Closes"));
+
+        let single = vec![pair(7, "First thing", "spec")];
+        let no_summary = BuildOutcome {
+            summary: None,
+            ..outcome
+        };
+        let (title, body) = pr_text(&single, &no_summary);
+        assert_eq!(title, "First thing");
+        assert!(body.contains("- First thing (#7)"));
+    }
+
+    #[test]
+    fn redact_strips_credentials_but_not_path_ats() {
+        assert_eq!(
+            redact(
+                "fatal: could not read from 'https://x-access-token:ghp_abc123@github.com/o/r.git'"
+            ),
+            "fatal: could not read from 'https://***@github.com/o/r.git'"
+        );
+        assert_eq!(
+            redact("https://user@host/path and /a/path@with-at stays"),
+            "https://***@host/path and /a/path@with-at stays"
+        );
+        // No credentials, no change.
+        assert_eq!(
+            redact("https://github.com/o/r.git plain"),
+            "https://github.com/o/r.git plain"
+        );
+        assert_eq!(redact("no urls at all"), "no urls at all");
+    }
+}

--- a/crates/tasks/src/events.rs
+++ b/crates/tasks/src/events.rs
@@ -7,7 +7,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::models::{
-    GhState, Mode, ProjectId, SessionId, SessionStatus, SpecId, SpecQueueStatus, TaskId, TaskState,
+    BuildId, BuildStatus, GhState, Mode, ProjectId, SessionId, SessionStatus, SpecId,
+    SpecQueueStatus, TaskId, TaskState,
 };
 
 /// A timestamped, sequenced record. `seq` is assigned by the store on append.
@@ -71,6 +72,27 @@ pub enum EventPayload {
     /// The spec queue was reordered. Same semantics as [`Self::QueueReordered`].
     SpecQueueReordered {
         spec_ids: Vec<SpecId>,
+    },
+    /// A Builder run was requested over a set of approved specs.
+    BuildRequested {
+        build_id: BuildId,
+        spec_ids: Vec<SpecId>,
+    },
+    /// The serial build loop claimed the build; a Builder VM is running it.
+    BuildStarted {
+        build_id: BuildId,
+    },
+    /// The build reached a terminal status. Detail (branch, PR, exit reason)
+    /// is on the build row — refetch it.
+    BuildCompleted {
+        build_id: BuildId,
+        status: BuildStatus,
+    },
+    /// The server pushed the branch and opened the pull request. `pr_number`
+    /// is an identifier: the PR's state is GitHub's, queried, never stored.
+    PullRequestOpened {
+        build_id: BuildId,
+        pr_number: u64,
     },
     ModeChanged {
         from: Mode,

--- a/crates/tasks/src/github.rs
+++ b/crates/tasks/src/github.rs
@@ -12,6 +12,7 @@ use tracing::{debug, warn};
 use crate::models::GhState;
 
 const DEFAULT_BASE_URL: &str = "https://api.github.com/graphql";
+const DEFAULT_REST_BASE_URL: &str = "https://api.github.com";
 const PAGE_SIZE: u32 = 100;
 const CLOSE_INFO_BATCH: usize = 50;
 
@@ -21,6 +22,8 @@ pub enum GhError {
     Http(#[from] reqwest::Error),
     #[error("graphql: {0}")]
     GraphQl(String),
+    #[error("rest: {0}")]
+    Rest(String),
     #[error("unexpected response shape: {0}")]
     Shape(String),
 }
@@ -49,6 +52,7 @@ pub struct GitHubClient {
     http: reqwest::Client,
     token: String,
     base_url: String,
+    rest_base_url: String,
 }
 
 impl GitHubClient {
@@ -65,7 +69,58 @@ impl GitHubClient {
             http,
             token: token.into(),
             base_url: base_url.into(),
+            rest_base_url: DEFAULT_REST_BASE_URL.into(),
         }
+    }
+
+    /// Override the REST root (`GITHUB_REST_API_URL`) — GitHub Enterprise,
+    /// tests. Issues stay on GraphQL; only PR creation uses REST.
+    pub fn with_rest_base_url(mut self, rest_base_url: impl Into<String>) -> Self {
+        self.rest_base_url = rest_base_url.into();
+        self
+    }
+
+    /// Open a pull request — the system's only GitHub write, and it lives on
+    /// the server. Returns the PR *number*: an immutable identifier we may
+    /// persist. The PR's state/mergeability/checks are GitHub's and are not
+    /// read here, let alone stored.
+    pub async fn create_pull_request(
+        &self,
+        owner: &str,
+        name: &str,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+    ) -> Result<u64, GhError> {
+        let url = format!("{}/repos/{owner}/{name}/pulls", self.rest_base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.token)
+            .header("Accept", "application/vnd.github+json")
+            .json(&serde_json::json!({
+                "title": title,
+                "head": head,
+                "base": base,
+                "body": body,
+            }))
+            .send()
+            .await?;
+        let status = resp.status();
+        let body: serde_json::Value = resp.json().await?;
+        if !status.is_success() {
+            let msg = body
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("(no message)");
+            return Err(GhError::Rest(format!(
+                "create pull request: {status}: {msg}"
+            )));
+        }
+        body.get("number")
+            .and_then(|n| n.as_u64())
+            .ok_or_else(|| GhError::Shape("pull request response missing `number`".into()))
     }
 
     /// Fetch all OPEN issues for a repository, paging as needed.

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -3,6 +3,7 @@
 //! This library is split into modules: `models` (domain types), `store` (SQLite
 //! persistence). More modules land as we implement each step of the Diamond 1 plan.
 
+pub mod builder;
 pub mod events;
 pub mod github;
 pub mod models;

--- a/crates/tasks/src/models.rs
+++ b/crates/tasks/src/models.rs
@@ -44,6 +44,7 @@ id_newtype!(ProjectId, "proj");
 id_newtype!(TaskId, "task");
 id_newtype!(SessionId, "sess");
 id_newtype!(SpecId, "spec");
+id_newtype!(BuildId, "build");
 
 /// A repo being tracked.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -122,6 +123,9 @@ pub enum TaskState {
     InReview,
     /// Spec approved; parked until a Builder run consumes it.
     ReadyToBuild,
+    /// A Builder run is implementing this task's spec (possibly batched with
+    /// others). Failure returns to `ReadyToBuild` — the spec is still good.
+    Building,
     /// Completed through the pipeline.
     Done,
     /// Rejected and won't be pursued.
@@ -136,6 +140,7 @@ impl TaskState {
             TaskState::Scouting => "scouting",
             TaskState::InReview => "in_review",
             TaskState::ReadyToBuild => "ready_to_build",
+            TaskState::Building => "building",
             TaskState::Done => "done",
             TaskState::Rejected => "rejected",
         }
@@ -148,6 +153,7 @@ impl TaskState {
             "scouting" => Some(TaskState::Scouting),
             "in_review" => Some(TaskState::InReview),
             "ready_to_build" => Some(TaskState::ReadyToBuild),
+            "building" => Some(TaskState::Building),
             "done" => Some(TaskState::Done),
             "rejected" => Some(TaskState::Rejected),
             _ => None,
@@ -333,6 +339,10 @@ pub enum SpecQueueStatus {
     NeedsRevision,
     Blocked,
     Rejected,
+    /// Consumed by a successful Builder run. Terminal, and system-assigned:
+    /// `review_spec` rejects it — it is how the approved queue drains, not a
+    /// verdict a reviewer can render.
+    Built,
 }
 
 impl SpecQueueStatus {
@@ -343,6 +353,7 @@ impl SpecQueueStatus {
             SpecQueueStatus::NeedsRevision => "needs_revision",
             SpecQueueStatus::Blocked => "blocked",
             SpecQueueStatus::Rejected => "rejected",
+            SpecQueueStatus::Built => "built",
         }
     }
 
@@ -353,6 +364,7 @@ impl SpecQueueStatus {
             "needs_revision" => Some(SpecQueueStatus::NeedsRevision),
             "blocked" => Some(SpecQueueStatus::Blocked),
             "rejected" => Some(SpecQueueStatus::Rejected),
+            "built" => Some(SpecQueueStatus::Built),
             _ => None,
         }
     }
@@ -381,6 +393,70 @@ impl Mode {
             "play" => Some(Mode::Play),
             "pause" => Some(Mode::Pause),
             "stop" => Some(Mode::Stop),
+            _ => None,
+        }
+    }
+}
+
+/// One serial Builder run over a *set* of approved specs, producing one
+/// branch and one PR. Set-shaped from day one (`build_specs`), even though v0
+/// is usually invoked with a single spec.
+///
+/// Everything here is Tasks-owned or immutable. `pr_number` is an identifier,
+/// never a state: PR mergeability, checks, and open/closed are GitHub's and
+/// are queried at decision time, not stored.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Build {
+    pub id: BuildId,
+    pub project_id: ProjectId,
+    pub vm_id: Option<String>,
+    /// Branch name the server pushes, chosen at request time: `build/<id>`.
+    pub branch: String,
+    pub base_branch: String,
+    /// Commit the branch grew from — the bundle's prerequisite. Immutable.
+    pub base_sha: Option<String>,
+    /// Branch tip the VM reported and the server verified before pushing.
+    pub head_sha: Option<String>,
+    pub pr_number: Option<u64>,
+    pub status: BuildStatus,
+    /// SUMMARY.md from the agent (the PR body), if it wrote one.
+    pub summary: Option<String>,
+    pub files_touched: Vec<String>,
+    pub exit_reason: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildStatus {
+    /// Requested, waiting for the serial build loop to claim it.
+    Queued,
+    /// Claimed; a Builder VM is (or is about to be) running it.
+    Running,
+    /// Branch pushed and PR opened.
+    Succeeded,
+    /// Any failure — agent, egress, push, or PR. `exit_reason` says which.
+    Failed,
+}
+
+impl BuildStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BuildStatus::Queued => "queued",
+            BuildStatus::Running => "running",
+            BuildStatus::Succeeded => "succeeded",
+            BuildStatus::Failed => "failed",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "queued" => Some(BuildStatus::Queued),
+            "running" => Some(BuildStatus::Running),
+            "succeeded" => Some(BuildStatus::Succeeded),
+            "failed" => Some(BuildStatus::Failed),
             _ => None,
         }
     }

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -43,6 +43,7 @@ use tracing::{info, warn};
 use vm_pool_client::{Client, ClientError};
 use vm_pool_protocol::VmConfig;
 
+use crate::builder::{Builder, BuilderConfig, BuilderError};
 use crate::events::EventPayload;
 use crate::github::GitHubClient;
 use crate::models::{GhState, Mode, Project, Spec, Task, TaskId, TaskState};
@@ -55,7 +56,11 @@ pub const DEFAULT_PORT: u16 = 4800;
 const DEFAULT_POLL_INTERVAL_SECS: u64 = 60;
 const DEFAULT_SCOUT_MAX_CONCURRENT: usize = 2;
 const DEFAULT_SCOUT_IMAGE: &str = "agent:v1";
+const DEFAULT_BUILDER_IMAGE: &str = "builder:v1";
 const DEFAULT_VM_POOL_SOCKET: &str = "/tmp/vm-pool.sock";
+/// Builds get the same wall-clock budget as scouts, for the same reason: it
+/// must sit below vm-pool's 7200s reaper so the app deadline fires first.
+const DEFAULT_BUILDER_TIMEOUT_SECS: u64 = 3600;
 /// Wall-clock budget for one scout. ~2.5x the observed 23-minute live run, and
 /// deliberately below vm-pool's own `PoolConfig::vm_timeout` (7200s): if the
 /// app deadline sat at or above the pool's reaper, infrastructure would tear
@@ -137,6 +142,12 @@ pub struct Config {
     pub scout_base_branch: String,
     /// VM shape requested from vm-pool for each scout.
     pub vm_config: VmConfig,
+    /// vm-pool image builds run in (`BUILDER_IMAGE`).
+    pub builder_image: String,
+    /// Wall-clock budget for one build (`BUILDER_TIMEOUT_SECS`).
+    pub builder_timeout: Duration,
+    /// REST endpoint override (`GITHUB_REST_API_URL`) — PR creation only.
+    pub github_rest_api_url: Option<String>,
 }
 
 impl Config {
@@ -175,14 +186,26 @@ impl Config {
                 env: scout_vm_env(),
                 ..VmConfig::default()
             },
+            builder_image: env_string("BUILDER_IMAGE")
+                .unwrap_or_else(|| DEFAULT_BUILDER_IMAGE.into()),
+            builder_timeout: Duration::from_secs(parse_env(
+                "BUILDER_TIMEOUT_SECS",
+                "a number of seconds",
+                DEFAULT_BUILDER_TIMEOUT_SECS,
+            )?),
+            github_rest_api_url: env_string("GITHUB_REST_API_URL"),
         })
     }
 
     fn github_client(&self) -> Option<GitHubClient> {
         let token = self.github_token.as_ref()?;
-        Some(match &self.github_api_url {
+        let client = match &self.github_api_url {
             Some(url) => GitHubClient::with_base_url(token, url),
             None => GitHubClient::new(token),
+        };
+        Some(match &self.github_rest_api_url {
+            Some(url) => client.with_rest_base_url(url),
+            None => client,
         })
     }
 }
@@ -281,6 +304,11 @@ pub async fn run(config: Config) -> Result<(), RunError> {
         config.clone(),
         shutdown_rx.clone(),
     ));
+    let build = tokio::spawn(build_loop(
+        store.clone(),
+        config.clone(),
+        shutdown_rx.clone(),
+    ));
 
     server::serve_with_shutdown(store, config.port, async {
         let _ = tokio::signal::ctrl_c().await;
@@ -290,13 +318,16 @@ pub async fn run(config: Config) -> Result<(), RunError> {
 
     let _ = shutdown_tx.send(true);
     let _ = poll.await;
-    if tokio::time::timeout(SHUTDOWN_GRACE, dispatch)
-        .await
-        .is_err()
+    if tokio::time::timeout(SHUTDOWN_GRACE, async {
+        let _ = dispatch.await;
+        let _ = build.await;
+    })
+    .await
+    .is_err()
     {
         warn!(
             grace_secs = SHUTDOWN_GRACE.as_secs(),
-            "in-flight scouts did not finish within the grace period; exiting anyway"
+            "in-flight work did not finish within the grace period; exiting anyway"
         );
     }
     Ok(())
@@ -724,14 +755,134 @@ fn is_disconnect(error: &ScoutError) -> bool {
 
 /// Where a scout clones from. Derived per project; the token, when set, rides
 /// along as basic auth so private repos clone without a credential helper.
+// --- serial build loop ---
+
+/// Run queued builds one at a time until `shutdown` flips.
+///
+/// Mirrors [`dispatch_loop`]'s connection handling — own vm-pool connection,
+/// reconnect every [`VM_POOL_RETRY`] — but awaits each build inline, which
+/// *is* the serialization at the loop level;
+/// [`Store::claim_next_queued_build`] is the serialization at the store.
+/// Every batch is cut from a base branch that already contains the previous
+/// batch. Do not relax this.
+///
+/// Requires GitHub credentials (the push and the PR are server-side writes);
+/// without a token the loop is disabled with a warning and everything else
+/// runs normally. Mode gates the *start* of a run only — `Pause` never
+/// interrupts a running build, which has more at stake than a scout: a
+/// half-built branch has no home.
+pub async fn build_loop(store: Arc<Store>, config: Config, mut shutdown: watch::Receiver<bool>) {
+    let Some(github) = config.github_client() else {
+        warn!("no GITHUB_TOKEN; builds disabled (a build must push and open a PR)");
+        return;
+    };
+    let github = Arc::new(github);
+
+    loop {
+        if *shutdown.borrow() {
+            return;
+        }
+        let client = match Client::<TasksProtocol>::connect(&config.vm_pool_socket).await {
+            Ok(client) => client,
+            Err(e) => {
+                warn!(
+                    socket = %config.vm_pool_socket.display(),
+                    error = %e,
+                    retry_secs = VM_POOL_RETRY.as_secs(),
+                    "vm-pool unavailable — builds disabled"
+                );
+                tokio::select! {
+                    _ = tokio::time::sleep(VM_POOL_RETRY) => continue,
+                    _ = shutdown.changed() => return,
+                }
+            }
+        };
+
+        let builder = Builder::new(
+            store.clone(),
+            client.handle(),
+            github.clone(),
+            BuilderConfig {
+                image: config.builder_image.clone(),
+                vm_config: config.vm_config.clone(),
+                timeout: config.builder_timeout,
+                scratch_root: config.data_dir.join("build-scratch"),
+            },
+        );
+
+        loop {
+            match store.get_mode().await {
+                Ok(Mode::Play) => {
+                    match store.claim_next_queued_build().await {
+                        Ok(Some(build)) => {
+                            let project = match store.get_project(&build.project_id).await {
+                                Ok(Some(p)) => p,
+                                Ok(None) => {
+                                    warn!(build_id = %build.id, "build references a missing project");
+                                    let _ = store
+                                        .finalize_build_failed(&build.id, "project not found")
+                                        .await;
+                                    continue;
+                                }
+                                Err(e) => {
+                                    warn!(error = %e, "could not load the build's project");
+                                    continue;
+                                }
+                            };
+                            let url = clone_url(&config, &project);
+                            // Inline await = serial by construction.
+                            match builder.dispatch(build, &url).await {
+                                Ok(done) => {
+                                    info!(build_id = %done.id, pr = ?done.pr_number, "build succeeded");
+                                }
+                                Err(e) => {
+                                    // Already finalized inside dispatch; a dead
+                                    // socket additionally means reconnecting.
+                                    if matches!(
+                                        e,
+                                        BuilderError::Client(_) | BuilderError::StreamClosed
+                                    ) {
+                                        warn!(error = %e, "lost the vm-pool connection mid-build");
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(e) => warn!(error = %e, "could not read the build queue"),
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => warn!(error = %e, "could not read mode; skipping build tick"),
+            }
+
+            tokio::select! {
+                _ = tokio::time::sleep(DISPATCH_TICK) => {}
+                _ = shutdown.changed() => return,
+            }
+        }
+    }
+}
+
 fn clone_url(config: &Config, project: &Project) -> String {
+    clone_url_for(
+        &config.clone_url_base,
+        config.github_token.as_deref(),
+        project,
+    )
+}
+
+/// The credentialed clone URL for a project — shared by the scout and builder
+/// paths so both sides of the diamond clone (and the builder pushes) the same
+/// way. Non-https bases take no credentials; they'd be meaningless.
+pub(crate) fn clone_url_for(base: &str, token: Option<&str>, project: &Project) -> String {
     let url = format!(
         "{}/{}/{}.git",
-        config.clone_url_base.trim_end_matches('/'),
+        base.trim_end_matches('/'),
         project.repo_owner,
         project.repo_name
     );
-    match (&config.github_token, url.strip_prefix("https://")) {
+    match (token, url.strip_prefix("https://")) {
         (Some(token), Some(rest)) => format!("https://x-access-token:{token}@{rest}"),
         _ => url,
     }
@@ -759,6 +910,9 @@ mod tests {
             clone_url_base: DEFAULT_CLONE_URL_BASE.into(),
             scout_base_branch: "main".into(),
             vm_config: VmConfig::default(),
+            builder_image: DEFAULT_BUILDER_IMAGE.into(),
+            builder_timeout: Duration::from_secs(DEFAULT_BUILDER_TIMEOUT_SECS),
+            github_rest_api_url: None,
         }
     }
 

--- a/crates/tasks/src/scout.rs
+++ b/crates/tasks/src/scout.rs
@@ -23,7 +23,7 @@ use crate::models::{
     Complexity, ReviewedSpec, Session, SessionId, SessionStatus, SessionUsage, Spec, SpecId,
     SpecQueueEntry, SpecQueueStatus, Task, TaskState, TranscriptStream,
 };
-use crate::protocol::{LogStream, ScoutCommand, ScoutEvent, TasksProtocol};
+use crate::protocol::{LogStream, ScoutCommand, ScoutEvent, TaskCommand, TaskEvent, TasksProtocol};
 use crate::store::{Store, StoreError};
 
 #[derive(Debug, Error)]
@@ -160,12 +160,12 @@ impl Scout {
             .client
             .send_to_vm(
                 &vm_id,
-                ScoutCommand::Start {
+                TaskCommand::Scout(ScoutCommand::Start {
                     task_id: task.id.to_string(),
                     repo_clone_url: target.repo_clone_url.clone(),
                     base_branch: target.base_branch.clone(),
                     prompt,
-                },
+                }),
             )
             .await
         {
@@ -574,7 +574,10 @@ async fn drain_scout_events(
         let event = events.recv().await.ok_or(ScoutError::StreamClosed)?;
 
         match event {
-            ServiceEvent::VmApp { vm_id, event: app } if &vm_id == target_vm => match app {
+            ServiceEvent::VmApp {
+                vm_id,
+                event: TaskEvent::Scout(app),
+            } if &vm_id == target_vm => match app {
                 ScoutEvent::Started { branch: b } => {
                     branch = Some(b);
                 }

--- a/crates/tasks/src/server.rs
+++ b/crates/tasks/src/server.rs
@@ -29,8 +29,8 @@ use tracing::{error, info, warn};
 
 use crate::events::{Event, EventPayload};
 use crate::models::{
-    Mode, Project, ProjectId, Session, SessionId, Spec, SpecId, SpecQueueItem, SpecQueueStatus,
-    Task, TaskId, TranscriptLine,
+    Build, BuildId, Mode, Project, ProjectId, Session, SessionId, Spec, SpecId, SpecQueueItem,
+    SpecQueueStatus, Task, TaskId, TranscriptLine,
 };
 use crate::store::{Store, StoreError};
 
@@ -107,6 +107,8 @@ pub fn router(store: Arc<Store>) -> Router {
         .route("/spec-queue", get(list_spec_queue))
         .route("/spec-queue/reorder", post(reorder_spec_queue))
         .route("/spec-queue/{spec_id}/review", post(review_spec))
+        .route("/builds", get(list_builds).post(request_build))
+        .route("/builds/{build_id}", get(get_build))
         .route("/mode", get(get_mode).post(set_mode))
         .route("/queue/reorder", post(reorder_queue))
         .route("/events", get(list_events))
@@ -325,6 +327,54 @@ async fn review_spec(
         entry,
         task_id: spec.task_id,
     }))
+}
+
+// --- builds ---
+
+#[derive(Debug, Deserialize)]
+struct BuildRequest {
+    spec_ids: Vec<SpecId>,
+    /// Branch the batch is cut from and PR'd against. Defaults to `main`.
+    #[serde(default)]
+    base_branch: Option<String>,
+}
+
+/// A build with its batch, in position order.
+#[derive(Debug, Serialize)]
+struct BuildDetail {
+    #[serde(flatten)]
+    build: Build,
+    spec_ids: Vec<SpecId>,
+}
+
+/// 202, not 200/201-with-result: builds are serial and this only queues one.
+/// Watch `build_started` / `build_completed` on the event stream, or poll
+/// `GET /builds/{id}`.
+async fn request_build(
+    State(store): State<Arc<Store>>,
+    Json(body): Json<BuildRequest>,
+) -> ApiResult<(StatusCode, Json<BuildDetail>)> {
+    let base_branch = body.base_branch.as_deref().unwrap_or("main");
+    let build = store.create_build(&body.spec_ids, base_branch).await?;
+    let spec_ids = store.build_spec_ids(&build.id).await?;
+    Ok((StatusCode::ACCEPTED, Json(BuildDetail { build, spec_ids })))
+}
+
+async fn list_builds(State(store): State<Arc<Store>>) -> ApiResult<Json<Vec<Build>>> {
+    Ok(Json(store.list_builds().await?))
+}
+
+async fn get_build(
+    State(store): State<Arc<Store>>,
+    Path(build_id): Path<String>,
+) -> ApiResult<Json<BuildDetail>> {
+    let id = BuildId::from_raw(build_id);
+    let build = store
+        .get_build(&id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("build {id}")))?;
+    let spec_ids = store.build_spec_ids(&id).await?;
+    Ok(Json(BuildDetail { build, spec_ids }))
 }
 
 // --- mode ---

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -11,9 +11,9 @@ use tokio::sync::broadcast;
 use crate::events::{Event, EventPayload};
 use crate::github::GhIssue;
 use crate::models::{
-    Complexity, GhState, Mode, Project, ProjectId, ReviewedSpec, Session, SessionId, SessionStatus,
-    SessionUsage, Spec, SpecId, SpecQueueEntry, SpecQueueItem, SpecQueueStatus, Task, TaskId,
-    TaskState, TranscriptLine, TranscriptStream,
+    Build, BuildId, BuildStatus, Complexity, GhState, Mode, Project, ProjectId, ReviewedSpec,
+    Session, SessionId, SessionStatus, SessionUsage, Spec, SpecId, SpecQueueEntry, SpecQueueItem,
+    SpecQueueStatus, Task, TaskId, TaskState, TranscriptLine, TranscriptStream,
 };
 
 /// Result of upserting an external record into our domain.
@@ -57,12 +57,16 @@ pub struct ReconcileReport {
     pub sessions: usize,
     /// `scouting` tasks put back in the queue as `new`.
     pub tasks: usize,
+    /// `running` builds failed as orphaned (queued builds are durable intent
+    /// and survive a restart untouched). A wedged running build would block
+    /// the serial queue forever, strictly worse than an orphaned session.
+    pub builds: usize,
 }
 
 impl ReconcileReport {
     /// Whether anything at all was reconciled — the only case worth logging.
     pub fn is_empty(&self) -> bool {
-        self.sessions == 0 && self.tasks == 0
+        self.sessions == 0 && self.tasks == 0 && self.builds == 0
     }
 }
 
@@ -920,6 +924,27 @@ impl Store {
             .map(|row| Ok::<_, StoreError>(TaskId::from_raw(row.try_get::<String, _>("id")?)))
             .collect::<Result<Vec<_>, _>>()?;
 
+        // A `running` build belongs to a dead process; left alone it wedges
+        // the serial build queue forever. `queued` builds are durable intent
+        // and survive untouched. Tasks mid-`building` go back to
+        // `ready_to_build` — their specs are still approved and good.
+        let build_rows = sqlx::query("SELECT id FROM builds WHERE status = ?")
+            .bind(BuildStatus::Running.as_str())
+            .fetch_all(&mut *tx)
+            .await?;
+        let orphaned_builds = build_rows
+            .into_iter()
+            .map(|row| Ok::<_, StoreError>(BuildId::from_raw(row.try_get::<String, _>("id")?)))
+            .collect::<Result<Vec<_>, _>>()?;
+        let building_rows = sqlx::query("SELECT id FROM tasks WHERE state = ?")
+            .bind(TaskState::Building.as_str())
+            .fetch_all(&mut *tx)
+            .await?;
+        let orphaned_building = building_rows
+            .into_iter()
+            .map(|row| Ok::<_, StoreError>(TaskId::from_raw(row.try_get::<String, _>("id")?)))
+            .collect::<Result<Vec<_>, _>>()?;
+
         if !orphaned_sessions.is_empty() {
             sqlx::query(
                 "UPDATE sessions SET status = ?, completed_at = ?, exit_reason = ? \
@@ -942,11 +967,32 @@ impl Store {
                 .execute(&mut *tx)
                 .await?;
         }
+        if !orphaned_builds.is_empty() {
+            sqlx::query(
+                "UPDATE builds SET status = ?, completed_at = ?, exit_reason = ? \
+                 WHERE status = ?",
+            )
+            .bind(BuildStatus::Failed.as_str())
+            .bind(now.to_rfc3339())
+            .bind(ORPHANED_EXIT_REASON)
+            .bind(BuildStatus::Running.as_str())
+            .execute(&mut *tx)
+            .await?;
+        }
+        if !orphaned_building.is_empty() {
+            sqlx::query("UPDATE tasks SET state = ?, updated_at = ? WHERE state = ?")
+                .bind(TaskState::ReadyToBuild.as_str())
+                .bind(now.to_rfc3339())
+                .bind(TaskState::Building.as_str())
+                .execute(&mut *tx)
+                .await?;
+        }
         tx.commit().await?;
 
         let report = ReconcileReport {
             sessions: orphaned_sessions.len(),
             tasks: orphaned_tasks.len(),
+            builds: orphaned_builds.len(),
         };
 
         for (session_id, task_id) in orphaned_sessions {
@@ -962,6 +1008,21 @@ impl Store {
                 task_id,
                 from: TaskState::Scouting,
                 to: TaskState::Queued,
+            })
+            .await?;
+        }
+        for build_id in orphaned_builds {
+            self.append_event(EventPayload::BuildCompleted {
+                build_id,
+                status: BuildStatus::Failed,
+            })
+            .await?;
+        }
+        for task_id in orphaned_building {
+            self.append_event(EventPayload::TaskStateChanged {
+                task_id,
+                from: TaskState::Building,
+                to: TaskState::ReadyToBuild,
             })
             .await?;
         }
@@ -1158,7 +1219,9 @@ impl Store {
             SpecQueueStatus::Approved => TaskState::ReadyToBuild,
             SpecQueueStatus::Rejected => TaskState::Rejected,
             SpecQueueStatus::NeedsRevision => TaskState::Queued,
-            SpecQueueStatus::PendingReview | SpecQueueStatus::Blocked => {
+            // `Built` is how the approved queue drains — assigned by a
+            // successful Builder run, never rendered by a reviewer.
+            SpecQueueStatus::PendingReview | SpecQueueStatus::Blocked | SpecQueueStatus::Built => {
                 return Err(StoreError::Invalid(format!(
                     "{} is not a review outcome",
                     status.as_str()
@@ -1225,6 +1288,438 @@ impl Store {
             feedback,
             ..entry
         })
+    }
+
+    // --- builds ---
+
+    /// Queue a Builder run over a set of approved specs. Returns the created
+    /// build in `queued` status; the serial build loop picks it up.
+    ///
+    /// Validation (all → [`StoreError::Invalid`], a 400 at the API):
+    /// - the set is non-empty and free of duplicates
+    /// - every spec exists and its queue status is `approved`
+    /// - all specs belong to one project (one build = one branch = one repo)
+    /// - no spec is already part of a `queued`/`running` build
+    ///
+    /// The order the caller sends is irrelevant: the batch is re-sorted into
+    /// spec-queue order (rank, then spec age), because the queue is
+    /// human-authoritative and a build must not scramble it.
+    pub async fn create_build(
+        &self,
+        spec_ids: &[SpecId],
+        base_branch: &str,
+    ) -> Result<Build, StoreError> {
+        if spec_ids.is_empty() {
+            return Err(StoreError::Invalid(
+                "a build needs at least one spec".into(),
+            ));
+        }
+        let mut seen = std::collections::HashSet::new();
+        for id in spec_ids {
+            if !seen.insert(id.as_str()) {
+                return Err(StoreError::Invalid(format!("duplicate spec id: {id}")));
+            }
+        }
+
+        let mut tx = self.pool.begin().await?;
+
+        // One query resolves existence, review status, project, and queue
+        // order for the whole batch.
+        let mut resolved: Vec<(SpecId, String, Option<i64>, i64)> = Vec::new();
+        for id in spec_ids {
+            let row = sqlx::query(
+                "SELECT s.id, s.rowid AS spec_rowid, t.project_id, q.status, q.rank \
+                 FROM specs s \
+                 JOIN tasks t ON t.id = s.task_id \
+                 LEFT JOIN spec_queue q ON q.spec_id = s.id \
+                 WHERE s.id = ?",
+            )
+            .bind(id.as_str())
+            .fetch_optional(&mut *tx)
+            .await?
+            .ok_or_else(|| StoreError::NotFound(format!("spec {id}")))?;
+
+            let status: Option<String> = row.try_get("status")?;
+            match status.as_deref().and_then(SpecQueueStatus::from_str) {
+                Some(SpecQueueStatus::Approved) => {}
+                other => {
+                    return Err(StoreError::Invalid(format!(
+                        "spec {id} is {}, only approved specs can be built",
+                        other.map(|s| s.as_str()).unwrap_or("not in the queue")
+                    )));
+                }
+            }
+
+            let in_flight = sqlx::query(
+                "SELECT b.id FROM build_specs bs JOIN builds b ON b.id = bs.build_id \
+                 WHERE bs.spec_id = ? AND b.status IN (?, ?)",
+            )
+            .bind(id.as_str())
+            .bind(BuildStatus::Queued.as_str())
+            .bind(BuildStatus::Running.as_str())
+            .fetch_optional(&mut *tx)
+            .await?;
+            if let Some(row) = in_flight {
+                let build: String = row.try_get("id")?;
+                return Err(StoreError::Invalid(format!(
+                    "spec {id} is already part of build {build}"
+                )));
+            }
+
+            resolved.push((
+                id.clone(),
+                row.try_get("project_id")?,
+                row.try_get("rank")?,
+                row.try_get("spec_rowid")?,
+            ));
+        }
+
+        let project_id = resolved[0].1.clone();
+        if resolved.iter().any(|(_, p, _, _)| *p != project_id) {
+            return Err(StoreError::Invalid(
+                "specs span multiple projects; one build builds one repo".into(),
+            ));
+        }
+
+        // Spec-queue order: rank first (nulls last), then spec age.
+        resolved.sort_by_key(|(_, _, rank, rowid)| (rank.is_none(), rank.unwrap_or(0), *rowid));
+
+        let build = Build {
+            id: BuildId::new(),
+            project_id: ProjectId::from_raw(project_id),
+            vm_id: None,
+            branch: String::new(), // set below, needs the id
+            base_branch: base_branch.to_string(),
+            base_sha: None,
+            head_sha: None,
+            pr_number: None,
+            status: BuildStatus::Queued,
+            summary: None,
+            files_touched: vec![],
+            exit_reason: None,
+            created_at: Utc::now(),
+            started_at: None,
+            completed_at: None,
+        };
+        let branch = format!("build/{}", build.id);
+        sqlx::query(
+            "INSERT INTO builds (id, project_id, branch, base_branch, status, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(build.id.as_str())
+        .bind(build.project_id.as_str())
+        .bind(&branch)
+        .bind(&build.base_branch)
+        .bind(build.status.as_str())
+        .bind(build.created_at.to_rfc3339())
+        .execute(&mut *tx)
+        .await?;
+        for (position, (spec_id, _, _, _)) in resolved.iter().enumerate() {
+            sqlx::query("INSERT INTO build_specs (build_id, spec_id, position) VALUES (?, ?, ?)")
+                .bind(build.id.as_str())
+                .bind(spec_id.as_str())
+                .bind(position as i64 + 1)
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+
+        self.append_event(EventPayload::BuildRequested {
+            build_id: build.id.clone(),
+            spec_ids: resolved.iter().map(|(id, _, _, _)| id.clone()).collect(),
+        })
+        .await?;
+
+        Ok(Build { branch, ..build })
+    }
+
+    /// Claim the next build for the serial loop: if any build is `running`,
+    /// returns `None`; otherwise the oldest `queued` build becomes `running`
+    /// in the same transaction — the check and the claim cannot be split,
+    /// which is what makes execution serial by construction.
+    ///
+    /// The specs' tasks move `ready_to_build → building` (tasks that left
+    /// `ready_to_build` some other way — e.g. retired because their issue
+    /// closed — are left alone). Emits `BuildStarted` plus the task events.
+    pub async fn claim_next_queued_build(&self) -> Result<Option<Build>, StoreError> {
+        let now = Utc::now();
+        let mut tx = self.pool.begin().await?;
+
+        let running = sqlx::query("SELECT 1 FROM builds WHERE status = ? LIMIT 1")
+            .bind(BuildStatus::Running.as_str())
+            .fetch_optional(&mut *tx)
+            .await?;
+        if running.is_some() {
+            return Ok(None);
+        }
+
+        let Some(row) = sqlx::query(
+            "SELECT id FROM builds WHERE status = ? ORDER BY created_at, rowid LIMIT 1",
+        )
+        .bind(BuildStatus::Queued.as_str())
+        .fetch_optional(&mut *tx)
+        .await?
+        else {
+            return Ok(None);
+        };
+        let build_id = BuildId::from_raw(row.try_get::<String, _>("id")?);
+
+        sqlx::query("UPDATE builds SET status = ?, started_at = ? WHERE id = ?")
+            .bind(BuildStatus::Running.as_str())
+            .bind(now.to_rfc3339())
+            .bind(build_id.as_str())
+            .execute(&mut *tx)
+            .await?;
+
+        let task_rows = sqlx::query(
+            "SELECT DISTINCT t.id FROM build_specs bs \
+             JOIN specs s ON s.id = bs.spec_id \
+             JOIN tasks t ON t.id = s.task_id \
+             WHERE bs.build_id = ? AND t.state = ?",
+        )
+        .bind(build_id.as_str())
+        .bind(TaskState::ReadyToBuild.as_str())
+        .fetch_all(&mut *tx)
+        .await?;
+        let mut building_tasks = Vec::new();
+        for row in task_rows {
+            let id = TaskId::from_raw(row.try_get::<String, _>("id")?);
+            sqlx::query("UPDATE tasks SET state = ?, updated_at = ? WHERE id = ?")
+                .bind(TaskState::Building.as_str())
+                .bind(now.to_rfc3339())
+                .bind(id.as_str())
+                .execute(&mut *tx)
+                .await?;
+            building_tasks.push(id);
+        }
+        tx.commit().await?;
+
+        self.append_event(EventPayload::BuildStarted {
+            build_id: build_id.clone(),
+        })
+        .await?;
+        for task_id in building_tasks {
+            self.append_event(EventPayload::TaskStateChanged {
+                task_id,
+                from: TaskState::ReadyToBuild,
+                to: TaskState::Building,
+            })
+            .await?;
+        }
+
+        self.get_build(&build_id)
+            .await?
+            .ok_or_else(|| StoreError::NotFound(format!("build {build_id}")))
+            .map(Some)
+    }
+
+    pub async fn get_build(&self, id: &BuildId) -> Result<Option<Build>, StoreError> {
+        let row = sqlx::query(
+            "SELECT id, project_id, vm_id, branch, base_branch, base_sha, head_sha, \
+             pr_number, status, summary, files_touched, exit_reason, created_at, \
+             started_at, completed_at FROM builds WHERE id = ?",
+        )
+        .bind(id.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(build_from_row).transpose()
+    }
+
+    /// Newest first.
+    pub async fn list_builds(&self) -> Result<Vec<Build>, StoreError> {
+        let rows = sqlx::query(
+            "SELECT id, project_id, vm_id, branch, base_branch, base_sha, head_sha, \
+             pr_number, status, summary, files_touched, exit_reason, created_at, \
+             started_at, completed_at FROM builds ORDER BY created_at DESC, rowid DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(build_from_row).collect()
+    }
+
+    /// The build's specs in batch order.
+    pub async fn build_spec_ids(&self, id: &BuildId) -> Result<Vec<SpecId>, StoreError> {
+        let rows =
+            sqlx::query("SELECT spec_id FROM build_specs WHERE build_id = ? ORDER BY position")
+                .bind(id.as_str())
+                .fetch_all(&self.pool)
+                .await?;
+        rows.into_iter()
+            .map(|row| Ok(SpecId::from_raw(row.try_get::<String, _>("spec_id")?)))
+            .collect()
+    }
+
+    pub async fn set_build_vm(&self, id: &BuildId, vm_id: &str) -> Result<(), StoreError> {
+        sqlx::query("UPDATE builds SET vm_id = ? WHERE id = ?")
+            .bind(vm_id)
+            .bind(id.as_str())
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn set_build_base_sha(&self, id: &BuildId, base_sha: &str) -> Result<(), StoreError> {
+        sqlx::query("UPDATE builds SET base_sha = ? WHERE id = ?")
+            .bind(base_sha)
+            .bind(id.as_str())
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Terminal success: branch pushed, PR open. In one transaction the build
+    /// row is completed, the batch's specs drain `approved → built` (a spec
+    /// cannot be built twice), and their tasks conclude `building → done`.
+    pub async fn finalize_build_succeeded(
+        &self,
+        id: &BuildId,
+        head_sha: &str,
+        pr_number: u64,
+        summary: Option<&str>,
+        files_touched: &[String],
+    ) -> Result<Build, StoreError> {
+        let now = Utc::now();
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query(
+            "UPDATE builds SET status = ?, head_sha = ?, pr_number = ?, summary = ?, \
+             files_touched = ?, completed_at = ? WHERE id = ?",
+        )
+        .bind(BuildStatus::Succeeded.as_str())
+        .bind(head_sha)
+        .bind(pr_number as i64)
+        .bind(summary)
+        .bind(serde_json::to_string(files_touched)?)
+        .bind(now.to_rfc3339())
+        .bind(id.as_str())
+        .execute(&mut *tx)
+        .await?;
+
+        let spec_rows = sqlx::query(
+            "SELECT bs.spec_id, s.task_id, t.state FROM build_specs bs \
+             JOIN specs s ON s.id = bs.spec_id \
+             JOIN tasks t ON t.id = s.task_id \
+             WHERE bs.build_id = ? ORDER BY bs.position",
+        )
+        .bind(id.as_str())
+        .fetch_all(&mut *tx)
+        .await?;
+        let mut built_specs = Vec::new();
+        let mut done_tasks = Vec::new();
+        for row in spec_rows {
+            let spec_id = SpecId::from_raw(row.try_get::<String, _>("spec_id")?);
+            sqlx::query("UPDATE spec_queue SET status = ? WHERE spec_id = ?")
+                .bind(SpecQueueStatus::Built.as_str())
+                .bind(spec_id.as_str())
+                .execute(&mut *tx)
+                .await?;
+            built_specs.push(spec_id);
+
+            let task_id = TaskId::from_raw(row.try_get::<String, _>("task_id")?);
+            let state: String = row.try_get("state")?;
+            if state == TaskState::Building.as_str() && !done_tasks.contains(&task_id) {
+                sqlx::query("UPDATE tasks SET state = ?, updated_at = ? WHERE id = ?")
+                    .bind(TaskState::Done.as_str())
+                    .bind(now.to_rfc3339())
+                    .bind(task_id.as_str())
+                    .execute(&mut *tx)
+                    .await?;
+                done_tasks.push(task_id);
+            }
+        }
+        tx.commit().await?;
+
+        for spec_id in built_specs {
+            self.append_event(EventPayload::SpecQueueStatusChanged {
+                spec_id,
+                from: Some(SpecQueueStatus::Approved),
+                to: SpecQueueStatus::Built,
+            })
+            .await?;
+        }
+        for task_id in done_tasks {
+            self.append_event(EventPayload::TaskStateChanged {
+                task_id,
+                from: TaskState::Building,
+                to: TaskState::Done,
+            })
+            .await?;
+        }
+        self.append_event(EventPayload::PullRequestOpened {
+            build_id: id.clone(),
+            pr_number,
+        })
+        .await?;
+        self.append_event(EventPayload::BuildCompleted {
+            build_id: id.clone(),
+            status: BuildStatus::Succeeded,
+        })
+        .await?;
+
+        self.get_build(id)
+            .await?
+            .ok_or_else(|| StoreError::NotFound(format!("build {id}")))
+    }
+
+    /// Terminal failure, any stage. The batch's specs stay `approved` and
+    /// their tasks return `building → ready_to_build` — never further back: a
+    /// failed build must not re-scout work that already has a good spec.
+    pub async fn finalize_build_failed(
+        &self,
+        id: &BuildId,
+        reason: &str,
+    ) -> Result<Build, StoreError> {
+        let now = Utc::now();
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("UPDATE builds SET status = ?, exit_reason = ?, completed_at = ? WHERE id = ?")
+            .bind(BuildStatus::Failed.as_str())
+            .bind(reason)
+            .bind(now.to_rfc3339())
+            .bind(id.as_str())
+            .execute(&mut *tx)
+            .await?;
+
+        let task_rows = sqlx::query(
+            "SELECT DISTINCT t.id FROM build_specs bs \
+             JOIN specs s ON s.id = bs.spec_id \
+             JOIN tasks t ON t.id = s.task_id \
+             WHERE bs.build_id = ? AND t.state = ?",
+        )
+        .bind(id.as_str())
+        .bind(TaskState::Building.as_str())
+        .fetch_all(&mut *tx)
+        .await?;
+        let mut returned = Vec::new();
+        for row in task_rows {
+            let task_id = TaskId::from_raw(row.try_get::<String, _>("id")?);
+            sqlx::query("UPDATE tasks SET state = ?, updated_at = ? WHERE id = ?")
+                .bind(TaskState::ReadyToBuild.as_str())
+                .bind(now.to_rfc3339())
+                .bind(task_id.as_str())
+                .execute(&mut *tx)
+                .await?;
+            returned.push(task_id);
+        }
+        tx.commit().await?;
+
+        for task_id in returned {
+            self.append_event(EventPayload::TaskStateChanged {
+                task_id,
+                from: TaskState::Building,
+                to: TaskState::ReadyToBuild,
+            })
+            .await?;
+        }
+        self.append_event(EventPayload::BuildCompleted {
+            build_id: id.clone(),
+            status: BuildStatus::Failed,
+        })
+        .await?;
+
+        self.get_build(id)
+            .await?
+            .ok_or_else(|| StoreError::NotFound(format!("build {id}")))
     }
 
     // --- mode ---
@@ -1377,6 +1872,38 @@ fn transcript_line_from_row(row: sqlx::sqlite::SqliteRow) -> Result<TranscriptLi
             value: stream_raw,
         })?,
         line: row.try_get("line")?,
+    })
+}
+
+fn build_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Build, StoreError> {
+    let status_raw: String = row.try_get("status")?;
+    let files_raw: String = row.try_get("files_touched")?;
+    let opt_ts = |col: &'static str| -> Result<Option<DateTime<Utc>>, StoreError> {
+        row.try_get::<Option<String>, _>(col)?
+            .map(|s| parse_ts(&s, col))
+            .transpose()
+    };
+    Ok(Build {
+        id: BuildId::from_raw(row.try_get::<String, _>("id")?),
+        project_id: ProjectId::from_raw(row.try_get::<String, _>("project_id")?),
+        vm_id: row.try_get("vm_id")?,
+        branch: row.try_get("branch")?,
+        base_branch: row.try_get("base_branch")?,
+        base_sha: row.try_get("base_sha")?,
+        head_sha: row.try_get("head_sha")?,
+        pr_number: row
+            .try_get::<Option<i64>, _>("pr_number")?
+            .map(|n| n.max(0) as u64),
+        status: BuildStatus::from_str(&status_raw).ok_or(StoreError::BadEnum {
+            column: "status",
+            value: status_raw,
+        })?,
+        summary: row.try_get("summary")?,
+        files_touched: serde_json::from_str(&files_raw)?,
+        exit_reason: row.try_get("exit_reason")?,
+        created_at: parse_ts(&row.try_get::<String, _>("created_at")?, "created_at")?,
+        started_at: opt_ts("started_at")?,
+        completed_at: opt_ts("completed_at")?,
     })
 }
 
@@ -2326,7 +2853,8 @@ mod tests {
             report,
             ReconcileReport {
                 sessions: 1,
-                tasks: 2
+                tasks: 2,
+                builds: 0
             }
         );
 
@@ -3128,5 +3656,277 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, StoreError::Invalid(_)));
+    }
+
+    /// Insert the full chain a build consumes: a ready_to_build task, its
+    /// session, its spec, and an approved queue entry.
+    async fn approved_spec(store: &Store, project: &Project, issue: u64) -> (Task, Spec) {
+        let mut task = sample_task(&project.id);
+        task.gh_issue_number = issue;
+        task.state = TaskState::ReadyToBuild;
+        store.insert_task(&task).await.unwrap();
+
+        let session = Session {
+            id: SessionId::new(),
+            task_id: task.id.clone(),
+            vm_id: None,
+            branch: format!("scout/{}", task.id),
+            status: SessionStatus::ScoutSucceeded,
+            started_at: Utc::now(),
+            completed_at: Some(Utc::now()),
+            exit_reason: None,
+            usage: None,
+        };
+        store.insert_session(&session).await.unwrap();
+
+        let spec = Spec {
+            id: SpecId::new(),
+            session_id: session.id,
+            task_id: task.id.clone(),
+            content: format!("## Spec: issue {issue}"),
+            complexity: Complexity::Simple,
+            files_touched: vec![],
+            created_at: Utc::now(),
+        };
+        store.insert_spec(&spec).await.unwrap();
+        store
+            .upsert_spec_queue_entry(&SpecQueueEntry {
+                spec_id: spec.id.clone(),
+                status: SpecQueueStatus::Approved,
+                rank: None,
+                approved_at: Some(Utc::now()),
+                feedback: None,
+                blocking_dependencies: vec![],
+            })
+            .await
+            .unwrap();
+        (task, spec)
+    }
+
+    #[tokio::test]
+    async fn create_build_validates_the_batch() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+        let (_task, spec) = approved_spec(&store, &project, 1).await;
+
+        // Empty and duplicated sets.
+        assert!(matches!(
+            store.create_build(&[], "main").await.unwrap_err(),
+            StoreError::Invalid(_)
+        ));
+        assert!(matches!(
+            store
+                .create_build(&[spec.id.clone(), spec.id.clone()], "main")
+                .await
+                .unwrap_err(),
+            StoreError::Invalid(_)
+        ));
+
+        // A non-approved spec.
+        let (_t2, pending) = approved_spec(&store, &project, 2).await;
+        store
+            .review_spec(&pending.id, SpecQueueStatus::Rejected, None)
+            .await
+            .unwrap();
+        let err = store
+            .create_build(&[pending.id.clone()], "main")
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("rejected"), "{err}");
+
+        // A spec already in an active build.
+        let build = store
+            .create_build(&[spec.id.clone()], "main")
+            .await
+            .unwrap();
+        assert_eq!(build.status, BuildStatus::Queued);
+        assert_eq!(build.branch, format!("build/{}", build.id));
+        let err = store
+            .create_build(&[spec.id.clone()], "main")
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("already part of"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn create_build_resorts_the_batch_into_spec_queue_order() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+        let (_ta, spec_a) = approved_spec(&store, &project, 1).await;
+        let (_tb, spec_b) = approved_spec(&store, &project, 2).await;
+        // Rank b above a; the human's order wins over the caller's.
+        store
+            .set_spec_queue_order(&[spec_b.id.clone(), spec_a.id.clone()])
+            .await
+            .unwrap();
+
+        let build = store
+            .create_build(&[spec_a.id.clone(), spec_b.id.clone()], "main")
+            .await
+            .unwrap();
+        assert_eq!(
+            store.build_spec_ids(&build.id).await.unwrap(),
+            vec![spec_b.id, spec_a.id]
+        );
+    }
+
+    #[tokio::test]
+    async fn claiming_is_serial_by_construction() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+        let (task_a, spec_a) = approved_spec(&store, &project, 1).await;
+        let (_tb, spec_b) = approved_spec(&store, &project, 2).await;
+
+        let first = store
+            .create_build(&[spec_a.id.clone()], "main")
+            .await
+            .unwrap();
+        let _second = store
+            .create_build(&[spec_b.id.clone()], "main")
+            .await
+            .unwrap();
+
+        let claimed = store.claim_next_queued_build().await.unwrap().unwrap();
+        assert_eq!(claimed.id, first.id, "oldest first");
+        assert_eq!(claimed.status, BuildStatus::Running);
+        // Its task went building; the second build cannot be claimed.
+        assert_eq!(
+            store.get_task(&task_a.id).await.unwrap().unwrap().state,
+            TaskState::Building
+        );
+        assert!(
+            store.claim_next_queued_build().await.unwrap().is_none(),
+            "one at a time"
+        );
+
+        // Failure returns the task to ready_to_build, spec stays approved,
+        // and the queue unblocks.
+        store
+            .finalize_build_failed(&claimed.id, "agent produced no commits")
+            .await
+            .unwrap();
+        assert_eq!(
+            store.get_task(&task_a.id).await.unwrap().unwrap().state,
+            TaskState::ReadyToBuild
+        );
+        assert_eq!(
+            store
+                .get_spec_queue_entry(&spec_a.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            SpecQueueStatus::Approved
+        );
+        let next = store.claim_next_queued_build().await.unwrap().unwrap();
+        assert_eq!(next.status, BuildStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn a_successful_build_drains_the_batch() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+        let (task, spec) = approved_spec(&store, &project, 1).await;
+        let build = store
+            .create_build(&[spec.id.clone()], "main")
+            .await
+            .unwrap();
+        store.claim_next_queued_build().await.unwrap().unwrap();
+
+        let done = store
+            .finalize_build_succeeded(
+                &build.id,
+                "headsha123",
+                77,
+                Some("Did the thing."),
+                &["src/lib.rs".to_string()],
+            )
+            .await
+            .unwrap();
+        assert_eq!(done.status, BuildStatus::Succeeded);
+        assert_eq!(done.pr_number, Some(77));
+        assert_eq!(done.head_sha.as_deref(), Some("headsha123"));
+
+        // Spec drained, task concluded, and neither can be re-consumed.
+        assert_eq!(
+            store
+                .get_spec_queue_entry(&spec.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            SpecQueueStatus::Built
+        );
+        assert_eq!(
+            store.get_task(&task.id).await.unwrap().unwrap().state,
+            TaskState::Done
+        );
+        let err = store
+            .create_build(&[spec.id.clone()], "main")
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("built"), "{err}");
+
+        // Built is not a verdict a reviewer can render.
+        let err = store
+            .review_spec(&spec.id, SpecQueueStatus::Built, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, StoreError::Invalid(_)));
+
+        let payloads: Vec<EventPayload> = store
+            .events_since(0)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.payload)
+            .collect();
+        assert!(payloads.contains(&EventPayload::PullRequestOpened {
+            build_id: build.id.clone(),
+            pr_number: 77,
+        }));
+        assert!(payloads.contains(&EventPayload::BuildCompleted {
+            build_id: build.id,
+            status: BuildStatus::Succeeded,
+        }));
+    }
+
+    #[tokio::test]
+    async fn reconcile_fails_orphaned_running_builds_but_keeps_queued_ones() {
+        let store = Store::open_in_memory().await.unwrap();
+        let project = sample_project();
+        store.insert_project(&project).await.unwrap();
+        let (task_a, spec_a) = approved_spec(&store, &project, 1).await;
+        let (_tb, spec_b) = approved_spec(&store, &project, 2).await;
+        let running = store.create_build(&[spec_a.id], "main").await.unwrap();
+        let queued = store.create_build(&[spec_b.id], "main").await.unwrap();
+        store.claim_next_queued_build().await.unwrap().unwrap();
+
+        let report = store.reconcile_orphaned_work().await.unwrap();
+        assert_eq!(report.builds, 1);
+
+        let after = store.get_build(&running.id).await.unwrap().unwrap();
+        assert_eq!(after.status, BuildStatus::Failed);
+        assert_eq!(
+            after.exit_reason.as_deref(),
+            Some("orphaned by server restart")
+        );
+        assert_eq!(
+            store.get_task(&task_a.id).await.unwrap().unwrap().state,
+            TaskState::ReadyToBuild
+        );
+        // Queued builds are durable intent: untouched, claimable now.
+        assert_eq!(
+            store.get_build(&queued.id).await.unwrap().unwrap().status,
+            BuildStatus::Queued
+        );
+        assert_eq!(
+            store.claim_next_queued_build().await.unwrap().unwrap().id,
+            queued.id
+        );
     }
 }

--- a/crates/tasks/tests/builder.rs
+++ b/crates/tasks/tests/builder.rs
@@ -1,0 +1,317 @@
+//! End-to-end Builder dispatch integration test.
+//!
+//! Spins up:
+//! - A real vm-pool-service pointing at the real builder-supervisor binary.
+//! - A real vm-pool-client over a Unix socket.
+//! - A real SQLite store.
+//! - A real local git repo as the "remote" (non-bare — pushing works for any
+//!   branch that isn't the checked-out one, which is what makes a no-mock
+//!   push test possible at all).
+//! - A real HTTP server standing in for GitHub's REST API, recording the PR
+//!   request it receives.
+//!
+//! Then runs `Builder::dispatch(build, clone_url)` and asserts the branch
+//! actually lands in the remote and the store drains the batch. No mocks.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::response::Json as AxumJson;
+use axum::routing::post;
+use chrono::Utc;
+use serde_json::{Value, json};
+use tokio::process::Command;
+
+use tasks::builder::{Builder, BuilderConfig};
+use tasks::github::GitHubClient;
+use tasks::models::{
+    BuildStatus, Complexity, GhState, Project, ProjectId, Session, SessionId, SessionStatus, Spec,
+    SpecId, SpecQueueEntry, SpecQueueStatus, Task, TaskId, TaskState,
+};
+use tasks::store::Store;
+use tasks_protocol::TasksProtocol;
+use vm_pool_client::Client;
+use vm_pool_protocol::VmConfig;
+
+mod common;
+use common::{
+    cargo_build, make_fixture_repo, spawn_vm_pool, stub_builder_agent_path,
+    write_builder_supervisor_wrapper,
+};
+
+async fn run_git(dir: &std::path::Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .await
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// Fake GitHub REST endpoint: answers POST /repos/{owner}/{repo}/pulls with
+/// a fixed PR number and records the request body.
+async fn spawn_fake_github_rest(number: u64) -> (String, Arc<Mutex<Vec<Value>>>) {
+    let seen: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+    let state = seen.clone();
+    let app =
+        axum::Router::new()
+            .route(
+                "/repos/{owner}/{repo}/pulls",
+                post(
+                    move |State(s): State<Arc<Mutex<Vec<Value>>>>,
+                          AxumJson(body): AxumJson<Value>| async move {
+                        s.lock().unwrap().push(body);
+                        AxumJson(json!({ "number": number }))
+                    },
+                ),
+            )
+            .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (url, seen)
+}
+
+/// Seed a project plus the full chain a build consumes: a ready_to_build
+/// task, its scout session, its spec, and an approved queue entry.
+async fn seed_approved(store: &Store, project: &Project, issue: u64, title: &str) -> (Task, Spec) {
+    let now = Utc::now();
+    let task = Task {
+        id: TaskId::new(),
+        project_id: project.id.clone(),
+        gh_issue_number: issue,
+        title: title.into(),
+        body: "issue body".into(),
+        labels: vec![],
+        gh_state: GhState::Open,
+        state: TaskState::ReadyToBuild,
+        priority: 0,
+        manual_rank: None,
+        dispatch_attempts: 0,
+        ingested_at: now,
+        updated_at: now,
+    };
+    store.insert_task(&task).await.unwrap();
+
+    let session = Session {
+        id: SessionId::new(),
+        task_id: task.id.clone(),
+        vm_id: None,
+        branch: format!("scout/{}", task.id),
+        status: SessionStatus::ScoutSucceeded,
+        started_at: now,
+        completed_at: Some(now),
+        exit_reason: None,
+        usage: None,
+    };
+    store.insert_session(&session).await.unwrap();
+
+    let spec = Spec {
+        id: SpecId::new(),
+        session_id: session.id,
+        task_id: task.id.clone(),
+        content: format!("## Spec: {title}\n\nAdd a function for issue {issue}."),
+        complexity: Complexity::Simple,
+        files_touched: vec![],
+        created_at: now,
+    };
+    store.insert_spec(&spec).await.unwrap();
+    store
+        .upsert_spec_queue_entry(&SpecQueueEntry {
+            spec_id: spec.id.clone(),
+            status: SpecQueueStatus::Approved,
+            rank: None,
+            approved_at: Some(now),
+            feedback: None,
+            blocking_dependencies: vec![],
+        })
+        .await
+        .unwrap();
+    (task, spec)
+}
+
+struct Harness {
+    store: Arc<Store>,
+    builder: Builder,
+    project: Project,
+    repo_url: String,
+    repo: std::path::PathBuf,
+    seen_prs: Arc<Mutex<Vec<Value>>>,
+    _tmp: tempfile::TempDir,
+}
+
+async fn harness(agent_cmd: &str) -> Harness {
+    let tmp = tempfile::tempdir().unwrap();
+    let supervisor_bin = cargo_build("builder-supervisor").await;
+    let wrapper =
+        write_builder_supervisor_wrapper(tmp.path(), &supervisor_bin, agent_cmd, tmp.path()).await;
+    let (_service, socket) = spawn_vm_pool(tmp.path(), &wrapper, 1).await;
+    let client = Client::<TasksProtocol>::connect(&socket).await.unwrap();
+
+    let store = Arc::new(Store::open_in_memory().await.unwrap());
+    let project = Project {
+        id: ProjectId::new(),
+        repo_owner: "test".into(),
+        repo_name: "repo".into(),
+        added_at: Utc::now(),
+    };
+    store.insert_project(&project).await.unwrap();
+
+    let repo = make_fixture_repo(tmp.path(), "remote-repo").await;
+    let repo_url = format!("file://{}", repo.display());
+
+    let (rest_url, seen_prs) = spawn_fake_github_rest(42).await;
+    let github = Arc::new(
+        GitHubClient::with_base_url("token", "http://unused.invalid/graphql")
+            .with_rest_base_url(rest_url),
+    );
+
+    let builder = Builder::new(
+        store.clone(),
+        client.handle(),
+        github,
+        BuilderConfig {
+            image: "builder:test".into(),
+            vm_config: VmConfig::default(),
+            timeout: Duration::from_secs(60),
+            scratch_root: tmp.path().join("scratch"),
+        },
+    );
+
+    Harness {
+        store,
+        builder,
+        project,
+        repo_url,
+        repo,
+        seen_prs,
+        _tmp: tmp,
+    }
+}
+
+#[tokio::test]
+async fn a_batch_of_two_specs_lands_as_one_branch_and_one_pr() {
+    let h = harness(stub_builder_agent_path().to_str().unwrap()).await;
+    let (task_a, spec_a) = seed_approved(&h.store, &h.project, 7, "First thing").await;
+    let (task_b, spec_b) = seed_approved(&h.store, &h.project, 9, "Second thing").await;
+
+    let build = h
+        .store
+        .create_build(&[spec_a.id.clone(), spec_b.id.clone()], "main")
+        .await
+        .unwrap();
+    let claimed = h.store.claim_next_queued_build().await.unwrap().unwrap();
+    assert_eq!(claimed.id, build.id);
+
+    let done = h.builder.dispatch(claimed, &h.repo_url).await.unwrap();
+    assert_eq!(done.status, BuildStatus::Succeeded);
+    assert_eq!(done.pr_number, Some(42));
+    let head_sha = done.head_sha.clone().expect("head sha recorded");
+    assert!(done.base_sha.is_some(), "base sha recorded from Started");
+    assert!(
+        done.files_touched.contains(&"src/built.rs".to_string()),
+        "files: {:?}",
+        done.files_touched
+    );
+
+    // The branch REALLY landed: the remote repo has it, at the reported tip.
+    let branch_ref = format!("refs/heads/{}", done.branch);
+    let tip = run_git(&h.repo, &["rev-parse", &branch_ref]).await;
+    assert_eq!(tip, head_sha);
+    let listing = run_git(&h.repo, &["ls-tree", "-r", "--name-only", &tip]).await;
+    assert!(listing.contains("src/built.rs"));
+    assert!(!listing.contains("PROMPT.md") && !listing.contains("SUMMARY.md"));
+
+    // The PR request the fake GitHub saw.
+    let prs = h.seen_prs.lock().unwrap();
+    assert_eq!(prs.len(), 1);
+    let pr = &prs[0];
+    assert_eq!(pr["head"], json!(done.branch));
+    assert_eq!(pr["base"], json!("main"));
+    assert_eq!(pr["title"], json!("Build: #7, #9"));
+    let body = pr["body"].as_str().unwrap();
+    assert!(body.contains("Implements #7") && body.contains("Implements #9"));
+    assert!(
+        !body.contains("Closes"),
+        "closing an issue is not ours to write"
+    );
+    drop(prs);
+
+    // The batch drained: specs built, tasks done.
+    for (task, spec) in [(&task_a, &spec_a), (&task_b, &spec_b)] {
+        assert_eq!(
+            h.store
+                .get_spec_queue_entry(&spec.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            SpecQueueStatus::Built
+        );
+        assert_eq!(
+            h.store.get_task(&task.id).await.unwrap().unwrap().state,
+            TaskState::Done
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_failed_build_returns_the_work_without_wedging_the_queue() {
+    // `true` as the agent: exits 0 having committed nothing -> empty branch.
+    let h = harness("true").await;
+    let (task, spec) = seed_approved(&h.store, &h.project, 7, "First thing").await;
+
+    let build = h
+        .store
+        .create_build(&[spec.id.clone()], "main")
+        .await
+        .unwrap();
+    let claimed = h.store.claim_next_queued_build().await.unwrap().unwrap();
+
+    let err = h.builder.dispatch(claimed, &h.repo_url).await.unwrap_err();
+    assert!(format!("{err}").contains("no commits"), "{err}");
+
+    let after = h.store.get_build(&build.id).await.unwrap().unwrap();
+    assert_eq!(after.status, BuildStatus::Failed);
+    assert!(
+        after
+            .exit_reason
+            .as_deref()
+            .unwrap_or("")
+            .contains("no commits"),
+        "exit_reason: {:?}",
+        after.exit_reason
+    );
+    // Spec stays approved, task returns to ready_to_build — never further
+    // back — and the queue is claimable again.
+    assert_eq!(
+        h.store
+            .get_spec_queue_entry(&spec.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        SpecQueueStatus::Approved
+    );
+    assert_eq!(
+        h.store.get_task(&task.id).await.unwrap().unwrap().state,
+        TaskState::ReadyToBuild
+    );
+    assert!(
+        h.seen_prs.lock().unwrap().is_empty(),
+        "no PR for a failed build"
+    );
+
+    let again = h.store.create_build(&[spec.id], "main").await.unwrap();
+    assert_eq!(
+        h.store.claim_next_queued_build().await.unwrap().unwrap().id,
+        again.id
+    );
+}

--- a/crates/tasks/tests/common/mod.rs
+++ b/crates/tasks/tests/common/mod.rs
@@ -192,3 +192,42 @@ where
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 }
+
+/// Like [`write_supervisor_wrapper`], for the builder-supervisor's env.
+pub async fn write_builder_supervisor_wrapper(
+    dir: &Path,
+    supervisor_bin: &Path,
+    agent_cmd: &str,
+    workdir_root: &Path,
+) -> PathBuf {
+    let wrapper = dir.join("builder-supervisor-wrapper.sh");
+    let script = format!(
+        "#!/bin/sh\n\
+         export BUILDER_AGENT_CMD={agent}\n\
+         export BUILDER_WORKDIR_ROOT={root}\n\
+         exec {bin}\n",
+        agent = shell_escape(agent_cmd),
+        root = shell_escape(&workdir_root.display().to_string()),
+        bin = shell_escape(&supervisor_bin.display().to_string()),
+    );
+    tokio::fs::write(&wrapper, script).await.unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut p = tokio::fs::metadata(&wrapper).await.unwrap().permissions();
+        p.set_mode(0o755);
+        tokio::fs::set_permissions(&wrapper, p).await.unwrap();
+    }
+    wrapper
+}
+
+/// A stand-in builder agent that commits work, forgets one file, and writes
+/// SUMMARY.md — lives in the builder-supervisor crate's fixtures.
+pub fn stub_builder_agent_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("builder-supervisor")
+        .join("tests")
+        .join("fixtures")
+        .join("stub-builder-agent.sh")
+}

--- a/crates/tasks/tests/run.rs
+++ b/crates/tasks/tests/run.rs
@@ -387,6 +387,9 @@ fn test_config(vm_pool_socket: &Path, clone_root: &Path, max_concurrent: usize) 
         clone_url_base: format!("file://{}", clone_root.display()),
         scout_base_branch: "main".into(),
         vm_config: VmConfig::default(),
+        builder_image: "builder:v1".into(),
+        builder_timeout: Duration::from_secs(300),
+        github_rest_api_url: None,
     }
 }
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -64,6 +64,19 @@ the server only.
   render it as Markdown. Also carries `files_touched`, `complexity`,
   `agent_exit_code`.
 - `GET /spec-queue` — `{entry: {...}, task_id}` items for the review screen.
+- `POST /builds` `{"spec_ids": [...], "base_branch"?}` — queue a Builder run
+  over a set of **approved** specs; **202** with the build (`{..., spec_ids}`).
+  Builds are strictly serial — one runs at a time, each cut from a base that
+  already contains the previous one — so 202 means queued, not started. The
+  batch is re-sorted into spec-queue order server-side. 400 on an empty or
+  duplicated set, a non-approved spec, specs from two projects, or a spec
+  already in an active build. Watch `build_*` events or poll.
+- `GET /builds` (newest first), `GET /builds/{id}` (`{..., spec_ids}`) —
+  `branch`, `base_branch`, `base_sha`/`head_sha`, `pr_number`, `status`,
+  `summary` (the PR body the agent wrote), `files_touched`, `exit_reason`.
+  `pr_number` is an identifier, not a state: the PR's mergeability/CI/open
+  state is GitHub's — link out (`https://github.com/{owner}/{repo}/pull/N`),
+  don't expect it here.
 - `GET /events?since=&limit=` — catch-up (default limit 100);
   `GET /events/stream` — SSE, each `data:` line is one Event JSON.
 
@@ -121,7 +134,10 @@ All enums are snake_case strings on the wire:
 - `Task.state`: `backlog` (ingested, inert — the Tasks table) → `queued`
   (explicitly picked up — the Queue, ordered by `manual_rank`) → `scouting` →
   `in_review` (spec awaits a verdict) → `ready_to_build` (approved, parked
-  for a Builder) → `done`, with `rejected` as the terminal failure state.
+  for a Builder) → `building` (a Builder run is implementing it, possibly
+  batched with others) → `done`, with `rejected` as the terminal failure
+  state. A failed build returns `building → ready_to_build` — the spec is
+  still good.
   Scout failures and `needs_revision` verdicts return to `queued`, never
   `backlog` — picked-up work stays picked up.
 - There is no "mark done" endpoint, deliberately: **closing the GitHub issue
@@ -134,8 +150,11 @@ All enums are snake_case strings on the wire:
   issue instead.
 - `Session.status`: `running`, `scout_succeeded`, `scout_failed`, `cancelled`.
 - `SpecQueueEntry.status`: `pending_review`, `approved`, `needs_revision`,
-  `blocked`, `rejected` (only the three verdict values are accepted by the
-  review endpoint; `pending_review`/`blocked` are server-assigned).
+  `blocked`, `rejected`, `built` (only the three verdict values are accepted
+  by the review endpoint; `pending_review`/`blocked` are server-assigned, and
+  `built` is how the approved queue drains — a successful Builder run
+  assigns it, and a spec cannot be built twice).
+- `Build.status`: `queued` → `running` → `succeeded` | `failed`.
 - `Complexity`: `simple`, `medium`, `complex`.
 - `Mode`: `play`, `pause`, `stop`.
 
@@ -149,6 +168,9 @@ snapshot of GitHub's open/closed flag moved, most often because the issue
 dropped out of the repository's open set; refetch the task or the list),
 `session_started`, `session_completed`, `spec_created`,
 `spec_queue_status_changed`, `queue_reordered`, `spec_queue_reordered`,
+`build_requested` (`build_id`, `spec_ids`), `build_started`,
+`build_completed` (`build_id`, `status` — refetch the build for detail),
+`pull_request_opened` (`build_id`, `pr_number`),
 `mode_changed`, `note` (`source`, `message` — free-form breadcrumbs; a
 scrolling activity feed of these is the cheapest useful "what is it doing"
 view).

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -1,0 +1,25 @@
+# Builder image for Tasks (tagged builder:v1)
+# vm-pool agent image (Claude Code + dev tools) with builder-supervisor as
+# PID 1. Same base as the scout image; only the supervisor and the agent's
+# job differ — a Builder's deliverable is the branch, shipped back to the
+# server as a git bundle. No push credential ever enters this image or VM.
+
+FROM vm-pool-agent:latest
+
+USER root
+COPY builder-supervisor /usr/local/bin/builder-supervisor
+RUN chmod +x /usr/local/bin/builder-supervisor
+
+USER agent
+WORKDIR /home/agent
+
+# The base image installs Rust for root only; builders build as `agent`.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+ENV PATH="/home/agent/.cargo/bin:${PATH}"
+
+# Headless agent invocation — same shape as the scout image; see
+# images/scout/Dockerfile for why --verbose is mandatory with stream-json.
+# Credentials (ANTHROPIC_API_KEY) are injected per-VM, never baked in.
+ENV BUILDER_AGENT_CMD="claude --print --output-format stream-json --verbose --dangerously-skip-permissions"
+
+ENTRYPOINT ["/usr/local/bin/builder-supervisor"]


### PR DESCRIPTION
Implements the approved spec for #764 (Diamond 2's first increment), adjusted per review feedback to current main (migration 0007; lifecycle mapping: builds consume `ready_to_build`, add `building`, failure returns to `ready_to_build`).

**Protocol** — `TasksProtocol` is now a role-tagged union (`TaskCommand`/`TaskEvent`, `{"role":"scout"|"build", "kind":...}`). The Scout/Builder barrier is a deserialization error plus a supervisor-side refusal, not a convention — tested both ways.

**builder-supervisor** — full-depth clone (`git bundle` refuses shallow history), host-chosen branch, sweep commit for forgotten work, PROMPT/SUMMARY stripped, `head == base` → failure, egress as a base64 thin bundle (32 MiB cap). No credential ever enters a VM.

**Server** — `builds` + `build_specs` (set-shaped from day one), `claim_next_queued_build` checks-and-claims in one transaction (serial by construction), the dispatcher lands the bundle in a scratch repo (fetch base first, verify tip == reported head, push), opens the PR server-side (`Implements #N`, never `Closes`), finalizes on every exit path, and redacts credentials from git errors. Orphaned running builds are reconciled at startup; queued builds survive restart. `POST /builds` (202) / `GET /builds` / `GET /builds/{id}`; `build_*` events; docs/clients.md updated.

**Tests** — no mocks throughout: supervisor tests unbundle into a scratch repo and verify the tip; the tasks integration test runs real vm-pool + real supervisor + a real git remote that receives the branch + a real HTTP server standing in for GitHub REST, asserted field by field. 112 tests across the workspace's tasks crates.

**Deploy notes** — the wire change requires restarting the vm-pool service and rebuilding BOTH images (`make images`: agent:v1 + builder:v1) before the next live scout or build.