### PR TITLE
Makefile: 'make app' installs the mac app to ~/Applications, 'make run' relaunches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,24 @@ BUILDER_BIN := target/$(LINUX_TARGET)/release/builder-supervisor
 VM_SUPERVISOR_BIN := target/$(LINUX_TARGET)/release/supervisor
 
 .PHONY: check-toolchain scout-supervisor-linux builder-supervisor-linux \
-        vm-supervisor-linux image-base image-agent image-scout image-builder images
+        vm-supervisor-linux image-base image-agent image-scout image-builder images \
+        app run
+
+# Build the mac app and install it to ~/Applications, replacing any existing
+# copy. Uses xcodebuild's own answer for where the product landed, so this
+# shares DerivedData (and its build cache) with Xcode.
+app:
+	xcodebuild -project app/Tasks.xcodeproj -scheme Tasks -configuration Debug -quiet build
+	@built="$$(xcodebuild -project app/Tasks.xcodeproj -scheme Tasks -configuration Debug -showBuildSettings 2>/dev/null | awk '/ BUILT_PRODUCTS_DIR =/{print $$3; exit}')"; \
+	mkdir -p ~/Applications; \
+	rm -rf ~/Applications/Tasks.app; \
+	ditto "$$built/Tasks.app" ~/Applications/Tasks.app; \
+	echo "installed ~/Applications/Tasks.app"
+
+# Build, install, and (re)launch.
+run: app
+	@pkill -x Tasks 2>/dev/null || true
+	open ~/Applications/Tasks.app
 
 check-toolchain:
 	@which $(LINUX_TARGET)-gcc >/dev/null || { echo "missing cross linker: brew install messense/macos-cross-toolchains/aarch64-unknown-linux-gnu"; exit 1; }


### PR DESCRIPTION
Launching from DerivedData paths was the only way to run a fresh build.
'make app' builds with xcodebuild and dittos the product (located via
-showBuildSettings, so Xcode's DerivedData cache is shared) over
~/Applications/Tasks.app; 'make run' additionally kills and relaunches.
