### PR TITLE
App: full-width Tasks table with click-to-open inspector + markdown render cache

### DIFF
--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     @Environment(AppModel.self) private var model
     @State private var section: NavSection? = .queue
     @State private var selectedTask: TaskItem.ID?
+    @State private var showTaskInspector = false
     @State private var selectedQueueTask: TaskItem.ID?
     /// Events newer than this get the unread accent while Activity is open.
     /// Captured from `lastSeenSeq` when the section is entered, then the model
@@ -28,19 +29,13 @@ struct ContentView: View {
             }
     }
 
-    /// Tasks and Queue are list + detail; Activity and Chat are single
-    /// surfaces and get the full width — no dead detail pane.
+    /// Queue is list + detail (its detail is where review happens). Tasks,
+    /// Activity, and Chat are single full-width surfaces — Tasks opens its
+    /// detail as a click-to-open, Esc-to-close inspector instead of a
+    /// permanently reserved pane.
     @ViewBuilder
     private var split: some View {
-        if section == .activity || section == .chat {
-            NavigationSplitView {
-                sidebar
-                    .navigationSplitViewColumnWidth(min: 150, ideal: 180)
-            } detail: {
-                sectionList
-                    .frame(minWidth: 500)
-            }
-        } else {
+        if section == .queue || section == nil {
             NavigationSplitView {
                 sidebar
                     .navigationSplitViewColumnWidth(min: 150, ideal: 180)
@@ -50,6 +45,14 @@ struct ContentView: View {
             } detail: {
                 detail
                     .frame(minWidth: 380)
+            }
+        } else {
+            NavigationSplitView {
+                sidebar
+                    .navigationSplitViewColumnWidth(min: 150, ideal: 180)
+            } detail: {
+                sectionList
+                    .frame(minWidth: 500)
             }
         }
     }
@@ -126,6 +129,13 @@ struct ContentView: View {
         switch section {
         case .tasks:
             TasksTable(selection: $selectedTask)
+                .onChange(of: selectedTask) { _, selected in
+                    if selected != nil { showTaskInspector = true }
+                }
+                .inspector(isPresented: $showTaskInspector) {
+                    taskInspector
+                        .inspectorColumnWidth(min: 360, ideal: 460, max: 700)
+                }
         case .queue, nil:
             queueList
         case .activity:
@@ -133,6 +143,39 @@ struct ContentView: View {
         case .chat:
             ChatView()
         }
+    }
+
+    /// The click-to-open task detail. Esc (`.cancelAction`) and the X both
+    /// close it *and* clear the selection, so clicking any row — including
+    /// the same one — reopens it.
+    @ViewBuilder
+    private var taskInspector: some View {
+        if let id = selectedTask, let task = model.task(id) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Spacer()
+                    Button {
+                        closeTaskInspector()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .keyboardShortcut(.cancelAction)
+                    .help("Close (Esc)")
+                }
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+                TaskDetailView(task: task)
+            }
+        } else {
+            ContentUnavailableView("", systemImage: "sidebar.right")
+        }
+    }
+
+    private func closeTaskInspector() {
+        showTaskInspector = false
+        selectedTask = nil
     }
 
     /// The queue, grouped in attention order: verdicts you owe, work running
@@ -225,16 +268,10 @@ struct ContentView: View {
     @ViewBuilder
     private var detail: some View {
         switch section {
-        case .tasks:
-            if let id = selectedTask, let task = model.task(id) {
-                TaskDetailView(task: task)
-            } else {
-                noSelection("Select a task")
-            }
         case .queue, nil:
             queueDetail
-        case .activity, .chat:
-            // Unreachable — these sections use the two-column layout.
+        case .tasks, .activity, .chat:
+            // Unreachable — these sections use the full-width layout.
             EmptyView()
         }
     }

--- a/app/Tasks/Markdown.swift
+++ b/app/Tasks/Markdown.swift
@@ -10,7 +10,10 @@ struct MarkdownView: View {
     let text: String
 
     var body: some View {
-        let blocks = MarkdownParser.parse(text)
+        // Cached: SwiftUI re-evaluates body on every scroll frame of a lazy
+        // container (and on every streaming delta), and parsing — especially
+        // AttributedString's markdown init — is far too expensive for that.
+        let blocks = MarkdownCache.blocks(for: text)
         VStack(alignment: .leading, spacing: 8) {
             ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
                 BlockView(block: block)
@@ -18,6 +21,55 @@ struct MarkdownView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .textSelection(.enabled)
+    }
+}
+
+/// Memoizes the two expensive steps behind rendering: block parsing and
+/// inline `AttributedString(markdown:)`. Keyed by source text — chat
+/// messages, issue bodies, and specs are immutable once written, and the one
+/// mutating case (the streaming live reply) changes the key each delta, so a
+/// stale entry is never served. NSCache bounds memory; main-actor isolation
+/// satisfies strict concurrency (all callers are SwiftUI view bodies).
+@MainActor
+enum MarkdownCache {
+    private final class Box<T> {
+        let value: T
+        init(_ value: T) { self.value = value }
+    }
+
+    private static let parsed: NSCache<NSString, AnyObject> = {
+        let cache = NSCache<NSString, AnyObject>()
+        cache.countLimit = 512
+        return cache
+    }()
+    private static let inlined: NSCache<NSString, AnyObject> = {
+        let cache = NSCache<NSString, AnyObject>()
+        cache.countLimit = 4096
+        return cache
+    }()
+
+    static func blocks(for text: String) -> [MarkdownBlock] {
+        let key = text as NSString
+        if let hit = parsed.object(forKey: key) as? Box<[MarkdownBlock]> {
+            return hit.value
+        }
+        let blocks = MarkdownParser.parse(text)
+        parsed.setObject(Box(blocks), forKey: key)
+        return blocks
+    }
+
+    static func inline(_ text: String) -> AttributedString {
+        let key = text as NSString
+        if let hit = inlined.object(forKey: key) as? Box<AttributedString> {
+            return hit.value
+        }
+        let attributed =
+            (try? AttributedString(
+                markdown: text,
+                options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
+            ?? AttributedString(text)
+        inlined.setObject(Box(attributed), forKey: key)
+        return attributed
     }
 }
 
@@ -112,14 +164,7 @@ private struct BlockView: View {
     }
 
     private func inline(_ text: String) -> Text {
-        if let attributed = try? AttributedString(
-            markdown: text,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace))
-        {
-            Text(attributed)
-        } else {
-            Text(text)
-        }
+        Text(MarkdownCache.inline(text))
     }
 }
 


### PR DESCRIPTION
The Tasks table shared the window with a permanently reserved detail
pane that was empty until a row was selected — half the width for
nothing, truncated titles in the half that mattered. The table now gets
the full window; clicking a row opens the detail as a trailing
inspector, closed by an X or Esc (closing clears the selection so any
click, including the same row, reopens it).

Also fixes the Chat scrolling lockup: MarkdownView parsed blocks and ran
AttributedString(markdown:) inside body, which a lazy container
re-evaluates on every scroll frame — and streaming re-evaluated every
bubble per delta. Both steps now memoize through an NSCache keyed by
source text (immutable once written; the growing live reply changes its
key each delta, so nothing stale is ever served).
