### PR TITLE
Orchestrator capabilities become configuration: ORCHESTRATOR_WORKDIR + per-turn system prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,6 @@ env / `.env`:
 | `GITHUB_TOKEN` | — | required for polling; also used for clones |
 | `GITHUB_API_URL` | api.github.com | GraphQL endpoint override |
 | `GITHUB_CLONE_URL_BASE` | `https://github.com` | clone URL prefix |
+| `ORCHESTRATOR_CMD` | `claude --print … --allowedTools Bash(curl:*)` | orchestrator agent command; its permission flags decide what the orchestrator may do |
+| `ORCHESTRATOR_WORKDIR` | `<data dir>/orchestrator` | orchestrator cwd; point at the repo checkout (with `--dangerously-skip-permissions` in the cmd) to run it as a full dev agent |
+| `ORCHESTRATOR_TIMEOUT_SECS` | 600 | wall-clock budget per orchestrator tick |

--- a/crates/tasks/src/orchestrator.rs
+++ b/crates/tasks/src/orchestrator.rs
@@ -10,10 +10,16 @@
 //! the loop answers whatever user turns arrived since the last assistant
 //! turn, so a crash mid-reply just means the next pass answers again.
 //!
-//! The orchestrator acts through the tasks HTTP API (curl against
-//! `127.0.0.1:<port>`), which keeps every write inside the server's rules —
-//! notably "GitHub writes go through the server". Its child environment has
-//! `GITHUB_TOKEN` explicitly removed: the API is its only pair of hands.
+//! What the orchestrator may *do* is decided by configuration, not code:
+//! `ORCHESTRATOR_CMD` carries Claude Code's permission flags and
+//! `ORCHESTRATOR_WORKDIR` its working directory. Pointed at the real repo
+//! checkout with `--dangerously-skip-permissions`, it is a full development
+//! agent; with the defaults it is an API-only controller. Either way,
+//! *pipeline* writes go through the tasks HTTP API (curl against
+//! `127.0.0.1:<port>`) so state changes stay inside the server's rules, and
+//! the server's own `GITHUB_TOKEN` is stripped from the child env — when the
+//! agent talks to GitHub it authenticates as itself (gh's keychain auth),
+//! not with the server's credential.
 
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -112,26 +118,34 @@ impl Orchestrator {
     /// Run one headless Claude Code turn against the persistent session,
     /// creating the session on first use and healing a lost one by starting
     /// over with a fresh id (context is lost, the chat projection is not).
+    /// The standing prompt rides along on every turn — resume included — so
+    /// prompt updates reach a long-lived session without resetting it.
     async fn run_agent(&self, prompt: &str) -> Result<String, OrchestratorError> {
+        let system = system_prompt(self.config.api_port);
         match self.store.orchestrator_cc_session().await? {
-            None => self.run_fresh(prompt).await,
-            Some(session) => match self.invoke(&["--resume", &session], prompt).await {
+            None => self.run_fresh(&system, prompt).await,
+            Some(session) => match self
+                .invoke(
+                    &["--resume", &session, "--append-system-prompt", &system],
+                    prompt,
+                )
+                .await
+            {
                 Ok(reply) => Ok(reply),
                 Err(e @ OrchestratorError::AgentFailed { .. }) => {
                     warn!(error = %e, "resume failed; starting a fresh orchestrator session");
-                    self.run_fresh(prompt).await
+                    self.run_fresh(&system, prompt).await
                 }
                 Err(e) => Err(e),
             },
         }
     }
 
-    async fn run_fresh(&self, prompt: &str) -> Result<String, OrchestratorError> {
+    async fn run_fresh(&self, system: &str, prompt: &str) -> Result<String, OrchestratorError> {
         let session = Uuid::new_v4().to_string();
-        let system = system_prompt(self.config.api_port);
         let reply = self
             .invoke(
-                &["--session-id", &session, "--append-system-prompt", &system],
+                &["--session-id", &session, "--append-system-prompt", system],
                 prompt,
             )
             .await?;
@@ -159,8 +173,8 @@ impl Orchestrator {
         cmd.args(&base_args)
             .args(extra_args)
             .current_dir(&self.config.workdir)
-            // The API is the orchestrator's only pair of hands. No direct
-            // GitHub writes, so no token.
+            // The server's token stays the server's. When the agent talks to
+            // GitHub it authenticates as itself (gh keychain auth).
             .env_remove("GITHUB_TOKEN")
             // A timeout drops the read future below, which drops the child —
             // this makes that drop kill the process instead of leaking it.
@@ -304,17 +318,23 @@ fn tool_label(item: &serde_json::Value) -> String {
 }
 
 /// The orchestrator's standing instructions. Appended (not replacing) so
-/// Claude Code's own tool discipline stays intact.
+/// Claude Code's own tool discipline stays intact, and passed on every turn
+/// (resume included) so edits here reach a long-lived session.
 fn system_prompt(port: u16) -> String {
     format!(
-        "You are the Orchestrator for a Tasks server — a human-in-the-loop \
-         platform that turns GitHub issues into specs (via Scout agents) and \
-         approved specs into PRs (via Builder agents).\n\n\
-         You are a persistent conversation the human returns to. Answer \
-         questions about pipeline state, and take pipeline actions when — and \
-         only when — the human asks for them. Never invent work for yourself.\n\n\
-         Your only tool for acting is the tasks HTTP API at \
-         http://127.0.0.1:{port} (use curl). Endpoints:\n\
+        "You are the Orchestrator for Tasks — a human-in-the-loop platform \
+         that turns GitHub issues into specs (via Scout agents) and approved \
+         specs into PRs (via Builder agents). You are a persistent \
+         conversation the human returns to. Answer questions, and act when — \
+         and only when — the human asks. Never invent work for yourself.\n\n\
+         Your working directory is the project checkout itself. Within your \
+         permission settings you may read and edit code, run builds and \
+         tests, and use `gh` (e.g. to file issues the human asks for). If a \
+         tool call is denied, say what was denied instead of improvising \
+         around it.\n\n\
+         Pipeline control goes through the tasks HTTP API at \
+         http://127.0.0.1:{port} (use curl) — not around it; API writes keep \
+         state and the activity log honest. Endpoints:\n\
          - GET /tasks (working set; ?all=true for history), GET /tasks/{{id}}\n\
          - POST /tasks/{{id}}/queue | /dequeue | /scout — queue membership\n\
          - GET /sessions, GET /sessions/{{id}}/transcript?since=N — scout runs\n\
@@ -332,12 +352,15 @@ fn system_prompt(port: u16) -> String {
          - States: backlog → queued → scouting → in_review → ready_to_build → \
            building → done (rejected = terminal). Issue closure on GitHub \
            retires work automatically; there is no manual mark-done.\n\
-         - Never touch GitHub directly — the server is the only thing that \
-           writes there. You have no credentials for it anyway.\n\
          - Reviews are the human's: only submit a verdict they explicitly \
            stated, and quote their feedback verbatim.\n\
-         - Be concise. Plain sentences, not markdown headers. When you took \
-           actions, say exactly which calls you made.\n\
+         - The checkout is shared with the human and other agents. Never \
+           switch branches, stash, or discard changes you did not make; do \
+           your own work on branches and leave the tree as you found it.\n\
+         - Do not restart the tasks server or vm-pool unasked — a restart \
+           orphans in-flight builds.\n\
+         - Be concise. When you took actions, say exactly which calls or \
+           commands you ran.\n\
          - When asked for status, lead with what needs the human's attention: \
            specs awaiting review, failed builds, then everything else."
     )
@@ -351,7 +374,8 @@ mod tests {
     fn the_system_prompt_carries_the_port_and_the_guardrails() {
         let p = system_prompt(4800);
         assert!(p.contains("http://127.0.0.1:4800"));
-        assert!(p.contains("Never touch GitHub directly"));
         assert!(p.contains("only when — the human asks"));
+        assert!(p.contains("Never switch branches"));
+        assert!(p.contains("verdict they explicitly stated"));
     }
 }

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -164,6 +164,11 @@ pub struct Config {
     pub orchestrator_cmd: String,
     /// Wall-clock budget for one orchestrator tick (`ORCHESTRATOR_TIMEOUT_SECS`).
     pub orchestrator_timeout: Duration,
+    /// Working directory for the orchestrator agent (`ORCHESTRATOR_WORKDIR`).
+    /// Default is a neutral dir under the data dir; point it at a dedicated
+    /// repo clone to run the orchestrator as a full development agent
+    /// (pair with `--dangerously-skip-permissions` in `ORCHESTRATOR_CMD`).
+    pub orchestrator_workdir: Option<PathBuf>,
 }
 
 impl Config {
@@ -217,6 +222,7 @@ impl Config {
                 "a number of seconds",
                 DEFAULT_ORCHESTRATOR_TIMEOUT_SECS,
             )?),
+            orchestrator_workdir: env_string("ORCHESTRATOR_WORKDIR").map(PathBuf::from),
         })
     }
 
@@ -800,7 +806,10 @@ pub async fn orchestrator_loop(
         OrchestratorConfig {
             command: config.orchestrator_cmd.clone(),
             timeout: config.orchestrator_timeout,
-            workdir: config.data_dir.join("orchestrator"),
+            workdir: config
+                .orchestrator_workdir
+                .clone()
+                .unwrap_or_else(|| config.data_dir.join("orchestrator")),
             api_port: config.port,
         },
     );
@@ -978,6 +987,7 @@ mod tests {
             github_rest_api_url: None,
             orchestrator_cmd: "true".into(),
             orchestrator_timeout: Duration::from_secs(60),
+            orchestrator_workdir: None,
         }
     }
 

--- a/crates/tasks/tests/run.rs
+++ b/crates/tasks/tests/run.rs
@@ -392,6 +392,7 @@ fn test_config(vm_pool_socket: &Path, clone_root: &Path, max_concurrent: usize) 
         github_rest_api_url: None,
         orchestrator_cmd: "true".into(),
         orchestrator_timeout: Duration::from_secs(60),
+        orchestrator_workdir: None,
     }
 }
 


### PR DESCRIPTION
The orchestrator hit its own walls in chat — 'approve gh and I'll file
it' — but headless runs have no approval prompt: off-allowlist tools are
silently denied, and handing it the server's token was never the answer.
What it may do is now config, not code: ORCHESTRATOR_WORKDIR points its
cwd anywhere (the real checkout, per Nate — no clones/worktrees), and
ORCHESTRATOR_CMD's permission flags (e.g. --dangerously-skip-permissions)
decide its reach. Defaults unchanged: neutral dir, curl-only.

The standing prompt now rides along on every turn (--append-system-prompt
on resume too), so prompt updates reach the long-lived session without
resetting it. Prompt rewritten for the full-agent deployment: repo cwd,
gh for GitHub writes the human asks for, pipeline actions still through
the API, never switch branches or touch changes it didn't make, never
restart the server unasked. The server's GITHUB_TOKEN stays stripped —
the agent authenticates as itself via gh's keychain auth.
