### PR TITLE
Orchestrator streaming: live deltas + tool calls over /orchestrator/stream

### DIFF
--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -36,6 +36,15 @@ final class AppModel {
     var connectionError: String?
     var lastRefreshed: Date?
 
+    /// Live view of the in-flight orchestrator tick, from
+    /// `/orchestrator/stream`. `liveReply` is the assistant text generated so
+    /// far (reset on each tool call — pre-tool text is working narration, and
+    /// the segment after the last tool call is the reply that persists);
+    /// `liveActivity` is the latest tool-call label. Both are ephemeral and
+    /// cleared once the durable message lands in `chat`.
+    var liveReply = ""
+    var liveActivity: String?
+
     // Non-private: session-detail views borrow it for transcript tailing.
     let client = TasksClient()
     private var started = false
@@ -169,6 +178,7 @@ final class AppModel {
     func start() async {
         guard !started else { return }
         started = true
+        Task { await orchestratorFeedLoop() }
         while !Task.isCancelled {
             do {
                 for try await _ in client.eventStream() {
@@ -181,6 +191,38 @@ final class AppModel {
             } catch {
                 connectionError = error.localizedDescription
             }
+            try? await Task.sleep(for: .seconds(3))
+        }
+    }
+
+    /// Tail `/orchestrator/stream` forever, mirroring the event loop's
+    /// reconnect policy. A dropped connection just clears the live view —
+    /// the durable reply still arrives through the ordinary refresh.
+    private func orchestratorFeedLoop() async {
+        while !Task.isCancelled {
+            do {
+                for try await frame in client.orchestratorFeed() {
+                    switch frame.kind {
+                    case "delta":
+                        liveReply += frame.text ?? ""
+                    case "tool":
+                        liveActivity = frame.label
+                        liveReply = ""
+                    case "done":
+                        // Keep the reply text visible; the refresh replaces
+                        // it with the persisted message (no flash).
+                        liveActivity = nil
+                    default:
+                        break
+                    }
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                // Connection errors surface via the event loop's banner.
+            }
+            liveReply = ""
+            liveActivity = nil
             try? await Task.sleep(for: .seconds(3))
         }
     }
@@ -213,7 +255,14 @@ final class AppModel {
         apply(await sessions) { self.sessions = $0 }
         apply(await specs) { self.specs = $0 }
         apply(await builds) { self.builds = $0 }
-        apply(await chat) { self.chat = $0 }
+        apply(await chat) {
+            self.chat = $0
+            // The durable reply has landed — drop the live-tick preview.
+            if $0.last?.role == .assistant {
+                self.liveReply = ""
+                self.liveActivity = nil
+            }
+        }
         apply(await specQueue) { self.specQueue = $0 }
         apply(await mode) { self.mode = $0 }
         apply(await events) { self.events = $0.sorted { $0.seq > $1.seq } }

--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -543,14 +543,8 @@ struct ChatView: View {
                                 .id(message.seq)
                         }
                         if awaitingReply {
-                            HStack(spacing: 6) {
-                                ProgressView().controlSize(.small)
-                                Text("Orchestrator is thinking…")
-                                    .font(.callout)
-                                    .foregroundStyle(.secondary)
-                            }
-                            .padding(.horizontal, 4)
-                            .id(Int64.max)
+                            liveTick
+                                .id(Int64.max)
                         }
                     }
                     .padding(12)
@@ -562,6 +556,11 @@ struct ChatView: View {
                 .onChange(of: model.chat.last?.seq) {
                     if let last = model.chat.last?.seq {
                         withAnimation { proxy.scrollTo(last, anchor: .bottom) }
+                    }
+                }
+                .onChange(of: model.liveReply) {
+                    if awaitingReply {
+                        proxy.scrollTo(Int64.max, anchor: .bottom)
                     }
                 }
             }
@@ -588,6 +587,33 @@ struct ChatView: View {
     /// The last turn is the human's: a reply is on its way.
     private var awaitingReply: Bool {
         model.chat.last?.role == .user
+    }
+
+    /// The in-flight tick, live: the reply streaming into a bubble as it's
+    /// generated, with the agent's current tool call (or "thinking") below.
+    private var liveTick: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if !model.liveReply.isEmpty {
+                HStack {
+                    MarkdownView(text: model.liveReply)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 7)
+                        .background(
+                            .quaternary.opacity(0.6),
+                            in: RoundedRectangle(cornerRadius: 10))
+                    Spacer(minLength: 60)
+                }
+            }
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text(model.liveActivity ?? "Orchestrator is thinking…")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .padding(.horizontal, 4)
+        }
     }
 
     private func send() {

--- a/app/Tasks/Models.swift
+++ b/app/Tasks/Models.swift
@@ -417,6 +417,17 @@ struct ChatMessage: Decodable, Identifiable, Hashable {
     var id: Int64 { seq }
 }
 
+/// One frame of `/orchestrator/stream` — the live view of an in-flight tick.
+/// Loose by design: unknown kinds are skipped, and nothing here is durable
+/// (the finished message arrives via `/orchestrator/messages`).
+struct OrchestratorFeedFrame: Decodable, Sendable {
+    let kind: String
+    /// Present when kind == "delta": a chunk of assistant text.
+    let text: String?
+    /// Present when kind == "tool": a one-line tool-call label.
+    let label: String?
+}
+
 enum ChatRole: WireEnum {
     case user, assistant
     case unknown(String)

--- a/app/Tasks/TasksClient.swift
+++ b/app/Tasks/TasksClient.swift
@@ -181,6 +181,33 @@ struct TasksClient: Sendable {
         return try await post("orchestrator/messages", body: Body(content: content))
     }
 
+    /// SSE feed of the in-flight orchestrator tick: text deltas, tool-call
+    /// labels, and `done`. Ephemeral — no backfill; a (re)connect only sees
+    /// what happens next, and the durable reply always arrives via
+    /// `orchestratorMessages`. Finishes when the server closes the
+    /// connection; the caller owns reconnect policy.
+    func orchestratorFeed() -> AsyncThrowingStream<OrchestratorFeedFrame, Error> {
+        let url = baseURL.appending(path: "orchestrator/stream")
+        return AsyncThrowingStream { continuation in
+            let reader = Task {
+                do {
+                    let (bytes, response) = try await URLSession.shared.bytes(from: url)
+                    try Self.checkOK(response)
+                    let decoder = Self.makeDecoder()
+                    for try await raw in bytes.lines where raw.hasPrefix("data: ") {
+                        let payload = Data(raw.dropFirst("data: ".count).utf8)
+                        continuation.yield(
+                            try decoder.decode(OrchestratorFeedFrame.self, from: payload))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in reader.cancel() }
+        }
+    }
+
     private func postEmpty<T: Decodable>(_ path: String) async throws -> T {
         var request = URLRequest(url: baseURL.appending(path: path))
         request.httpMethod = "POST"

--- a/crates/tasks/src/models.rs
+++ b/crates/tasks/src/models.rs
@@ -494,3 +494,18 @@ impl ChatRole {
         }
     }
 }
+
+/// One moment of an in-flight orchestrator tick, streamed over
+/// `GET /orchestrator/stream`. Ephemeral by design: nothing here is
+/// persisted — the durable record is the finished message in
+/// `orchestrator_messages` (and Claude Code's own session transcript).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum OrchestratorFeedEvent {
+    /// A chunk of assistant text, in generation order.
+    Delta { text: String },
+    /// The agent invoked a tool (e.g. a curl against this API).
+    Tool { label: String },
+    /// The tick finished; fetch `/orchestrator/messages` for the reply.
+    Done,
+}

--- a/crates/tasks/src/orchestrator.rs
+++ b/crates/tasks/src/orchestrator.rs
@@ -21,11 +21,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use thiserror::Error;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::models::ChatRole;
+use crate::models::{ChatRole, OrchestratorFeedEvent};
 use crate::store::{Store, StoreError};
 
 #[derive(Debug, Error)]
@@ -101,6 +101,11 @@ impl Orchestrator {
         self.store
             .append_orchestrator_message(ChatRole::Assistant, content)
             .await?;
+        // The durable message exists now — tell live-feed subscribers the
+        // in-flight view is over (after the append, so a client reacting to
+        // `done` finds the message already fetchable).
+        self.store
+            .publish_orchestrator_feed(OrchestratorFeedEvent::Done);
         Ok(true)
     }
 
@@ -136,6 +141,11 @@ impl Orchestrator {
         Ok(reply)
     }
 
+    /// Run the agent, streaming its stdout as it arrives. stream-json lines
+    /// become live-feed events (text deltas, tool-call labels) and the
+    /// `result` record's text becomes the reply; anything that isn't
+    /// stream-json is collected raw and returned whole, so plain-text agents
+    /// (and test stubs) keep working — they just don't stream.
     async fn invoke(&self, extra_args: &[&str], prompt: &str) -> Result<String, OrchestratorError> {
         let mut parts = self.config.command.split_whitespace();
         let prog = parts.next().unwrap_or("claude").to_string();
@@ -152,34 +162,144 @@ impl Orchestrator {
             // The API is the orchestrator's only pair of hands. No direct
             // GitHub writes, so no token.
             .env_remove("GITHUB_TOKEN")
+            // A timeout drops the read future below, which drops the child —
+            // this makes that drop kill the process instead of leaking it.
+            .kill_on_drop(true)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
         let mut child = cmd.spawn().map_err(OrchestratorError::Spawn)?;
         let mut stdin = child.stdin.take().expect("piped stdin");
+        let stdout = child.stdout.take().expect("piped stdout");
+        let stderr = child.stderr.take().expect("piped stderr");
+
         let prompt_owned = prompt.to_string();
         tokio::spawn(async move {
             let _ = stdin.write_all(prompt_owned.as_bytes()).await;
             drop(stdin);
         });
+        // Drain stderr concurrently so a chatty agent can't fill the pipe
+        // and deadlock against our stdout read.
+        let stderr_task = tokio::spawn(async move {
+            let mut buf = String::new();
+            let mut stderr = stderr;
+            let _ = stderr.read_to_string(&mut buf).await;
+            buf
+        });
+
+        let read = async {
+            let mut lines = BufReader::new(stdout).lines();
+            let mut raw = String::new();
+            let mut result_text: Option<String> = None;
+            while let Some(line) = lines.next_line().await.map_err(OrchestratorError::Spawn)? {
+                match parse_stream_line(&line) {
+                    StreamLine::Delta(text) => self
+                        .store
+                        .publish_orchestrator_feed(OrchestratorFeedEvent::Delta { text }),
+                    StreamLine::Tools(labels) => {
+                        for label in labels {
+                            self.store
+                                .publish_orchestrator_feed(OrchestratorFeedEvent::Tool { label });
+                        }
+                    }
+                    StreamLine::Result(text) => result_text = Some(text),
+                    StreamLine::Other => {}
+                    StreamLine::NotStreamJson => {
+                        raw.push_str(&line);
+                        raw.push('\n');
+                    }
+                }
+            }
+            let status = child.wait().await.map_err(OrchestratorError::Spawn)?;
+            Ok::<_, OrchestratorError>((status, result_text, raw))
+        };
 
         let secs = self.config.timeout.as_secs();
-        let output = tokio::time::timeout(self.config.timeout, child.wait_with_output())
+        let (status, result_text, raw) = tokio::time::timeout(self.config.timeout, read)
             .await
-            .map_err(|_| OrchestratorError::Timeout { secs })?
-            .map_err(OrchestratorError::Spawn)?;
+            .map_err(|_| OrchestratorError::Timeout { secs })??;
 
-        if !output.status.success() {
+        if !status.success() {
+            let stderr = stderr_task.await.unwrap_or_default();
             return Err(OrchestratorError::AgentFailed {
-                status: output.status,
-                stderr: String::from_utf8_lossy(&output.stderr)
-                    .chars()
-                    .take(2000)
-                    .collect(),
+                status,
+                stderr: stderr.chars().take(2000).collect(),
             });
         }
-        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        Ok(result_text.unwrap_or(raw))
+    }
+}
+
+/// What one line of agent stdout means for the live feed.
+enum StreamLine {
+    /// Assistant text as it's generated (`--include-partial-messages`).
+    Delta(String),
+    /// Tool invocations from a completed assistant turn.
+    Tools(Vec<String>),
+    /// The final `result` record's reply text.
+    Result(String),
+    /// A stream-json record with nothing for us (init, thinking, tool results).
+    Other,
+    /// Not stream-json at all — a plain-text agent's output.
+    NotStreamJson,
+}
+
+fn parse_stream_line(line: &str) -> StreamLine {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+        return StreamLine::NotStreamJson;
+    };
+    match v.get("type").and_then(|t| t.as_str()) {
+        Some("stream_event") => match v.pointer("/event/delta/text").and_then(|t| t.as_str()) {
+            Some(text) => StreamLine::Delta(text.to_string()),
+            None => StreamLine::Other,
+        },
+        Some("assistant") => {
+            let labels: Vec<String> = v
+                .pointer("/message/content")
+                .and_then(|c| c.as_array())
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter(|i| i.get("type").and_then(|t| t.as_str()) == Some("tool_use"))
+                        .map(tool_label)
+                        .collect()
+                })
+                .unwrap_or_default();
+            if labels.is_empty() {
+                StreamLine::Other
+            } else {
+                StreamLine::Tools(labels)
+            }
+        }
+        Some("result") => match v.get("result").and_then(|r| r.as_str()) {
+            Some(text) => StreamLine::Result(text.to_string()),
+            None => StreamLine::Other,
+        },
+        Some(_) => StreamLine::Other,
+        // JSON, but not a stream record — treat like plain output.
+        None => StreamLine::NotStreamJson,
+    }
+}
+
+/// One-line human label for a tool call, e.g. `Bash: curl -s .../tasks`.
+fn tool_label(item: &serde_json::Value) -> String {
+    let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
+    let detail = item
+        .pointer("/input/command")
+        .and_then(|c| c.as_str())
+        .or_else(|| item.pointer("/input/description").and_then(|d| d.as_str()))
+        .unwrap_or("");
+    let label = if detail.is_empty() {
+        name.to_string()
+    } else {
+        format!("{name}: {detail}")
+    };
+    let one_line = label.split_whitespace().collect::<Vec<_>>().join(" ");
+    if one_line.chars().count() > 120 {
+        format!("{}…", one_line.chars().take(119).collect::<String>())
+    } else {
+        one_line
     }
 }
 

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -64,9 +64,12 @@ const DEFAULT_VM_POOL_SOCKET: &str = "/tmp/vm-pool.sock";
 const DEFAULT_BUILDER_TIMEOUT_SECS: u64 = 3600;
 /// Default agent command for orchestrator ticks. `--allowedTools` lets the
 /// headless run curl the tasks API without permission prompts — and nothing
-/// else beyond Claude Code's defaults.
-const DEFAULT_ORCHESTRATOR_CMD: &str =
-    "claude --print --output-format text --allowedTools Bash(curl:*)";
+/// else beyond Claude Code's defaults. stream-json (+ partial messages) is
+/// what feeds `/orchestrator/stream`: text deltas and tool calls surface live
+/// instead of one opaque multi-minute wait. `--verbose` is mandatory with
+/// `--print --output-format stream-json` (see images/scout/Dockerfile).
+const DEFAULT_ORCHESTRATOR_CMD: &str = "claude --print --output-format stream-json --verbose \
+     --include-partial-messages --allowedTools Bash(curl:*)";
 const DEFAULT_ORCHESTRATOR_TIMEOUT_SECS: u64 = 600;
 /// How often the orchestrator loop checks for unanswered user turns.
 const ORCHESTRATOR_TICK: Duration = Duration::from_secs(1);

--- a/crates/tasks/src/server.rs
+++ b/crates/tasks/src/server.rs
@@ -113,6 +113,7 @@ pub fn router(store: Arc<Store>) -> Router {
             "/orchestrator/messages",
             get(list_orchestrator_messages).post(send_orchestrator_message),
         )
+        .route("/orchestrator/stream", get(stream_orchestrator))
         .route("/mode", get(get_mode).post(set_mode))
         .route("/queue/reorder", post(reorder_queue))
         .route("/events", get(list_events))
@@ -415,6 +416,33 @@ async fn list_orchestrator_messages(
     Query(q): Query<MessagesQuery>,
 ) -> ApiResult<Json<Vec<OrchestratorMessage>>> {
     Ok(Json(store.orchestrator_messages_since(q.since).await?))
+}
+
+/// SSE feed of the in-flight orchestrator tick: `delta` chunks as the reply
+/// is generated, `tool` labels as the agent works, `done` when the durable
+/// message has landed in `/orchestrator/messages`. Ephemeral — there is no
+/// backfill, and a lagged or reconnecting client just resyncs by fetching
+/// the messages; nothing here is ever the source of truth.
+async fn stream_orchestrator(
+    State(store): State<Arc<Store>>,
+) -> Sse<impl Stream<Item = Result<SseEvent, Infallible>>> {
+    let stream = BroadcastStream::new(store.subscribe_orchestrator_feed()).filter_map(|result| {
+        let event = match result {
+            Ok(event) => event,
+            Err(err) => {
+                warn!(error = %err, "orchestrator feed subscriber lagged");
+                return None;
+            }
+        };
+        match SseEvent::default().json_data(&event) {
+            Ok(sse) => Some(Ok(sse)),
+            Err(err) => {
+                error!(error = %err, "serializing orchestrator feed event for sse");
+                None
+            }
+        }
+    });
+    Sse::new(stream).keep_alive(KeepAlive::new().interval(SSE_KEEPALIVE))
 }
 
 // --- mode ---

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -11,10 +11,10 @@ use tokio::sync::broadcast;
 use crate::events::{Event, EventPayload};
 use crate::github::GhIssue;
 use crate::models::{
-    Build, BuildId, BuildStatus, ChatRole, Complexity, GhState, Mode, OrchestratorMessage, Project,
-    ProjectId, ReviewedSpec, Session, SessionId, SessionStatus, SessionUsage, Spec, SpecId,
-    SpecQueueEntry, SpecQueueItem, SpecQueueStatus, Task, TaskId, TaskState, TranscriptLine,
-    TranscriptStream,
+    Build, BuildId, BuildStatus, ChatRole, Complexity, GhState, Mode, OrchestratorFeedEvent,
+    OrchestratorMessage, Project, ProjectId, ReviewedSpec, Session, SessionId, SessionStatus,
+    SessionUsage, Spec, SpecId, SpecQueueEntry, SpecQueueItem, SpecQueueStatus, Task, TaskId,
+    TaskState, TranscriptLine, TranscriptStream,
 };
 
 /// Result of upserting an external record into our domain.
@@ -45,6 +45,11 @@ const EVENT_BROADCAST_CAPACITY: usize = 1024;
 /// agent output is far higher-rate, and a session-detail view that lags briefly
 /// should resync rather than lose its place.
 const TRANSCRIPT_BROADCAST_CAPACITY: usize = 4096;
+
+/// Capacity of the orchestrator live-feed channel. Sized like the transcript
+/// one (token deltas are high-rate); a lagged subscriber just misses deltas —
+/// the durable message arrives via `orchestrator_messages` regardless.
+const ORCHESTRATOR_FEED_CAPACITY: usize = 4096;
 
 /// `exit_reason` written to sessions that were still `running` when the server
 /// came back up.
@@ -93,6 +98,7 @@ pub struct Store {
     pool: SqlitePool,
     event_tx: broadcast::Sender<Event>,
     transcript_tx: broadcast::Sender<TranscriptLine>,
+    orchestrator_feed_tx: broadcast::Sender<OrchestratorFeedEvent>,
 }
 
 impl Store {
@@ -107,10 +113,12 @@ impl Store {
         MIGRATOR.run(&pool).await?;
         let (event_tx, _) = broadcast::channel(EVENT_BROADCAST_CAPACITY);
         let (transcript_tx, _) = broadcast::channel(TRANSCRIPT_BROADCAST_CAPACITY);
+        let (orchestrator_feed_tx, _) = broadcast::channel(ORCHESTRATOR_FEED_CAPACITY);
         Ok(Self {
             pool,
             event_tx,
             transcript_tx,
+            orchestrator_feed_tx,
         })
     }
 
@@ -123,10 +131,12 @@ impl Store {
         MIGRATOR.run(&pool).await?;
         let (event_tx, _) = broadcast::channel(EVENT_BROADCAST_CAPACITY);
         let (transcript_tx, _) = broadcast::channel(TRANSCRIPT_BROADCAST_CAPACITY);
+        let (orchestrator_feed_tx, _) = broadcast::channel(ORCHESTRATOR_FEED_CAPACITY);
         Ok(Self {
             pool,
             event_tx,
             transcript_tx,
+            orchestrator_feed_tx,
         })
     }
 
@@ -1824,6 +1834,18 @@ impl Store {
             content: content.to_string(),
             created_at: now,
         })
+    }
+
+    /// Publish one moment of an in-flight tick to live-feed subscribers.
+    /// Fire-and-forget: no subscribers, no problem — nothing is persisted.
+    pub fn publish_orchestrator_feed(&self, event: OrchestratorFeedEvent) {
+        let _ = self.orchestrator_feed_tx.send(event);
+    }
+
+    /// Live feed of the in-flight orchestrator tick (`/orchestrator/stream`).
+    /// A lagged subscriber misses deltas, never the durable message.
+    pub fn subscribe_orchestrator_feed(&self) -> broadcast::Receiver<OrchestratorFeedEvent> {
+        self.orchestrator_feed_tx.subscribe()
     }
 
     /// Messages with `seq > since`, oldest first.

--- a/crates/tasks/tests/orchestrator.rs
+++ b/crates/tasks/tests/orchestrator.rs
@@ -111,6 +111,131 @@ async fn a_tick_answers_pending_turns_and_resumes_the_same_session() {
     assert!(!events.is_empty());
 }
 
+/// The streaming path: a stream-json agent's deltas and tool calls surface
+/// on the live feed in order, and the persisted reply is the `result`
+/// record's text — never raw JSON.
+#[tokio::test]
+async fn a_stream_json_agent_feeds_deltas_and_tools_and_lands_the_result() {
+    use tasks::models::OrchestratorFeedEvent as Feed;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let fixture = tmp.path().join("stream.jsonl");
+    tokio::fs::write(
+        &fixture,
+        concat!(
+            r#"{"type":"system","subtype":"init"}"#,
+            "\n",
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"Check"}}}"#,
+            "\n",
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"ing"}}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"curl -s http://127.0.0.1:4800/tasks"}}]}}"#,
+            "\n",
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"All good."}}}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success","result":"All good."}"#,
+            "\n",
+        ),
+    )
+    .await
+    .unwrap();
+
+    let stub = tmp.path().join("stream-stub.sh");
+    tokio::fs::write(
+        &stub,
+        format!(
+            "#!/bin/sh\ncat > /dev/null\ncat {}\n",
+            common::shell_escape(&fixture.display().to_string())
+        ),
+    )
+    .await
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut p = tokio::fs::metadata(&stub).await.unwrap().permissions();
+        p.set_mode(0o755);
+        tokio::fs::set_permissions(&stub, p).await.unwrap();
+    }
+
+    let store = Arc::new(Store::open_in_memory().await.unwrap());
+    // Subscribe before the tick so nothing published during it is missed.
+    let mut feed = store.subscribe_orchestrator_feed();
+    let orch = orchestrator(store.clone(), &stub, tmp.path());
+    store
+        .append_orchestrator_message(ChatRole::User, "status?")
+        .await
+        .unwrap();
+    assert!(orch.tick().await.unwrap());
+
+    let messages = store.orchestrator_messages_since(0).await.unwrap();
+    assert_eq!(
+        messages[1].content, "All good.",
+        "reply is the result record's text, not raw stream-json"
+    );
+
+    let mut got = Vec::new();
+    while let Ok(event) = feed.try_recv() {
+        got.push(event);
+    }
+    assert_eq!(
+        got,
+        vec![
+            Feed::Delta {
+                text: "Check".into()
+            },
+            Feed::Delta { text: "ing".into() },
+            Feed::Tool {
+                label: "Bash: curl -s http://127.0.0.1:4800/tasks".into()
+            },
+            Feed::Delta {
+                text: "All good.".into()
+            },
+            Feed::Done,
+        ]
+    );
+}
+
+#[tokio::test]
+async fn the_orchestrator_stream_endpoint_relays_the_feed() {
+    use tasks::models::OrchestratorFeedEvent as Feed;
+
+    let store = Arc::new(Store::open_in_memory().await.unwrap());
+    let app = tasks::server::router(store.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let mut resp = reqwest::Client::new()
+        .get(format!("{base}/orchestrator/stream"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    // Headers received means the handler ran, which means the subscription
+    // exists — publishing now cannot race it.
+    store.publish_orchestrator_feed(Feed::Delta { text: "hi".into() });
+    store.publish_orchestrator_feed(Feed::Tool {
+        label: "Bash: curl".into(),
+    });
+    store.publish_orchestrator_feed(Feed::Done);
+
+    let mut body = String::new();
+    while !body.contains(r#"{"kind":"done"}"#) {
+        let chunk = tokio::time::timeout(Duration::from_secs(5), resp.chunk())
+            .await
+            .expect("feed frame within 5s")
+            .unwrap()
+            .expect("stream still open");
+        body.push_str(&String::from_utf8_lossy(&chunk));
+    }
+    assert!(body.contains(r#"{"kind":"delta","text":"hi"}"#), "{body}");
+    assert!(
+        body.contains(r#"{"kind":"tool","label":"Bash: curl"}"#),
+        "{body}"
+    );
+}
+
 /// A failing agent must settle the tick (error becomes the assistant turn)
 /// rather than retrying a poison prompt forever.
 #[tokio::test]

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -79,6 +79,17 @@ the server only.
   /orchestrator/messages?since=N` returns turns with `seq > N`, oldest first:
   `{seq, role: "user"|"assistant", content, created_at}`. Render an
   "answering…" affordance while the newest turn is the user's.
+- `GET /orchestrator/stream` — SSE live view of the in-flight tick, one JSON
+  frame per `data:` line: `{"kind":"delta","text"}` (assistant text in
+  generation order), `{"kind":"tool","label"}` (a tool call, e.g.
+  `Bash: curl …`), `{"kind":"done"}` (the durable reply is now fetchable).
+  **Ephemeral**: no backfill, a (re)connect only sees what happens next, and
+  a lagged subscriber misses deltas — never the reply, which always lands in
+  `/orchestrator/messages`. Suggested rendering: accumulate deltas into a
+  growing bubble, reset the accumulator on each `tool` frame (pre-tool text
+  is working narration; the segment after the last tool call is the reply),
+  show the latest tool label as status, and swap in the persisted message
+  when it arrives. Skip unknown `kind`s.
 - `GET /builds` (newest first), `GET /builds/{id}` (`{..., spec_ids}`) —
   `branch`, `base_branch`, `base_sha`/`head_sha`, `pr_number`, `status`,
   `summary` (the PR body the agent wrote), `files_touched`, `exit_reason`.


### PR DESCRIPTION
A tick was one opaque multi-minute wait behind 'thinking…'. The
orchestrator now runs Claude Code with --output-format stream-json
--include-partial-messages (the typed output we're supposed to consume)
and relays it live: text deltas and tool-call labels go out over a new
ephemeral SSE endpoint, GET /orchestrator/stream, backed by an in-memory
broadcast channel — nothing new is persisted, the durable record stays
the finished message. Plain-text agents (and existing test stubs) still
work: non-stream-json stdout is collected raw as the reply.

The app tails the feed and renders the reply streaming into a bubble as
it's generated, with the agent's current tool call (e.g. 'Bash: curl
…/tasks') as live status under it.
