### PR TITLE
App: About window with git-stamped version + kill the chat scroll lockup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,18 @@ VM_SUPERVISOR_BIN := target/$(LINUX_TARGET)/release/supervisor
         vm-supervisor-linux image-base image-agent image-scout image-builder images \
         app run
 
+# Version identity stamped into the app (shown in About Tasks): version is
+# 0.1.<commit count>, build is the short SHA, "-dirty" when uncommitted
+# changes were present. Answers "is what I'm running fresh?" at a glance.
+APP_VERSION := 0.1.$(shell git rev-list --count HEAD)
+APP_COMMIT := $(shell git rev-parse --short HEAD)$(shell git diff --quiet 2>/dev/null || echo "-dirty")
+
 # Build the mac app and install it to ~/Applications, replacing any existing
 # copy. Uses xcodebuild's own answer for where the product landed, so this
 # shares DerivedData (and its build cache) with Xcode.
 app:
-	xcodebuild -project app/Tasks.xcodeproj -scheme Tasks -configuration Debug -quiet build
+	xcodebuild -project app/Tasks.xcodeproj -scheme Tasks -configuration Debug -quiet \
+		MARKETING_VERSION=$(APP_VERSION) CURRENT_PROJECT_VERSION=$(APP_COMMIT) build
 	@built="$$(xcodebuild -project app/Tasks.xcodeproj -scheme Tasks -configuration Debug -showBuildSettings 2>/dev/null | awk '/ BUILT_PRODUCTS_DIR =/{print $$3; exit}')"; \
 	mkdir -p ~/Applications; \
 	rm -rf ~/Applications/Tasks.app; \

--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -566,7 +566,11 @@ struct ChatView: View {
         VStack(spacing: 0) {
             ScrollViewReader { proxy in
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 12) {
+                    // Non-lazy on purpose: a lazy container tears down and
+                    // rebuilds these rich markdown bubbles continuously
+                    // while scrolling. The conversation is bounded and the
+                    // parses are cached — build once, scroll compositing.
+                    VStack(alignment: .leading, spacing: 12) {
                         if model.chat.isEmpty {
                             ContentUnavailableView(
                                 "Talk to the orchestrator",

--- a/app/Tasks/Markdown.swift
+++ b/app/Tasks/Markdown.swift
@@ -20,7 +20,10 @@ struct MarkdownView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .textSelection(.enabled)
+        // Deliberately NOT .textSelection(.enabled) here: container-wide
+        // selection turns every table cell and list row into its own AppKit
+        // selectable-text host — hundreds per chat — which is what locked
+        // scrolling up. BlockView opts in per copy-worthy block instead.
     }
 }
 
@@ -102,10 +105,12 @@ private struct BlockView: View {
                 .padding(.top, level <= 2 ? 4 : 2)
         case .paragraph(let text):
             inline(text)
+                .textSelection(.enabled)
         case .code(let code):
             ScrollView(.horizontal, showsIndicators: false) {
                 Text(code)
                     .font(.callout.monospaced())
+                    .textSelection(.enabled)
                     .padding(8)
             }
             .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))

--- a/app/Tasks/TasksApp.swift
+++ b/app/Tasks/TasksApp.swift
@@ -1,5 +1,19 @@
 import SwiftUI
 
+/// Version identity, stamped by `make app`: MARKETING_VERSION becomes
+/// `0.1.<commit count>` and CURRENT_PROJECT_VERSION the short git SHA
+/// (`-dirty` when the tree had uncommitted changes). An Xcode-launched build
+/// shows the static project values instead — if About says `0.1 (1)`, you're
+/// not looking at a `make app` install.
+enum BuildInfo {
+    static var version: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "dev"
+    }
+    static var commit: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+    }
+}
+
 @main
 struct TasksApp: App {
     @State private var model = AppModel()
@@ -12,5 +26,20 @@ struct TasksApp: App {
                 .frame(minWidth: 480, minHeight: 360)
         }
         .defaultSize(width: 640, height: 720)
+        .commands {
+            CommandGroup(replacing: .appInfo) {
+                Button("About Tasks") {
+                    NSApplication.shared.orderFrontStandardAboutPanel(options: [
+                        .credits: NSAttributedString(
+                            string: "commit \(BuildInfo.commit)",
+                            attributes: [
+                                .font: NSFont.monospacedSystemFont(
+                                    ofSize: NSFont.smallSystemFontSize, weight: .regular),
+                                .foregroundColor: NSColor.secondaryLabelColor,
+                            ])
+                    ])
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
'make app' now stamps MARKETING_VERSION=0.1.<commit count> and
CURRENT_PROJECT_VERSION=<short sha>(-dirty) into the build; About Tasks
shows both plus a monospaced commit line, so 'is this fresh?' has an
answer. Xcode-launched builds show the static 0.1 (1) — itself a signal.

The remaining scroll lockup had two causes the render cache didn't
touch: container-wide .textSelection(.enabled) in MarkdownView made
every table cell and list row its own AppKit selectable-text host
(hundreds per chat), and the LazyVStack tore down and rebuilt those
bubbles continuously while scrolling. Selection is now scoped to
paragraphs and code blocks, and the bounded conversation renders in a
plain VStack — built once, scrolling is compositing.
