### PR TITLE
App: surface builds in the Queue and Activity

### DIFF
--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -11,6 +11,7 @@ final class AppModel {
     var tasks: [TaskItem] = []
     var sessions: [ScoutSession] = []
     var specs: [Spec] = []
+    var builds: [BuildItem] = []
     var specQueue: [SpecQueueItem] = []
     var mode: Mode?
     /// Recent event log, newest first, for the Activity feed.
@@ -80,6 +81,22 @@ final class AppModel {
 
     func scoutNow(_ id: String) async {
         await perform { try await self.client.scoutNow(id) }
+    }
+
+    /// The at-most-one build the serial loop is running.
+    var runningBuild: BuildItem? {
+        builds.first { $0.status == .running }
+    }
+
+    /// Queue a one-spec Builder run (the API takes a batch; the UI's unit is
+    /// a task's approved spec). 202 — the queue view reflects progress.
+    func buildNow(specId: String) async {
+        do {
+            _ = try await client.requestBuild(specIds: [specId])
+            await refresh()
+        } catch {
+            connectionError = error.localizedDescription
+        }
     }
 
     func setMode(_ mode: Mode) async {
@@ -162,6 +179,7 @@ final class AppModel {
         async let tasks = Self.attempt { try await c.tasks() }
         async let sessions = Self.attempt { try await c.sessions() }
         async let specs = Self.attempt { try await c.specs() }
+        async let builds = Self.attempt { try await c.builds() }
         async let specQueue = Self.attempt { try await c.specQueue() }
         async let mode = Self.attempt { try await c.mode() }
         async let events = Self.attempt { try await c.events() }
@@ -179,6 +197,7 @@ final class AppModel {
         apply(await tasks) { self.tasks = $0 }
         apply(await sessions) { self.sessions = $0 }
         apply(await specs) { self.specs = $0 }
+        apply(await builds) { self.builds = $0 }
         apply(await specQueue) { self.specQueue = $0 }
         apply(await mode) { self.mode = $0 }
         apply(await events) { self.events = $0.sorted { $0.seq > $1.seq } }

--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -128,6 +128,7 @@ struct ContentView: View {
         List(selection: $selectedQueueTask) {
             let needsYou = tasksIn(.inReview)
             let running = tasksIn(.scouting)
+            let building = tasksIn(.building)
             let upNext = tasksIn(.queued)
             let readyToBuild = tasksIn(.readyToBuild)
 
@@ -150,6 +151,13 @@ struct ContentView: View {
                     }
                 }
             }
+            if !building.isEmpty {
+                Section("Building") {
+                    ForEach(building) { task in
+                        QueueRow(task: task, accessory: .elapsed(model.runningBuild?.startedAt))
+                    }
+                }
+            }
             if !upNext.isEmpty {
                 Section("Up next") {
                     ForEach(upNext) { task in
@@ -168,6 +176,13 @@ struct ContentView: View {
                 Section("Ready to build") {
                     ForEach(readyToBuild) { task in
                         QueueRow(task: task, accessory: .complexity(latestSpec(for: task)?.complexity))
+                            .contextMenu {
+                                if let spec = latestSpec(for: task) {
+                                    Button("Build") {
+                                        Task { await model.buildNow(specId: spec.id) }
+                                    }
+                                }
+                            }
                     }
                 }
             }
@@ -425,6 +440,10 @@ struct ActivityFeed: View {
         case "spec_created": "doc.text"
         case "spec_queue_status_changed": "text.badge.checkmark"
         case "queue_reordered", "spec_queue_reordered": "arrow.up.arrow.down"
+        case "build_requested": "hammer"
+        case "build_started": "hammer.circle"
+        case "build_completed": "checkmark.seal"
+        case "pull_request_opened": "arrow.triangle.branch"
         case "mode_changed": "playpause"
         case "note": "text.bubble"
         case "project_added": "folder.badge.plus"
@@ -457,6 +476,18 @@ struct ActivityFeed: View {
             return "Queue reordered"
         case "spec_queue_reordered":
             return "Spec queue reordered"
+        case "build_requested":
+            return "Build requested"
+        case "build_started":
+            return "Build started"
+        case "build_completed":
+            let status = event.status ?? "finished"
+            return "Build \(status)"
+        case "pull_request_opened":
+            if let pr = event.prNumber {
+                return "Pull request #\(pr) opened"
+            }
+            return "Pull request opened"
         case "mode_changed":
             return "Mode: \(event.from ?? "?") → \(event.to ?? "?")"
         case "note":
@@ -519,6 +550,7 @@ extension TaskState {
         case .scouting: .blue
         case .inReview: .purple
         case .readyToBuild: .teal
+        case .building: .indigo
         case .done: .green
         case .rejected: .red
         case .unknown: .secondary

--- a/app/Tasks/Models.swift
+++ b/app/Tasks/Models.swift
@@ -70,7 +70,7 @@ enum GhState: WireEnum {
 /// One state per stage (docs/clients.md): backlog is the inert issue mirror;
 /// everything from queued onward is explicitly picked-up work.
 enum TaskState: WireEnum {
-    case backlog, queued, scouting, inReview, readyToBuild, done, rejected
+    case backlog, queued, scouting, inReview, readyToBuild, building, done, rejected
     case unknown(String)
 
     init(wire: String) {
@@ -80,6 +80,7 @@ enum TaskState: WireEnum {
         case "scouting": self = .scouting
         case "in_review": self = .inReview
         case "ready_to_build": self = .readyToBuild
+        case "building": self = .building
         case "done": self = .done
         case "rejected": self = .rejected
         default: self = .unknown(wire)
@@ -93,6 +94,7 @@ enum TaskState: WireEnum {
         case .scouting: "scouting"
         case .inReview: "in_review"
         case .readyToBuild: "ready_to_build"
+        case .building: "building"
         case .done: "done"
         case .rejected: "rejected"
         case .unknown(let raw): raw
@@ -102,7 +104,7 @@ enum TaskState: WireEnum {
     /// Whether the task is picked-up work (anything past backlog and not dead).
     var isQueuedWork: Bool {
         switch self {
-        case .queued, .scouting, .inReview, .readyToBuild: true
+        case .queued, .scouting, .inReview, .readyToBuild, .building: true
         default: false
         }
     }
@@ -328,6 +330,9 @@ struct ActivityEvent: Decodable, Identifiable, Hashable {
     let to: String?
     let source: String?
     let message: String?
+    let buildId: String?
+    let status: String?
+    let prNumber: Int64?
 
     var id: Int64 { seq }
 
@@ -336,6 +341,7 @@ struct ActivityEvent: Decodable, Identifiable, Hashable {
     }
     enum PayloadKeys: String, CodingKey {
         case kind, taskId, sessionId, specId, from, to, source, message
+        case buildId, status, prNumber
     }
 
     init(from decoder: any Decoder) throws {
@@ -351,5 +357,52 @@ struct ActivityEvent: Decodable, Identifiable, Hashable {
         to = try? p.decodeIfPresent(String.self, forKey: .to)
         source = try? p.decodeIfPresent(String.self, forKey: .source)
         message = try? p.decodeIfPresent(String.self, forKey: .message)
+        buildId = try? p.decodeIfPresent(String.self, forKey: .buildId)
+        status = try? p.decodeIfPresent(String.self, forKey: .status)
+        prNumber = try? p.decodeIfPresent(Int64.self, forKey: .prNumber)
+    }
+}
+
+/// One serial Builder run over a batch of approved specs. `prNumber` is an
+/// identifier — the PR's live state is GitHub's; link out for it.
+struct BuildItem: Decodable, Identifiable, Hashable {
+    let id: String
+    let projectId: String
+    let branch: String
+    let baseBranch: String
+    let baseSha: String?
+    let headSha: String?
+    let prNumber: UInt64?
+    let status: BuildStatus
+    let summary: String?
+    let filesTouched: [String]
+    let exitReason: String?
+    let createdAt: Date
+    let startedAt: Date?
+    let completedAt: Date?
+}
+
+enum BuildStatus: WireEnum {
+    case queued, running, succeeded, failed
+    case unknown(String)
+
+    init(wire: String) {
+        switch wire {
+        case "queued": self = .queued
+        case "running": self = .running
+        case "succeeded": self = .succeeded
+        case "failed": self = .failed
+        default: self = .unknown(wire)
+        }
+    }
+
+    var wire: String {
+        switch self {
+        case .queued: "queued"
+        case .running: "running"
+        case .succeeded: "succeeded"
+        case .failed: "failed"
+        case .unknown(let raw): raw
+        }
     }
 }

--- a/app/Tasks/TasksClient.swift
+++ b/app/Tasks/TasksClient.swift
@@ -154,6 +154,20 @@ struct TasksClient: Sendable {
         }
     }
 
+    func builds() async throws -> [BuildItem] {
+        try await get("builds")
+    }
+
+    /// Queue a Builder run over approved specs. 202: the response is the
+    /// queued build, not a finished one — the serial loop picks it up.
+    func requestBuild(specIds: [String]) async throws -> BuildItem {
+        struct Body: Encodable {
+            let specIds: [String]
+            enum CodingKeys: String, CodingKey { case specIds = "spec_ids" }
+        }
+        return try await post("builds", body: Body(specIds: specIds))
+    }
+
     private func postEmpty<T: Decodable>(_ path: String) async throws -> T {
         var request = URLRequest(url: baseURL.appending(path: path))
         request.httpMethod = "POST"


### PR DESCRIPTION
- TaskState gains building (was rendering as a raw unknown and matching
  no Queue group, so a mid-build task vanished from the Queue view).
  New 'Building' section between Running and Up next, with an elapsed
  timer off the serial loop's running build.
- Right-click a 'Ready to build' row -> Build: POSTs the task's
  approved spec to /builds. This was the gap where approving a spec
  appeared to do nothing.
- BuildItem model + /builds client + AppModel.builds in the resilient
  refresh; build_requested/started/completed and pull_request_opened
  get icons and descriptions in Activity (PR number included).
