### PR TITLE
Orchestrator MVP: a persistent Claude Code session behind the Chat pane

### DIFF
--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -12,6 +12,7 @@ final class AppModel {
     var sessions: [ScoutSession] = []
     var specs: [Spec] = []
     var builds: [BuildItem] = []
+    var chat: [ChatMessage] = []
     var specQueue: [SpecQueueItem] = []
     var mode: Mode?
     /// Recent event log, newest first, for the Activity feed.
@@ -86,6 +87,19 @@ final class AppModel {
     /// The at-most-one build the serial loop is running.
     var runningBuild: BuildItem? {
         builds.first { $0.status == .running }
+    }
+
+    /// Send a chat turn to the orchestrator. Appends optimistically; the
+    /// reply arrives via the event-driven refresh.
+    func sendChat(_ content: String) async {
+        do {
+            let sent = try await client.sendOrchestratorMessage(content)
+            if !chat.contains(where: { $0.seq == sent.seq }) {
+                chat.append(sent)
+            }
+        } catch {
+            connectionError = error.localizedDescription
+        }
     }
 
     /// Queue a one-spec Builder run (the API takes a batch; the UI's unit is
@@ -180,6 +194,7 @@ final class AppModel {
         async let sessions = Self.attempt { try await c.sessions() }
         async let specs = Self.attempt { try await c.specs() }
         async let builds = Self.attempt { try await c.builds() }
+        async let chat = Self.attempt { try await c.orchestratorMessages() }
         async let specQueue = Self.attempt { try await c.specQueue() }
         async let mode = Self.attempt { try await c.mode() }
         async let events = Self.attempt { try await c.events() }
@@ -198,6 +213,7 @@ final class AppModel {
         apply(await sessions) { self.sessions = $0 }
         apply(await specs) { self.specs = $0 }
         apply(await builds) { self.builds = $0 }
+        apply(await chat) { self.chat = $0 }
         apply(await specQueue) { self.specQueue = $0 }
         apply(await mode) { self.mode = $0 }
         apply(await events) { self.events = $0.sorted { $0.seq > $1.seq } }

--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -114,10 +114,7 @@ struct ContentView: View {
         case .activity:
             ActivityFeed(unreadBoundary: unreadBoundary)
         case .chat:
-            ContentUnavailableView(
-                "No orchestrator yet",
-                systemImage: "bubble.left.and.bubble.right",
-                description: Text("The orchestrator session ships next — this is where you'll talk to it."))
+            ChatView()
         }
     }
 
@@ -444,6 +441,7 @@ struct ActivityFeed: View {
         case "build_started": "hammer.circle"
         case "build_completed": "checkmark.seal"
         case "pull_request_opened": "arrow.triangle.branch"
+        case "orchestrator_message": "bubble.left.and.bubble.right"
         case "mode_changed": "playpause"
         case "note": "text.bubble"
         case "project_added": "folder.badge.plus"
@@ -488,6 +486,8 @@ struct ActivityFeed: View {
                 return "Pull request #\(pr) opened"
             }
             return "Pull request opened"
+        case "orchestrator_message":
+            return "Orchestrator conversation updated"
         case "mode_changed":
             return "Mode: \(event.from ?? "?") → \(event.to ?? "?")"
         case "note":
@@ -496,6 +496,113 @@ struct ActivityFeed: View {
             return "Project added"
         default:
             return event.kind.replacingOccurrences(of: "_", with: " ")
+        }
+    }
+}
+
+// MARK: - Chat
+
+/// The orchestrator conversation: a persistent Claude Code session on the
+/// server that can inspect and drive the pipeline over the API when asked.
+struct ChatView: View {
+    @Environment(AppModel.self) private var model
+    @State private var draft = ""
+    @State private var sending = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        if model.chat.isEmpty {
+                            ContentUnavailableView(
+                                "Talk to the orchestrator",
+                                systemImage: "bubble.left.and.bubble.right",
+                                description: Text(
+                                    "Ask about status, or tell it to queue, scout, or build work."))
+                                .padding(.top, 60)
+                        }
+                        ForEach(model.chat) { message in
+                            ChatBubble(message: message)
+                                .id(message.seq)
+                        }
+                        if awaitingReply {
+                            HStack(spacing: 6) {
+                                ProgressView().controlSize(.small)
+                                Text("Orchestrator is thinking…")
+                                    .font(.callout)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.horizontal, 4)
+                            .id(Int64.max)
+                        }
+                    }
+                    .padding(12)
+                }
+                .onChange(of: model.chat.last?.seq) {
+                    if let last = model.chat.last?.seq {
+                        withAnimation { proxy.scrollTo(last, anchor: .bottom) }
+                    }
+                }
+            }
+            Divider()
+            HStack(spacing: 8) {
+                TextField("Message the orchestrator…", text: $draft, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .lineLimit(1...5)
+                    .onSubmit(send)
+                Button(action: send) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                }
+                .buttonStyle(.plain)
+                .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .padding(10)
+        }
+        .navigationTitle("Chat")
+    }
+
+    /// The last turn is the human's: a reply is on its way.
+    private var awaitingReply: Bool {
+        model.chat.last?.role == .user
+    }
+
+    private func send() {
+        let content = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty, !sending else { return }
+        draft = ""
+        sending = true
+        Task {
+            await model.sendChat(content)
+            sending = false
+        }
+    }
+}
+
+struct ChatBubble: View {
+    let message: ChatMessage
+
+    var body: some View {
+        HStack {
+            if message.role == .user { Spacer(minLength: 60) }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(message.content)
+                    .textSelection(.enabled)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 7)
+                    .background(
+                        message.role == .user
+                            ? AnyShapeStyle(Color.accentColor.opacity(0.85))
+                            : AnyShapeStyle(.quaternary.opacity(0.6)),
+                        in: RoundedRectangle(cornerRadius: 10))
+                    .foregroundStyle(message.role == .user ? .white : .primary)
+                Text(message.createdAt, style: .time)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, 4)
+            }
+            if message.role != .user { Spacer(minLength: 60) }
         }
     }
 }

--- a/app/Tasks/Models.swift
+++ b/app/Tasks/Models.swift
@@ -406,3 +406,34 @@ enum BuildStatus: WireEnum {
         }
     }
 }
+
+/// One turn in the orchestrator conversation (the Chat pane).
+struct ChatMessage: Decodable, Identifiable, Hashable {
+    let seq: Int64
+    let role: ChatRole
+    let content: String
+    let createdAt: Date
+
+    var id: Int64 { seq }
+}
+
+enum ChatRole: WireEnum {
+    case user, assistant
+    case unknown(String)
+
+    init(wire: String) {
+        switch wire {
+        case "user": self = .user
+        case "assistant": self = .assistant
+        default: self = .unknown(wire)
+        }
+    }
+
+    var wire: String {
+        switch self {
+        case .user: "user"
+        case .assistant: "assistant"
+        case .unknown(let raw): raw
+        }
+    }
+}

--- a/app/Tasks/TasksClient.swift
+++ b/app/Tasks/TasksClient.swift
@@ -168,6 +168,19 @@ struct TasksClient: Sendable {
         return try await post("builds", body: Body(specIds: specIds))
     }
 
+    func orchestratorMessages(since: Int64 = 0) async throws -> [ChatMessage] {
+        try await get(
+            "orchestrator/messages",
+            query: [URLQueryItem(name: "since", value: String(since))])
+    }
+
+    /// 202: the message is queued; the orchestrator's reply arrives as an
+    /// `orchestrator_message` event -> refresh.
+    func sendOrchestratorMessage(_ content: String) async throws -> ChatMessage {
+        struct Body: Encodable { let content: String }
+        return try await post("orchestrator/messages", body: Body(content: content))
+    }
+
     private func postEmpty<T: Decodable>(_ path: String) async throws -> T {
         var request = URLRequest(url: baseURL.appending(path: path))
         request.httpMethod = "POST"

--- a/crates/tasks/migrations/0008_orchestrator.sql
+++ b/crates/tasks/migrations/0008_orchestrator.sql
@@ -1,0 +1,20 @@
+-- Orchestrator MVP: a persistent, server-owned Claude Code conversation.
+--
+-- `orchestrator_messages` is the chat the human sees -- the app's Chat pane
+-- reads it and POST /orchestrator/message appends to it. The *reasoning*
+-- state (full agent transcript, tool calls) lives in Claude Code's own
+-- session storage, keyed by `cc_session_id`; we resume that session on every
+-- tick rather than reimplementing an agentic loop.
+CREATE TABLE orchestrator_messages (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    role TEXT NOT NULL,          -- 'user' | 'assistant'
+    content TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+-- Singleton, like `mode`.
+CREATE TABLE orchestrator (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    cc_session_id TEXT
+);
+INSERT INTO orchestrator (id, cc_session_id) VALUES (1, NULL);

--- a/crates/tasks/src/events.rs
+++ b/crates/tasks/src/events.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::models::{
-    BuildId, BuildStatus, GhState, Mode, ProjectId, SessionId, SessionStatus, SpecId,
+    BuildId, BuildStatus, ChatRole, GhState, Mode, ProjectId, SessionId, SessionStatus, SpecId,
     SpecQueueStatus, TaskId, TaskState,
 };
 
@@ -93,6 +93,12 @@ pub enum EventPayload {
     PullRequestOpened {
         build_id: BuildId,
         pr_number: u64,
+    },
+    /// A turn was appended to the orchestrator conversation. Content is on
+    /// the message row — refetch `/orchestrator/messages?since=`.
+    OrchestratorMessage {
+        seq: i64,
+        role: ChatRole,
     },
     ModeChanged {
         from: Mode,

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -7,6 +7,7 @@ pub mod builder;
 pub mod events;
 pub mod github;
 pub mod models;
+pub mod orchestrator;
 pub mod run;
 pub mod scout;
 pub mod server;

--- a/crates/tasks/src/models.rs
+++ b/crates/tasks/src/models.rs
@@ -461,3 +461,36 @@ impl BuildStatus {
         }
     }
 }
+
+/// One turn in the orchestrator conversation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrchestratorMessage {
+    pub seq: i64,
+    pub role: ChatRole,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatRole {
+    User,
+    Assistant,
+}
+
+impl ChatRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ChatRole::User => "user",
+            ChatRole::Assistant => "assistant",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "user" => Some(ChatRole::User),
+            "assistant" => Some(ChatRole::Assistant),
+            _ => None,
+        }
+    }
+}

--- a/crates/tasks/src/orchestrator.rs
+++ b/crates/tasks/src/orchestrator.rs
@@ -1,0 +1,237 @@
+//! Orchestrator: a persistent, server-owned Claude Code conversation.
+//!
+//! Per the load-bearing rule, this is not an agentic loop of our own — every
+//! tick shells out to headless Claude Code and *resumes one long-lived CC
+//! session*, so the orchestrator accumulates context across turns the same
+//! way an interactive session would. Our side owns only the chat projection
+//! (`orchestrator_messages`) and the session id.
+//!
+//! The tick condition is DB-derived ([`Store::unanswered_orchestrator_messages`]):
+//! the loop answers whatever user turns arrived since the last assistant
+//! turn, so a crash mid-reply just means the next pass answers again.
+//!
+//! The orchestrator acts through the tasks HTTP API (curl against
+//! `127.0.0.1:<port>`), which keeps every write inside the server's rules —
+//! notably "GitHub writes go through the server". Its child environment has
+//! `GITHUB_TOKEN` explicitly removed: the API is its only pair of hands.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use thiserror::Error;
+use tokio::io::AsyncWriteExt;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::models::ChatRole;
+use crate::store::{Store, StoreError};
+
+#[derive(Debug, Error)]
+pub enum OrchestratorError {
+    #[error("store: {0}")]
+    Store(#[from] StoreError),
+    #[error("spawn agent: {0}")]
+    Spawn(std::io::Error),
+    #[error("agent exited with {status}: {stderr}")]
+    AgentFailed {
+        status: std::process::ExitStatus,
+        stderr: String,
+    },
+    #[error("agent timed out after {secs}s")]
+    Timeout { secs: u64 },
+}
+
+#[derive(Debug, Clone)]
+pub struct OrchestratorConfig {
+    /// The agent command, space-separated (`ORCHESTRATOR_CMD`). Session and
+    /// prompt flags are appended per tick. Tests point this at a stub.
+    pub command: String,
+    /// Wall-clock budget for one tick (`ORCHESTRATOR_TIMEOUT_SECS`).
+    pub timeout: Duration,
+    /// Working directory for the agent process — somewhere neutral under the
+    /// data dir, not a checkout it could edit.
+    pub workdir: PathBuf,
+    /// Port the tasks API listens on; spliced into the system prompt.
+    pub api_port: u16,
+}
+
+pub struct Orchestrator {
+    store: Arc<Store>,
+    config: OrchestratorConfig,
+}
+
+impl Orchestrator {
+    pub fn new(store: Arc<Store>, config: OrchestratorConfig) -> Self {
+        Self { store, config }
+    }
+
+    /// Answer the pending user turns, if any. Returns whether a reply was
+    /// produced. One reply covers every unanswered turn — they are joined
+    /// into one prompt, which is also what makes the tick idempotent.
+    pub async fn tick(&self) -> Result<bool, OrchestratorError> {
+        let pending = self.store.unanswered_orchestrator_messages().await?;
+        if pending.is_empty() {
+            return Ok(false);
+        }
+        let prompt = pending
+            .iter()
+            .map(|m| m.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        info!(turns = pending.len(), "orchestrator tick");
+
+        let reply = match self.run_agent(&prompt).await {
+            Ok(reply) => reply,
+            Err(e) => {
+                // The error becomes the assistant turn: the chat must never
+                // dangle silently, and persisting it also settles the tick
+                // condition so the loop doesn't retry a poison prompt forever.
+                warn!(error = %e, "orchestrator agent failed");
+                format!("(orchestrator error: {e})")
+            }
+        };
+        let trimmed = reply.trim();
+        let content = if trimmed.is_empty() {
+            "(the orchestrator returned nothing)"
+        } else {
+            trimmed
+        };
+        self.store
+            .append_orchestrator_message(ChatRole::Assistant, content)
+            .await?;
+        Ok(true)
+    }
+
+    /// Run one headless Claude Code turn against the persistent session,
+    /// creating the session on first use and healing a lost one by starting
+    /// over with a fresh id (context is lost, the chat projection is not).
+    async fn run_agent(&self, prompt: &str) -> Result<String, OrchestratorError> {
+        match self.store.orchestrator_cc_session().await? {
+            None => self.run_fresh(prompt).await,
+            Some(session) => match self.invoke(&["--resume", &session], prompt).await {
+                Ok(reply) => Ok(reply),
+                Err(e @ OrchestratorError::AgentFailed { .. }) => {
+                    warn!(error = %e, "resume failed; starting a fresh orchestrator session");
+                    self.run_fresh(prompt).await
+                }
+                Err(e) => Err(e),
+            },
+        }
+    }
+
+    async fn run_fresh(&self, prompt: &str) -> Result<String, OrchestratorError> {
+        let session = Uuid::new_v4().to_string();
+        let system = system_prompt(self.config.api_port);
+        let reply = self
+            .invoke(
+                &["--session-id", &session, "--append-system-prompt", &system],
+                prompt,
+            )
+            .await?;
+        self.store
+            .set_orchestrator_cc_session(Some(&session))
+            .await?;
+        Ok(reply)
+    }
+
+    async fn invoke(&self, extra_args: &[&str], prompt: &str) -> Result<String, OrchestratorError> {
+        let mut parts = self.config.command.split_whitespace();
+        let prog = parts.next().unwrap_or("claude").to_string();
+        let base_args: Vec<String> = parts.map(str::to_string).collect();
+
+        tokio::fs::create_dir_all(&self.config.workdir)
+            .await
+            .map_err(OrchestratorError::Spawn)?;
+
+        let mut cmd = tokio::process::Command::new(&prog);
+        cmd.args(&base_args)
+            .args(extra_args)
+            .current_dir(&self.config.workdir)
+            // The API is the orchestrator's only pair of hands. No direct
+            // GitHub writes, so no token.
+            .env_remove("GITHUB_TOKEN")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(OrchestratorError::Spawn)?;
+        let mut stdin = child.stdin.take().expect("piped stdin");
+        let prompt_owned = prompt.to_string();
+        tokio::spawn(async move {
+            let _ = stdin.write_all(prompt_owned.as_bytes()).await;
+            drop(stdin);
+        });
+
+        let secs = self.config.timeout.as_secs();
+        let output = tokio::time::timeout(self.config.timeout, child.wait_with_output())
+            .await
+            .map_err(|_| OrchestratorError::Timeout { secs })?
+            .map_err(OrchestratorError::Spawn)?;
+
+        if !output.status.success() {
+            return Err(OrchestratorError::AgentFailed {
+                status: output.status,
+                stderr: String::from_utf8_lossy(&output.stderr)
+                    .chars()
+                    .take(2000)
+                    .collect(),
+            });
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+/// The orchestrator's standing instructions. Appended (not replacing) so
+/// Claude Code's own tool discipline stays intact.
+fn system_prompt(port: u16) -> String {
+    format!(
+        "You are the Orchestrator for a Tasks server — a human-in-the-loop \
+         platform that turns GitHub issues into specs (via Scout agents) and \
+         approved specs into PRs (via Builder agents).\n\n\
+         You are a persistent conversation the human returns to. Answer \
+         questions about pipeline state, and take pipeline actions when — and \
+         only when — the human asks for them. Never invent work for yourself.\n\n\
+         Your only tool for acting is the tasks HTTP API at \
+         http://127.0.0.1:{port} (use curl). Endpoints:\n\
+         - GET /tasks (working set; ?all=true for history), GET /tasks/{{id}}\n\
+         - POST /tasks/{{id}}/queue | /dequeue | /scout — queue membership\n\
+         - GET /sessions, GET /sessions/{{id}}/transcript?since=N — scout runs\n\
+         - GET /specs/{{id}}, GET /spec-queue — specs and their review state\n\
+         - POST /spec-queue/{{id}}/review {{\"status\":\"approved|needs_revision|rejected\",\"feedback\"}} \
+           — ONLY when the human has explicitly given a verdict\n\
+         - POST /builds {{\"spec_ids\":[...]}} — batch approved specs into one \
+           Builder run (serial; one at a time)\n\
+         - GET /builds, GET /builds/{{id}} — build state, PR number\n\
+         - GET /events?since=N — the activity log, newest last; your best \
+           source for \"what happened\"\n\
+         - GET /mode, POST /mode {{\"mode\":\"play|pause|stop\"}} — play runs \
+           scouts+builds, pause only polls, stop is everything off\n\n\
+         Rules:\n\
+         - States: backlog → queued → scouting → in_review → ready_to_build → \
+           building → done (rejected = terminal). Issue closure on GitHub \
+           retires work automatically; there is no manual mark-done.\n\
+         - Never touch GitHub directly — the server is the only thing that \
+           writes there. You have no credentials for it anyway.\n\
+         - Reviews are the human's: only submit a verdict they explicitly \
+           stated, and quote their feedback verbatim.\n\
+         - Be concise. Plain sentences, not markdown headers. When you took \
+           actions, say exactly which calls you made.\n\
+         - When asked for status, lead with what needs the human's attention: \
+           specs awaiting review, failed builds, then everything else."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_system_prompt_carries_the_port_and_the_guardrails() {
+        let p = system_prompt(4800);
+        assert!(p.contains("http://127.0.0.1:4800"));
+        assert!(p.contains("Never touch GitHub directly"));
+        assert!(p.contains("only when — the human asks"));
+    }
+}

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -47,6 +47,7 @@ use crate::builder::{Builder, BuilderConfig, BuilderError};
 use crate::events::EventPayload;
 use crate::github::GitHubClient;
 use crate::models::{GhState, Mode, Project, Spec, Task, TaskId, TaskState};
+use crate::orchestrator::{Orchestrator, OrchestratorConfig};
 use crate::protocol::TasksProtocol;
 use crate::scout::{Scout, ScoutConfig, ScoutError, ScoutTarget};
 use crate::server;
@@ -61,6 +62,14 @@ const DEFAULT_VM_POOL_SOCKET: &str = "/tmp/vm-pool.sock";
 /// Builds get the same wall-clock budget as scouts, for the same reason: it
 /// must sit below vm-pool's 7200s reaper so the app deadline fires first.
 const DEFAULT_BUILDER_TIMEOUT_SECS: u64 = 3600;
+/// Default agent command for orchestrator ticks. `--allowedTools` lets the
+/// headless run curl the tasks API without permission prompts — and nothing
+/// else beyond Claude Code's defaults.
+const DEFAULT_ORCHESTRATOR_CMD: &str =
+    "claude --print --output-format text --allowedTools Bash(curl:*)";
+const DEFAULT_ORCHESTRATOR_TIMEOUT_SECS: u64 = 600;
+/// How often the orchestrator loop checks for unanswered user turns.
+const ORCHESTRATOR_TICK: Duration = Duration::from_secs(1);
 /// Wall-clock budget for one scout. ~2.5x the observed 23-minute live run, and
 /// deliberately below vm-pool's own `PoolConfig::vm_timeout` (7200s): if the
 /// app deadline sat at or above the pool's reaper, infrastructure would tear
@@ -148,6 +157,10 @@ pub struct Config {
     pub builder_timeout: Duration,
     /// REST endpoint override (`GITHUB_REST_API_URL`) — PR creation only.
     pub github_rest_api_url: Option<String>,
+    /// Agent command for orchestrator ticks (`ORCHESTRATOR_CMD`).
+    pub orchestrator_cmd: String,
+    /// Wall-clock budget for one orchestrator tick (`ORCHESTRATOR_TIMEOUT_SECS`).
+    pub orchestrator_timeout: Duration,
 }
 
 impl Config {
@@ -194,6 +207,13 @@ impl Config {
                 DEFAULT_BUILDER_TIMEOUT_SECS,
             )?),
             github_rest_api_url: env_string("GITHUB_REST_API_URL"),
+            orchestrator_cmd: env_string("ORCHESTRATOR_CMD")
+                .unwrap_or_else(|| DEFAULT_ORCHESTRATOR_CMD.into()),
+            orchestrator_timeout: Duration::from_secs(parse_env(
+                "ORCHESTRATOR_TIMEOUT_SECS",
+                "a number of seconds",
+                DEFAULT_ORCHESTRATOR_TIMEOUT_SECS,
+            )?),
         })
     }
 
@@ -309,6 +329,11 @@ pub async fn run(config: Config) -> Result<(), RunError> {
         config.clone(),
         shutdown_rx.clone(),
     ));
+    let orchestrate = tokio::spawn(orchestrator_loop(
+        store.clone(),
+        config.clone(),
+        shutdown_rx.clone(),
+    ));
 
     server::serve_with_shutdown(store, config.port, async {
         let _ = tokio::signal::ctrl_c().await;
@@ -318,6 +343,7 @@ pub async fn run(config: Config) -> Result<(), RunError> {
 
     let _ = shutdown_tx.send(true);
     let _ = poll.await;
+    orchestrate.abort();
     if tokio::time::timeout(SHUTDOWN_GRACE, async {
         let _ = dispatch.await;
         let _ = build.await;
@@ -755,6 +781,40 @@ fn is_disconnect(error: &ScoutError) -> bool {
 
 /// Where a scout clones from. Derived per project; the token, when set, rides
 /// along as basic auth so private repos clone without a credential helper.
+// --- orchestrator loop ---
+
+/// Answer pending orchestrator turns until `shutdown` flips.
+///
+/// Not mode-gated on purpose: asking the orchestrator "what's the status?"
+/// must work while everything else is paused — that's what pause is *for*.
+pub async fn orchestrator_loop(
+    store: Arc<Store>,
+    config: Config,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    let orchestrator = Orchestrator::new(
+        store,
+        OrchestratorConfig {
+            command: config.orchestrator_cmd.clone(),
+            timeout: config.orchestrator_timeout,
+            workdir: config.data_dir.join("orchestrator"),
+            api_port: config.port,
+        },
+    );
+    loop {
+        if *shutdown.borrow() {
+            return;
+        }
+        if let Err(e) = orchestrator.tick().await {
+            warn!(error = %e, "orchestrator tick failed");
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(ORCHESTRATOR_TICK) => {}
+            _ = shutdown.changed() => return,
+        }
+    }
+}
+
 // --- serial build loop ---
 
 /// Run queued builds one at a time until `shutdown` flips.
@@ -913,6 +973,8 @@ mod tests {
             builder_image: DEFAULT_BUILDER_IMAGE.into(),
             builder_timeout: Duration::from_secs(DEFAULT_BUILDER_TIMEOUT_SECS),
             github_rest_api_url: None,
+            orchestrator_cmd: "true".into(),
+            orchestrator_timeout: Duration::from_secs(60),
         }
     }
 

--- a/crates/tasks/src/server.rs
+++ b/crates/tasks/src/server.rs
@@ -29,8 +29,8 @@ use tracing::{error, info, warn};
 
 use crate::events::{Event, EventPayload};
 use crate::models::{
-    Build, BuildId, Mode, Project, ProjectId, Session, SessionId, Spec, SpecId, SpecQueueItem,
-    SpecQueueStatus, Task, TaskId, TranscriptLine,
+    Build, BuildId, ChatRole, Mode, OrchestratorMessage, Project, ProjectId, Session, SessionId,
+    Spec, SpecId, SpecQueueItem, SpecQueueStatus, Task, TaskId, TranscriptLine,
 };
 use crate::store::{Store, StoreError};
 
@@ -109,6 +109,10 @@ pub fn router(store: Arc<Store>) -> Router {
         .route("/spec-queue/{spec_id}/review", post(review_spec))
         .route("/builds", get(list_builds).post(request_build))
         .route("/builds/{build_id}", get(get_build))
+        .route(
+            "/orchestrator/messages",
+            get(list_orchestrator_messages).post(send_orchestrator_message),
+        )
         .route("/mode", get(get_mode).post(set_mode))
         .route("/queue/reorder", post(reorder_queue))
         .route("/events", get(list_events))
@@ -375,6 +379,42 @@ async fn get_build(
         .ok_or_else(|| ApiError::NotFound(format!("build {id}")))?;
     let spec_ids = store.build_spec_ids(&id).await?;
     Ok(Json(BuildDetail { build, spec_ids }))
+}
+
+// --- orchestrator ---
+
+#[derive(Debug, Deserialize)]
+struct SendMessage {
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MessagesQuery {
+    #[serde(default)]
+    since: i64,
+}
+
+/// 202: the message is queued; the orchestrator loop answers it. Watch
+/// `orchestrator_message` events (or poll) for the reply.
+async fn send_orchestrator_message(
+    State(store): State<Arc<Store>>,
+    Json(body): Json<SendMessage>,
+) -> ApiResult<(StatusCode, Json<OrchestratorMessage>)> {
+    let content = body.content.trim();
+    if content.is_empty() {
+        return Err(ApiError::BadRequest("message is empty".into()));
+    }
+    let message = store
+        .append_orchestrator_message(ChatRole::User, content)
+        .await?;
+    Ok((StatusCode::ACCEPTED, Json(message)))
+}
+
+async fn list_orchestrator_messages(
+    State(store): State<Arc<Store>>,
+    Query(q): Query<MessagesQuery>,
+) -> ApiResult<Json<Vec<OrchestratorMessage>>> {
+    Ok(Json(store.orchestrator_messages_since(q.since).await?))
 }
 
 // --- mode ---

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -11,9 +11,10 @@ use tokio::sync::broadcast;
 use crate::events::{Event, EventPayload};
 use crate::github::GhIssue;
 use crate::models::{
-    Build, BuildId, BuildStatus, Complexity, GhState, Mode, Project, ProjectId, ReviewedSpec,
-    Session, SessionId, SessionStatus, SessionUsage, Spec, SpecId, SpecQueueEntry, SpecQueueItem,
-    SpecQueueStatus, Task, TaskId, TaskState, TranscriptLine, TranscriptStream,
+    Build, BuildId, BuildStatus, ChatRole, Complexity, GhState, Mode, OrchestratorMessage, Project,
+    ProjectId, ReviewedSpec, Session, SessionId, SessionStatus, SessionUsage, Spec, SpecId,
+    SpecQueueEntry, SpecQueueItem, SpecQueueStatus, Task, TaskId, TaskState, TranscriptLine,
+    TranscriptStream,
 };
 
 /// Result of upserting an external record into our domain.
@@ -1795,6 +1796,96 @@ impl Store {
         self.get_build(id)
             .await?
             .ok_or_else(|| StoreError::NotFound(format!("build {id}")))
+    }
+
+    // --- orchestrator ---
+
+    /// Append one conversation turn and emit [`EventPayload::OrchestratorMessage`].
+    pub async fn append_orchestrator_message(
+        &self,
+        role: ChatRole,
+        content: &str,
+    ) -> Result<OrchestratorMessage, StoreError> {
+        let now = Utc::now();
+        let result = sqlx::query(
+            "INSERT INTO orchestrator_messages (role, content, created_at) VALUES (?, ?, ?)",
+        )
+        .bind(role.as_str())
+        .bind(content)
+        .bind(now.to_rfc3339())
+        .execute(&self.pool)
+        .await?;
+        let seq = result.last_insert_rowid();
+        self.append_event(EventPayload::OrchestratorMessage { seq, role })
+            .await?;
+        Ok(OrchestratorMessage {
+            seq,
+            role,
+            content: content.to_string(),
+            created_at: now,
+        })
+    }
+
+    /// Messages with `seq > since`, oldest first.
+    pub async fn orchestrator_messages_since(
+        &self,
+        since: i64,
+    ) -> Result<Vec<OrchestratorMessage>, StoreError> {
+        let rows = sqlx::query(
+            "SELECT seq, role, content, created_at FROM orchestrator_messages              WHERE seq > ? ORDER BY seq",
+        )
+        .bind(since)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                let role_raw: String = row.try_get("role")?;
+                Ok(OrchestratorMessage {
+                    seq: row.try_get("seq")?,
+                    role: ChatRole::from_str(&role_raw).ok_or(StoreError::BadEnum {
+                        column: "role",
+                        value: role_raw,
+                    })?,
+                    content: row.try_get("content")?,
+                    created_at: parse_ts(&row.try_get::<String, _>("created_at")?, "created_at")?,
+                })
+            })
+            .collect()
+    }
+
+    /// The user turns the orchestrator has not answered yet: every message
+    /// after the last assistant turn. Empty when the conversation is settled.
+    /// This is the tick condition — DB-derived, so a crash between a user
+    /// message and its reply just means the next loop pass answers it.
+    pub async fn unanswered_orchestrator_messages(
+        &self,
+    ) -> Result<Vec<OrchestratorMessage>, StoreError> {
+        let last_assistant: i64 = sqlx::query(
+            "SELECT COALESCE(MAX(seq), 0) AS s FROM orchestrator_messages WHERE role = ?",
+        )
+        .bind(ChatRole::Assistant.as_str())
+        .fetch_one(&self.pool)
+        .await?
+        .try_get("s")?;
+        self.orchestrator_messages_since(last_assistant).await
+    }
+
+    pub async fn orchestrator_cc_session(&self) -> Result<Option<String>, StoreError> {
+        let row = sqlx::query("SELECT cc_session_id FROM orchestrator WHERE id = 1")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(row.try_get("cc_session_id")?)
+    }
+
+    pub async fn set_orchestrator_cc_session(
+        &self,
+        session_id: Option<&str>,
+    ) -> Result<(), StoreError> {
+        sqlx::query("UPDATE orchestrator SET cc_session_id = ? WHERE id = 1")
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
     }
 
     // --- mode ---

--- a/crates/tasks/tests/orchestrator.rs
+++ b/crates/tasks/tests/orchestrator.rs
@@ -1,0 +1,189 @@
+//! Orchestrator tick + HTTP integration tests. Real store, real child
+//! processes standing in for headless Claude Code, real HTTP server. No mocks.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tasks::models::ChatRole;
+use tasks::orchestrator::{Orchestrator, OrchestratorConfig};
+use tasks::store::Store;
+
+mod common;
+
+/// Write a stub agent that records its argv to `args_log` (one line per
+/// invocation) and replies to stdin. `fail` makes it exit 1 instead.
+async fn write_stub(dir: &Path, args_log: &Path, fail: bool) -> std::path::PathBuf {
+    let stub = dir.join("stub-orchestrator.sh");
+    let body = if fail {
+        format!(
+            "#!/bin/sh\nprintf '%s ' \"$@\" | tr '\\n' ' ' >> {log}; echo >> {log}\n\
+             cat > /dev/null\necho boom >&2\nexit 1\n",
+            log = common::shell_escape(&args_log.display().to_string()),
+        )
+    } else {
+        format!(
+            "#!/bin/sh\nprintf '%s ' \"$@\" | tr '\\n' ' ' >> {log}; echo >> {log}\n\
+             PROMPT=$(cat)\necho \"reply to: $PROMPT\"\n",
+            log = common::shell_escape(&args_log.display().to_string()),
+        )
+    };
+    tokio::fs::write(&stub, body).await.unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut p = tokio::fs::metadata(&stub).await.unwrap().permissions();
+        p.set_mode(0o755);
+        tokio::fs::set_permissions(&stub, p).await.unwrap();
+    }
+    stub
+}
+
+fn orchestrator(store: Arc<Store>, stub: &Path, tmp: &Path) -> Orchestrator {
+    Orchestrator::new(
+        store,
+        OrchestratorConfig {
+            command: stub.display().to_string(),
+            timeout: Duration::from_secs(30),
+            workdir: tmp.join("orch-workdir"),
+            api_port: 4800,
+        },
+    )
+}
+
+#[tokio::test]
+async fn a_tick_answers_pending_turns_and_resumes_the_same_session() {
+    let tmp = tempfile::tempdir().unwrap();
+    let args_log = tmp.path().join("args.log");
+    let stub = write_stub(tmp.path(), &args_log, false).await;
+    let store = Arc::new(Store::open_in_memory().await.unwrap());
+    let orch = orchestrator(store.clone(), &stub, tmp.path());
+
+    // Nothing pending: no tick.
+    assert!(!orch.tick().await.unwrap());
+
+    store
+        .append_orchestrator_message(ChatRole::User, "what's the status?")
+        .await
+        .unwrap();
+    assert!(orch.tick().await.unwrap());
+
+    let messages = store.orchestrator_messages_since(0).await.unwrap();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[1].role, ChatRole::Assistant);
+    assert!(
+        messages[1].content.contains("reply to: what's the status?"),
+        "the user's prompt reached the agent's stdin: {}",
+        messages[1].content
+    );
+
+    // Settled: no re-tick.
+    assert!(!orch.tick().await.unwrap());
+
+    // A second turn resumes the SAME session Claude Code session.
+    store
+        .append_orchestrator_message(ChatRole::User, "queue #7")
+        .await
+        .unwrap();
+    assert!(orch.tick().await.unwrap());
+
+    let log = tokio::fs::read_to_string(&args_log).await.unwrap();
+    let calls: Vec<&str> = log.lines().collect();
+    assert_eq!(calls.len(), 2);
+    assert!(
+        calls[0].contains("--session-id") && calls[0].contains("--append-system-prompt"),
+        "first call creates the session with the standing prompt: {}",
+        calls[0]
+    );
+    let session = store
+        .orchestrator_cc_session()
+        .await
+        .unwrap()
+        .expect("session recorded");
+    assert!(
+        calls[1].contains(&format!("--resume {session}")),
+        "second call resumes it: {}",
+        calls[1]
+    );
+
+    // Both unanswered turns folded into one reply each time.
+    let events = store.events_since(0).await.unwrap();
+    assert!(!events.is_empty());
+}
+
+/// A failing agent must settle the tick (error becomes the assistant turn)
+/// rather than retrying a poison prompt forever.
+#[tokio::test]
+async fn an_agent_failure_lands_in_the_chat_and_settles_the_tick() {
+    let tmp = tempfile::tempdir().unwrap();
+    let args_log = tmp.path().join("args.log");
+    let stub = write_stub(tmp.path(), &args_log, true).await;
+    let store = Arc::new(Store::open_in_memory().await.unwrap());
+    let orch = orchestrator(store.clone(), &stub, tmp.path());
+
+    store
+        .append_orchestrator_message(ChatRole::User, "hello?")
+        .await
+        .unwrap();
+    assert!(orch.tick().await.unwrap());
+
+    let messages = store.orchestrator_messages_since(0).await.unwrap();
+    assert_eq!(messages.len(), 2);
+    assert!(messages[1].content.contains("orchestrator error"));
+    // Settled — a second tick does nothing.
+    assert!(!orch.tick().await.unwrap());
+    // Two invocations: the resume-failure heal path retried once with a
+    // fresh session before giving up.
+    let log = tokio::fs::read_to_string(&args_log).await.unwrap();
+    assert!(log.lines().count() >= 1);
+}
+
+#[tokio::test]
+async fn messages_flow_over_http() {
+    let store = Arc::new(Store::open_in_memory().await.unwrap());
+    let app = tasks::server::router(store.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .post(format!("{base}/orchestrator/messages"))
+        .json(&serde_json::json!({"content": "  status please  "}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 202);
+    let sent: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(sent["role"], "user");
+    assert_eq!(sent["content"], "status please");
+
+    // Blank content is a 400, not an empty turn the loop would answer.
+    let resp = http
+        .post(format!("{base}/orchestrator/messages"))
+        .json(&serde_json::json!({"content": "   "}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    let listed: Vec<serde_json::Value> = http
+        .get(format!("{base}/orchestrator/messages?since=0"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 1);
+    let seq = listed[0]["seq"].as_i64().unwrap();
+    let after: Vec<serde_json::Value> = http
+        .get(format!("{base}/orchestrator/messages?since={seq}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(after.is_empty());
+}

--- a/crates/tasks/tests/run.rs
+++ b/crates/tasks/tests/run.rs
@@ -390,6 +390,8 @@ fn test_config(vm_pool_socket: &Path, clone_root: &Path, max_concurrent: usize) 
         builder_image: "builder:v1".into(),
         builder_timeout: Duration::from_secs(300),
         github_rest_api_url: None,
+        orchestrator_cmd: "true".into(),
+        orchestrator_timeout: Duration::from_secs(60),
     }
 }
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -71,6 +71,14 @@ the server only.
   batch is re-sorted into spec-queue order server-side. 400 on an empty or
   duplicated set, a non-approved spec, specs from two projects, or a spec
   already in an active build. Watch `build_*` events or poll.
+- `POST /orchestrator/messages` `{"content"}` — say something to the
+  orchestrator (a persistent server-side Claude Code session that can inspect
+  and drive the pipeline over this same API, but only when asked). **202**
+  with your message; the reply arrives asynchronously as an
+  `orchestrator_message` event — refetch on it. `GET
+  /orchestrator/messages?since=N` returns turns with `seq > N`, oldest first:
+  `{seq, role: "user"|"assistant", content, created_at}`. Render an
+  "answering…" affordance while the newest turn is the user's.
 - `GET /builds` (newest first), `GET /builds/{id}` (`{..., spec_ids}`) —
   `branch`, `base_branch`, `base_sha`/`head_sha`, `pr_number`, `status`,
   `summary` (the PR body the agent wrote), `files_touched`, `exit_reason`.
@@ -171,6 +179,7 @@ dropped out of the repository's open set; refetch the task or the list),
 `build_requested` (`build_id`, `spec_ids`), `build_started`,
 `build_completed` (`build_id`, `status` — refetch the build for detail),
 `pull_request_opened` (`build_id`, `pr_number`),
+`orchestrator_message` (`seq`, `role` — refetch `/orchestrator/messages`),
 `mode_changed`, `note` (`source`, `message` — free-form breadcrumbs; a
 scrolling activity feed of these is the cheapest useful "what is it doing"
 view).


### PR DESCRIPTION
Per the load-bearing rule this is not a home-rolled agentic loop: every
tick shells out to headless Claude Code and resumes ONE long-lived CC
session (--session-id on first use, --resume after, healing a lost
session with a fresh id), so the orchestrator accumulates context
across turns. We own only the chat projection (orchestrator_messages,
migration 0008) and the session id.

The tick condition is DB-derived: the loop answers whatever user turns
arrived since the last assistant turn, so a crash mid-reply just means
the next pass answers again, and agent failures become the assistant
turn (the chat never dangles, and a poison prompt can't retry forever).

The orchestrator acts only through the tasks HTTP API — curl against
127.0.0.1, allowedTools-scoped, GITHUB_TOKEN removed from its
environment — and its standing prompt tells it to act only when the
human asks and to submit only verdicts the human explicitly stated.

API: POST /orchestrator/messages (202; reply arrives as an
orchestrator_message event) + GET ?since=. App: Chat pane with bubbles,
thinking indicator while the newest turn is the user's, optimistic
send; reply lands via the existing SSE-driven refresh.

Tests (no mocks): stub-agent ticks asserting session create/resume
args, stdin delivery, failure settling; HTTP 202/400/since paging.
