### PR TITLE
App: block-level markdown rendering + full-width Chat and Activity

### DIFF
--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -16,23 +16,40 @@ struct ContentView: View {
     @State private var unreadBoundary: Int64 = 0
 
     var body: some View {
-        NavigationSplitView {
-            sidebar
-                .navigationSplitViewColumnWidth(min: 150, ideal: 180)
-        } content: {
-            listColumn
-                .navigationSplitViewColumnWidth(min: 320, ideal: 420)
-        } detail: {
-            detail
-                .frame(minWidth: 380)
-        }
-        .navigationTitle("Tasks")
-        .navigationSubtitle(subtitle)
-        .toolbar { toolbarContent }
-        .onChange(of: section) { _, next in
-            if next == .activity {
-                unreadBoundary = model.lastSeenSeq
-                model.markActivityRead()
+        split
+            .navigationTitle("Tasks")
+            .navigationSubtitle(subtitle)
+            .toolbar { toolbarContent }
+            .onChange(of: section) { _, next in
+                if next == .activity {
+                    unreadBoundary = model.lastSeenSeq
+                    model.markActivityRead()
+                }
+            }
+    }
+
+    /// Tasks and Queue are list + detail; Activity and Chat are single
+    /// surfaces and get the full width — no dead detail pane.
+    @ViewBuilder
+    private var split: some View {
+        if section == .activity || section == .chat {
+            NavigationSplitView {
+                sidebar
+                    .navigationSplitViewColumnWidth(min: 150, ideal: 180)
+            } detail: {
+                sectionList
+                    .frame(minWidth: 500)
+            }
+        } else {
+            NavigationSplitView {
+                sidebar
+                    .navigationSplitViewColumnWidth(min: 150, ideal: 180)
+            } content: {
+                listColumn
+                    .navigationSplitViewColumnWidth(min: 320, ideal: 420)
+            } detail: {
+                detail
+                    .frame(minWidth: 380)
             }
         }
     }
@@ -216,10 +233,9 @@ struct ContentView: View {
             }
         case .queue, nil:
             queueDetail
-        case .activity:
-            noSelection("The feed is the whole story")
-        case .chat:
-            noSelection("")
+        case .activity, .chat:
+            // Unreachable — these sections use the two-column layout.
+            EmptyView()
         }
     }
 
@@ -538,6 +554,10 @@ struct ChatView: View {
                         }
                     }
                     .padding(12)
+                    // Full-width section, readable column: bubbles cap out
+                    // instead of stretching across a wide window.
+                    .frame(maxWidth: 720)
+                    .frame(maxWidth: .infinity)
                 }
                 .onChange(of: model.chat.last?.seq) {
                     if let last = model.chat.last?.seq {
@@ -559,6 +579,8 @@ struct ChatView: View {
                 .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
             .padding(10)
+            .frame(maxWidth: 720)
+            .frame(maxWidth: .infinity)
         }
         .navigationTitle("Chat")
     }
@@ -587,8 +609,7 @@ struct ChatBubble: View {
         HStack {
             if message.role == .user { Spacer(minLength: 60) }
             VStack(alignment: .leading, spacing: 2) {
-                Text(message.content)
-                    .textSelection(.enabled)
+                bubbleContent
                     .padding(.horizontal, 10)
                     .padding(.vertical, 7)
                     .background(
@@ -603,6 +624,18 @@ struct ChatBubble: View {
                     .padding(.horizontal, 4)
             }
             if message.role != .user { Spacer(minLength: 60) }
+        }
+    }
+
+    /// Assistant replies carry tables, code, and lists — render them.
+    /// User messages stay plain text: short, and styled white-on-accent.
+    @ViewBuilder
+    private var bubbleContent: some View {
+        if message.role == .user {
+            Text(message.content)
+                .textSelection(.enabled)
+        } else {
+            MarkdownView(text: message.content)
         }
     }
 }

--- a/app/Tasks/DetailViews.swift
+++ b/app/Tasks/DetailViews.swift
@@ -39,7 +39,7 @@ struct TaskDetailView: View {
 
                 Divider()
 
-                MarkdownBody(text: task.body)
+                MarkdownView(text: task.body)
             }
             .padding(16)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -99,7 +99,7 @@ struct SpecDetailView: View {
 
                 Divider()
 
-                MarkdownBody(text: spec.content)
+                MarkdownView(text: spec.content)
 
                 if entry != nil {
                     Divider()
@@ -324,26 +324,5 @@ struct Callout: View {
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(color.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
-    }
-}
-
-/// Renders GitHub-flavored markdown-ish text. Inline styles only, newlines
-/// preserved — good enough until a real markdown view earns its place.
-struct MarkdownBody: View {
-    let text: String
-
-    var body: some View {
-        if let attributed = try? AttributedString(
-            markdown: text,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace))
-        {
-            Text(attributed)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } else {
-            Text(text)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
     }
 }

--- a/app/Tasks/Markdown.swift
+++ b/app/Tasks/Markdown.swift
@@ -1,0 +1,277 @@
+import SwiftUI
+
+/// Dependency-free block-level markdown renderer. `AttributedString`'s
+/// markdown init only handles inline styling, which left the orchestrator's
+/// tables, code fences, and headings rendering as raw text — this covers the
+/// block shapes GitHub-flavored markdown actually produces in this app
+/// (issue bodies, spec content, orchestrator replies). Inline styling within
+/// blocks still goes through `AttributedString`.
+struct MarkdownView: View {
+    let text: String
+
+    var body: some View {
+        let blocks = MarkdownParser.parse(text)
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                BlockView(block: block)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .textSelection(.enabled)
+    }
+}
+
+enum MarkdownBlock {
+    case heading(level: Int, text: String)
+    case paragraph(String)
+    case code(String)
+    case list(items: [MarkdownListItem])
+    case table(header: [String], rows: [[String]])
+    case quote(String)
+    case rule
+}
+
+struct MarkdownListItem {
+    /// Nesting depth from leading indentation.
+    let indent: Int
+    /// The source marker: "•" for bullets, "3." for ordered items.
+    let marker: String
+    let text: String
+}
+
+private struct BlockView: View {
+    let block: MarkdownBlock
+
+    var body: some View {
+        switch block {
+        case .heading(let level, let text):
+            inline(text)
+                .font(headingFont(level))
+                .padding(.top, level <= 2 ? 4 : 2)
+        case .paragraph(let text):
+            inline(text)
+        case .code(let code):
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(code)
+                    .font(.callout.monospaced())
+                    .padding(8)
+            }
+            .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
+        case .list(let items):
+            VStack(alignment: .leading, spacing: 3) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text(item.marker)
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                        inline(item.text)
+                    }
+                    .padding(.leading, CGFloat(item.indent) * 16)
+                }
+            }
+        case .table(let header, let rows):
+            ScrollView(.horizontal, showsIndicators: false) {
+                Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 14, verticalSpacing: 5) {
+                    GridRow {
+                        ForEach(Array(header.enumerated()), id: \.offset) { _, cell in
+                            inline(cell).bold()
+                        }
+                    }
+                    Divider()
+                    ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                        GridRow {
+                            ForEach(Array(row.enumerated()), id: \.offset) { _, cell in
+                                inline(cell)
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+        case .quote(let text):
+            HStack(alignment: .top, spacing: 8) {
+                RoundedRectangle(cornerRadius: 1.5)
+                    .fill(.tertiary)
+                    .frame(width: 3)
+                inline(text)
+                    .foregroundStyle(.secondary)
+            }
+            .fixedSize(horizontal: false, vertical: true)
+        case .rule:
+            Divider()
+        }
+    }
+
+    private func headingFont(_ level: Int) -> Font {
+        switch level {
+        case 1: .title2.weight(.semibold)
+        case 2: .title3.weight(.semibold)
+        case 3: .headline
+        default: .subheadline.weight(.semibold)
+        }
+    }
+
+    private func inline(_ text: String) -> Text {
+        if let attributed = try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace))
+        {
+            Text(attributed)
+        } else {
+            Text(text)
+        }
+    }
+}
+
+enum MarkdownParser {
+    static func parse(_ text: String) -> [MarkdownBlock] {
+        let lines = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .components(separatedBy: "\n")
+        var blocks: [MarkdownBlock] = []
+        var paragraph: [String] = []
+
+        func flushParagraph() {
+            if !paragraph.isEmpty {
+                blocks.append(.paragraph(paragraph.joined(separator: "\n")))
+                paragraph = []
+            }
+        }
+
+        var i = 0
+        while i < lines.count {
+            let line = lines[i]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("```") {
+                flushParagraph()
+                var code: [String] = []
+                i += 1
+                while i < lines.count,
+                    !lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("```")
+                {
+                    code.append(lines[i])
+                    i += 1
+                }
+                i += 1  // closing fence (or EOF)
+                blocks.append(.code(code.joined(separator: "\n")))
+                continue
+            }
+            if trimmed.isEmpty {
+                flushParagraph()
+                i += 1
+                continue
+            }
+            if let (level, rest) = heading(trimmed) {
+                flushParagraph()
+                blocks.append(.heading(level: level, text: rest))
+                i += 1
+                continue
+            }
+            if isRule(trimmed) {
+                flushParagraph()
+                blocks.append(.rule)
+                i += 1
+                continue
+            }
+            if trimmed.hasPrefix("|"), i + 1 < lines.count,
+                isTableSeparator(lines[i + 1].trimmingCharacters(in: .whitespaces))
+            {
+                flushParagraph()
+                let header = cells(of: trimmed)
+                var rows: [[String]] = []
+                i += 2
+                while i < lines.count {
+                    let rowLine = lines[i].trimmingCharacters(in: .whitespaces)
+                    guard rowLine.hasPrefix("|") else { break }
+                    rows.append(cells(of: rowLine))
+                    i += 1
+                }
+                // Ragged rows render as empty cells rather than crashing Grid.
+                let width = ([header] + rows).map(\.count).max() ?? 0
+                let padded = rows.map { $0 + Array(repeating: "", count: width - $0.count) }
+                blocks.append(
+                    .table(
+                        header: header + Array(repeating: "", count: width - header.count),
+                        rows: padded))
+                continue
+            }
+            if listItem(line) != nil {
+                flushParagraph()
+                var items: [MarkdownListItem] = []
+                while i < lines.count, let item = listItem(lines[i]) {
+                    items.append(item)
+                    i += 1
+                }
+                blocks.append(.list(items: items))
+                continue
+            }
+            if trimmed.hasPrefix(">") {
+                flushParagraph()
+                var quoted: [String] = []
+                while i < lines.count {
+                    let q = lines[i].trimmingCharacters(in: .whitespaces)
+                    guard q.hasPrefix(">") else { break }
+                    quoted.append(String(q.dropFirst()).trimmingCharacters(in: .whitespaces))
+                    i += 1
+                }
+                blocks.append(.quote(quoted.joined(separator: "\n")))
+                continue
+            }
+            paragraph.append(line)
+            i += 1
+        }
+        flushParagraph()
+        return blocks
+    }
+
+    private static func heading(_ line: String) -> (Int, String)? {
+        let hashes = line.prefix(while: { $0 == "#" })
+        guard (1...6).contains(hashes.count) else { return nil }
+        let rest = line.dropFirst(hashes.count)
+        guard rest.first == " " else { return nil }
+        return (hashes.count, rest.trimmingCharacters(in: .whitespaces))
+    }
+
+    private static func isRule(_ line: String) -> Bool {
+        line.count >= 3 && (Set(line) == ["-"] || Set(line) == ["*"] || Set(line) == ["_"])
+    }
+
+    private static func isTableSeparator(_ line: String) -> Bool {
+        guard line.hasPrefix("|") || line.contains("-") else { return false }
+        let allowed = Set("|-: \t")
+        return line.contains("-") && line.allSatisfy { allowed.contains($0) }
+    }
+
+    private static func cells(of row: String) -> [String] {
+        var r = row
+        if r.hasPrefix("|") { r.removeFirst() }
+        if r.hasSuffix("|") { r.removeLast() }
+        return r.components(separatedBy: "|")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    private static func listItem(_ line: String) -> MarkdownListItem? {
+        let leading = line.prefix(while: { $0 == " " }).count
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        for bullet in ["- ", "* ", "+ "] {
+            if trimmed.hasPrefix(bullet) {
+                return MarkdownListItem(
+                    indent: leading / 2,
+                    marker: "•",
+                    text: String(trimmed.dropFirst(bullet.count)))
+            }
+        }
+        let digits = trimmed.prefix(while: \.isNumber)
+        if !digits.isEmpty {
+            let rest = trimmed.dropFirst(digits.count)
+            if rest.hasPrefix(". ") || rest.hasPrefix(") ") {
+                return MarkdownListItem(
+                    indent: leading / 2,
+                    marker: "\(digits).",
+                    text: String(rest.dropFirst(2)))
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Chat replies and detail bodies rendered tables, code fences, and
headings as raw text (AttributedString's markdown init is inline-only).
New dependency-free MarkdownView parses the block shapes this app
actually sees — headings, fenced code, lists (nested/ordered), pipe
tables, quotes, rules — and renders inline styling per block through
AttributedString. Used by assistant chat bubbles, task bodies, and spec
content.

Chat and Activity are single surfaces: they now use a two-column
layout with the full window width instead of parking a dead detail
pane. Chat content caps at a readable 720pt column.
