### PR TITLE
Orchestrator nudges: pipeline events become proactive event turns

### DIFF
--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -625,9 +625,12 @@ struct ChatView: View {
         .navigationTitle("Chat")
     }
 
-    /// The last turn is the human's: a reply is on its way.
+    /// The last turn is input (human or pipeline event): a reply is on its way.
     private var awaitingReply: Bool {
-        model.chat.last?.role == .user
+        switch model.chat.last?.role {
+        case .user, .event: true
+        default: false
+        }
     }
 
     /// The in-flight tick, live: the reply streaming into a bubble as it's
@@ -673,6 +676,39 @@ struct ChatBubble: View {
     let message: ChatMessage
 
     var body: some View {
+        if message.role == .event {
+            eventLine
+        } else {
+            bubble
+        }
+    }
+
+    /// Pipeline notifications read as system chrome, not conversation: a
+    /// compact secondary block the eye can skip past.
+    private var eventLine: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Image(systemName: "bolt.horizontal")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+            Text(eventBody)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
+    }
+
+    /// Strip the "[pipeline] Automated notification…" preamble — it's for
+    /// the agent; humans just want the bullets.
+    private var eventBody: String {
+        let lines = message.content.split(separator: "\n", omittingEmptySubsequences: true)
+        let bullets = lines.filter { !$0.hasPrefix("[pipeline]") }
+        return bullets.isEmpty ? message.content : bullets.joined(separator: "\n")
+    }
+
+    private var bubble: some View {
         HStack {
             if message.role == .user { Spacer(minLength: 60) }
             VStack(alignment: .leading, spacing: 2) {

--- a/app/Tasks/Models.swift
+++ b/app/Tasks/Models.swift
@@ -430,12 +430,17 @@ struct OrchestratorFeedFrame: Decodable, Sendable {
 
 enum ChatRole: WireEnum {
     case user, assistant
+    /// An automated pipeline notification injected into the conversation
+    /// (spec landed, build finished). The orchestrator answers it like a
+    /// user turn; the app renders it as a system line, not a bubble.
+    case event
     case unknown(String)
 
     init(wire: String) {
         switch wire {
         case "user": self = .user
         case "assistant": self = .assistant
+        case "event": self = .event
         default: self = .unknown(wire)
         }
     }
@@ -444,6 +449,7 @@ enum ChatRole: WireEnum {
         switch self {
         case .user: "user"
         case .assistant: "assistant"
+        case .event: "event"
         case .unknown(let raw): raw
         }
     }

--- a/crates/tasks/migrations/0009_orchestrator_watermark.sql
+++ b/crates/tasks/migrations/0009_orchestrator_watermark.sql
@@ -1,0 +1,12 @@
+-- Proactive orchestrator: pipeline events become 'event' turns in the
+-- conversation, so "unanswered" can no longer mean "after the last assistant
+-- turn" -- a message appended while the agent is mid-turn (minutes, now that
+-- it's a full dev agent) would land below the reply's seq and be silently
+-- skipped. `answered_through` is an explicit watermark: the tick records the
+-- highest seq it actually put in the prompt, and everything above it is
+-- unanswered regardless of arrival order.
+ALTER TABLE orchestrator ADD COLUMN answered_through INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill with the old rule so existing conversations stay settled.
+UPDATE orchestrator SET answered_through = COALESCE(
+    (SELECT MAX(seq) FROM orchestrator_messages WHERE role = 'assistant'), 0);

--- a/crates/tasks/src/models.rs
+++ b/crates/tasks/src/models.rs
@@ -476,6 +476,10 @@ pub struct OrchestratorMessage {
 pub enum ChatRole {
     User,
     Assistant,
+    /// An automated pipeline notification injected into the conversation
+    /// (spec landed, build finished, tasks ingested). Counts as unanswered
+    /// input like a user turn — the orchestrator reacts to it proactively.
+    Event,
 }
 
 impl ChatRole {
@@ -483,6 +487,7 @@ impl ChatRole {
         match self {
             ChatRole::User => "user",
             ChatRole::Assistant => "assistant",
+            ChatRole::Event => "event",
         }
     }
 
@@ -490,6 +495,7 @@ impl ChatRole {
         match s {
             "user" => Some(ChatRole::User),
             "assistant" => Some(ChatRole::Assistant),
+            "event" => Some(ChatRole::Event),
             _ => None,
         }
     }

--- a/crates/tasks/src/orchestrator.rs
+++ b/crates/tasks/src/orchestrator.rs
@@ -31,7 +31,8 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::models::{ChatRole, OrchestratorFeedEvent};
+use crate::events::{Event, EventPayload};
+use crate::models::{BuildStatus, OrchestratorFeedEvent, SessionStatus, SpecQueueStatus};
 use crate::store::{Store, StoreError};
 
 #[derive(Debug, Error)]
@@ -73,14 +74,16 @@ impl Orchestrator {
         Self { store, config }
     }
 
-    /// Answer the pending user turns, if any. Returns whether a reply was
-    /// produced. One reply covers every unanswered turn — they are joined
-    /// into one prompt, which is also what makes the tick idempotent.
+    /// Answer the pending input turns (user + event), if any. Returns whether
+    /// a reply was produced. One reply covers every unanswered turn — they
+    /// are joined into one prompt, which is also what makes the tick
+    /// idempotent.
     pub async fn tick(&self) -> Result<bool, OrchestratorError> {
         let pending = self.store.unanswered_orchestrator_messages().await?;
         if pending.is_empty() {
             return Ok(false);
         }
+        let answered_through = pending.last().map(|m| m.seq).unwrap_or(0);
         let prompt = pending
             .iter()
             .map(|m| m.content.as_str())
@@ -105,7 +108,7 @@ impl Orchestrator {
             trimmed
         };
         self.store
-            .append_orchestrator_message(ChatRole::Assistant, content)
+            .append_orchestrator_reply(content, answered_through)
             .await?;
         // The durable message exists now — tell live-feed subscribers the
         // in-flight view is over (after the append, so a client reacting to
@@ -317,6 +320,118 @@ fn tool_label(item: &serde_json::Value) -> String {
     }
 }
 
+/// Which pipeline events deserve a nudge into the orchestrator conversation.
+///
+/// Selective on purpose — every nudge costs an agent turn. Chosen: the
+/// moments a human coworker would want flagged (work arriving, specs landing,
+/// verdicts, builds concluding). Excluded: the orchestrator's own messages
+/// (feedback loop), derivative state transitions, and dispatch-level noise
+/// that the Activity feed already carries.
+pub fn nudge_worthy(payload: &EventPayload) -> bool {
+    match payload {
+        EventPayload::TaskIngested { .. }
+        | EventPayload::SpecCreated { .. }
+        | EventPayload::BuildCompleted { .. }
+        | EventPayload::PullRequestOpened { .. }
+        | EventPayload::ModeChanged { .. } => true,
+        // Success is conveyed by the SpecCreated that accompanies it.
+        EventPayload::SessionCompleted { status, .. } => *status == SessionStatus::ScoutFailed,
+        // Human review verdicts. PendingReview duplicates SpecCreated and
+        // Built duplicates BuildCompleted.
+        EventPayload::SpecQueueStatusChanged { to, .. } => matches!(
+            to,
+            SpecQueueStatus::Approved
+                | SpecQueueStatus::NeedsRevision
+                | SpecQueueStatus::Rejected
+                | SpecQueueStatus::Blocked
+        ),
+        _ => false,
+    }
+}
+
+/// Render a batch of nudge-worthy events as one `event` turn. Events are
+/// identifier-only, so detail comes from store lookups at format time; a row
+/// that has since vanished degrades to its id rather than failing the nudge.
+pub async fn format_nudge(store: &Store, events: &[Event]) -> String {
+    let mut lines = Vec::new();
+    let mut ingested = 0usize;
+    for event in events {
+        match &event.payload {
+            EventPayload::TaskIngested { task_id, .. } => {
+                ingested += 1;
+                lines.push(format!("- New task: {}", task_ref(store, task_id).await));
+            }
+            EventPayload::SpecCreated {
+                spec_id, task_id, ..
+            } => lines.push(format!(
+                "- Spec landed for review: {} ({spec_id})",
+                task_ref(store, task_id).await
+            )),
+            EventPayload::SessionCompleted {
+                session_id,
+                task_id,
+                ..
+            } => {
+                let reason = match store.get_session(session_id).await {
+                    Ok(Some(s)) => s.exit_reason.unwrap_or_else(|| "unknown".into()),
+                    _ => "unknown".into(),
+                };
+                lines.push(format!(
+                    "- Scout FAILED for {}: {reason}",
+                    task_ref(store, task_id).await
+                ));
+            }
+            EventPayload::SpecQueueStatusChanged { spec_id, to, .. } => {
+                let task = match store.get_spec(spec_id).await {
+                    Ok(Some(spec)) => task_ref(store, &spec.task_id).await,
+                    _ => spec_id.to_string(),
+                };
+                lines.push(format!("- Review verdict on {task}: {}", to.as_str()));
+            }
+            EventPayload::BuildCompleted { build_id, status } => {
+                let line = match store.get_build(build_id).await {
+                    Ok(Some(build)) => match status {
+                        BuildStatus::Succeeded => {
+                            format!("- Build {build_id} succeeded (branch {})", build.branch)
+                        }
+                        _ => format!(
+                            "- Build {build_id} FAILED: {}",
+                            build.exit_reason.unwrap_or_else(|| "unknown".into())
+                        ),
+                    },
+                    _ => format!("- Build {build_id}: {}", status.as_str()),
+                };
+                lines.push(line);
+            }
+            EventPayload::PullRequestOpened {
+                build_id,
+                pr_number,
+            } => lines.push(format!("- PR #{pr_number} opened (build {build_id})")),
+            EventPayload::ModeChanged { from, to } => lines.push(format!(
+                "- Mode changed: {} → {}",
+                from.as_str(),
+                to.as_str()
+            )),
+            _ => {}
+        }
+    }
+    if ingested > 1 {
+        lines.push(format!("({ingested} tasks ingested in this batch)"));
+    }
+    format!(
+        "[pipeline] Automated notification — not the human. Recent activity:\n{}",
+        lines.join("\n")
+    )
+}
+
+/// `#<issue> "<title>"` for a task, degrading to the raw id if it's gone.
+async fn task_ref(store: &Store, task_id: &crate::models::TaskId) -> String {
+    match store.get_task(task_id).await {
+        Ok(Some(task)) => format!("#{} \"{}\"", task.gh_issue_number, task.title),
+        _ => task_id.to_string(),
+    }
+}
+
 /// The orchestrator's standing instructions. Appended (not replacing) so
 /// Claude Code's own tool discipline stays intact, and passed on every turn
 /// (resume included) so edits here reach a long-lived session.
@@ -325,8 +440,36 @@ fn system_prompt(port: u16) -> String {
         "You are the Orchestrator for Tasks — a human-in-the-loop platform \
          that turns GitHub issues into specs (via Scout agents) and approved \
          specs into PRs (via Builder agents). You are a persistent \
-         conversation the human returns to. Answer questions, and act when — \
-         and only when — the human asks. Never invent work for yourself.\n\n\
+         conversation the human returns to, and a proactive teammate: besides \
+         the human's messages, you receive automated pipeline notifications \
+         (turns starting with \"[pipeline]\"). Treat those as your cue to act \
+         on the human's behalf — investigate, summarize, prepare — not just \
+         to acknowledge.\n\n\
+         On a [pipeline] turn:\n\
+         - Spec landed → read it (GET /specs/{{id}}) and review it \
+           ADVERSARIALLY: your value is finding what's wrong, not affirming \
+           the work — the scout already believes in it. Hunt for missed \
+           requirements, untested claims, wrong layers, scope creep. Then \
+           zoom out: does this work fit the larger picture of what's in \
+           flight and where the project is going, and is the underlying task \
+           worth doing at all? You are the one place \"why are we doing \
+           this?\" gets asked — did the agent miss the forest for the trees? \
+           Lead with your strongest objection, then say whether you'd \
+           approve. The verdict itself stays the human's.\n\
+         - Scout or build FAILED → investigate (transcript, build row, \
+           events) and report the cause and what you'd do about it.\n\
+         - New tasks → note anything urgent or related to in-flight work; \
+           otherwise a one-line summary is plenty.\n\
+         - PR opened / mode changed / verdicts → keep it to a line unless \
+           something needs attention.\n\
+         The same adversarial posture applies whenever the human asks you to \
+         review a spec, a PR, or an implementation: never be congratulatory — \
+         praise is noise, defects and risks are signal. \"Looks solid\" is \
+         only worth saying after you tried hard to break it and failed, and \
+         then say what you tried.\n\
+         Be brief on notifications — a quiet pipeline deserves a quiet \
+         channel. Never fabricate activity, and never take the gated actions \
+         below without the human.\n\n\
          Your working directory is the project checkout itself. Within your \
          permission settings you may read and edit code, run builds and \
          tests, and use `gh` (e.g. to file issues the human asks for). If a \
@@ -371,10 +514,64 @@ mod tests {
     use super::*;
 
     #[test]
+    fn nudges_are_selective() {
+        use crate::models::{BuildId, ChatRole, Mode, SessionId, SpecId, TaskId};
+        let task = || TaskId::from_raw("task_1");
+        let sess = || SessionId::from_raw("sess_1");
+        let spec = || SpecId::from_raw("spec_1");
+
+        // The moments a coworker would flag:
+        assert!(nudge_worthy(&EventPayload::SpecCreated {
+            spec_id: spec(),
+            task_id: task(),
+            session_id: sess(),
+        }));
+        assert!(nudge_worthy(&EventPayload::SessionCompleted {
+            session_id: sess(),
+            task_id: task(),
+            status: SessionStatus::ScoutFailed,
+        }));
+        assert!(nudge_worthy(&EventPayload::SpecQueueStatusChanged {
+            spec_id: spec(),
+            from: Some(SpecQueueStatus::PendingReview),
+            to: SpecQueueStatus::Approved,
+        }));
+        assert!(nudge_worthy(&EventPayload::ModeChanged {
+            from: Mode::Play,
+            to: Mode::Pause,
+        }));
+
+        // Feedback loops, duplicates, and noise:
+        assert!(!nudge_worthy(&EventPayload::OrchestratorMessage {
+            seq: 1,
+            role: ChatRole::Assistant,
+        }));
+        assert!(!nudge_worthy(&EventPayload::SessionCompleted {
+            session_id: sess(),
+            task_id: task(),
+            status: SessionStatus::ScoutSucceeded, // SpecCreated covers it
+        }));
+        assert!(!nudge_worthy(&EventPayload::SpecQueueStatusChanged {
+            spec_id: spec(),
+            from: None,
+            to: SpecQueueStatus::PendingReview, // SpecCreated covers it
+        }));
+        assert!(!nudge_worthy(&EventPayload::BuildStarted {
+            build_id: BuildId::from_raw("build_1"),
+        }));
+        assert!(!nudge_worthy(&EventPayload::QueueReordered {
+            task_ids: vec![]
+        }));
+    }
+
+    #[test]
     fn the_system_prompt_carries_the_port_and_the_guardrails() {
         let p = system_prompt(4800);
         assert!(p.contains("http://127.0.0.1:4800"));
-        assert!(p.contains("only when — the human asks"));
+        assert!(p.contains("[pipeline]"));
+        assert!(p.contains("proactive"));
+        assert!(p.contains("ADVERSARIALLY"));
+        assert!(p.contains("why are we doing"));
         assert!(p.contains("Never switch branches"));
         assert!(p.contains("verdict they explicitly stated"));
     }

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -46,8 +46,8 @@ use vm_pool_protocol::VmConfig;
 use crate::builder::{Builder, BuilderConfig, BuilderError};
 use crate::events::EventPayload;
 use crate::github::GitHubClient;
-use crate::models::{GhState, Mode, Project, Spec, Task, TaskId, TaskState};
-use crate::orchestrator::{Orchestrator, OrchestratorConfig};
+use crate::models::{ChatRole, GhState, Mode, Project, Spec, Task, TaskId, TaskState};
+use crate::orchestrator::{self, Orchestrator, OrchestratorConfig};
 use crate::protocol::TasksProtocol;
 use crate::scout::{Scout, ScoutConfig, ScoutError, ScoutTarget};
 use crate::server;
@@ -71,8 +71,15 @@ const DEFAULT_BUILDER_TIMEOUT_SECS: u64 = 3600;
 const DEFAULT_ORCHESTRATOR_CMD: &str = "claude --print --output-format stream-json --verbose \
      --include-partial-messages --allowedTools Bash(curl:*)";
 const DEFAULT_ORCHESTRATOR_TIMEOUT_SECS: u64 = 600;
-/// How often the orchestrator loop checks for unanswered user turns.
+/// How often the orchestrator loop checks for unanswered input turns.
 const ORCHESTRATOR_TICK: Duration = Duration::from_secs(1);
+/// Debounce for pipeline-event nudges: after the first nudge-worthy event,
+/// wait for this much quiet so a burst (a poller ingesting ten issues, a
+/// scout finishing + its spec landing) becomes ONE event turn — every nudge
+/// costs an agent turn.
+const NUDGE_DEBOUNCE: Duration = Duration::from_secs(5);
+/// Hard cap on how long a steady event trickle can hold a nudge open.
+const NUDGE_MAX_WAIT: Duration = Duration::from_secs(30);
 /// Wall-clock budget for one scout. ~2.5x the observed 23-minute live run, and
 /// deliberately below vm-pool's own `PoolConfig::vm_timeout` (7200s): if the
 /// app deadline sat at or above the pool's reaper, infrastructure would tear
@@ -343,6 +350,12 @@ pub async fn run(config: Config) -> Result<(), RunError> {
         config.clone(),
         shutdown_rx.clone(),
     ));
+    let nudge = tokio::spawn(orchestrator_nudge_loop(
+        store.clone(),
+        NUDGE_DEBOUNCE,
+        NUDGE_MAX_WAIT,
+        shutdown_rx.clone(),
+    ));
 
     server::serve_with_shutdown(store, config.port, async {
         let _ = tokio::signal::ctrl_c().await;
@@ -353,6 +366,7 @@ pub async fn run(config: Config) -> Result<(), RunError> {
     let _ = shutdown_tx.send(true);
     let _ = poll.await;
     orchestrate.abort();
+    nudge.abort();
     if tokio::time::timeout(SHUTDOWN_GRACE, async {
         let _ = dispatch.await;
         let _ = build.await;
@@ -823,6 +837,67 @@ pub async fn orchestrator_loop(
         tokio::select! {
             _ = tokio::time::sleep(ORCHESTRATOR_TICK) => {}
             _ = shutdown.changed() => return,
+        }
+    }
+}
+
+/// Turn significant pipeline events into `event` turns in the orchestrator
+/// conversation, so the agent reacts to the pipeline instead of only to the
+/// human. Bursts are debounced ([`NUDGE_DEBOUNCE`] of quiet, capped at
+/// `max_wait`) into one turn; [`orchestrator_loop`]'s next tick answers it.
+///
+/// `debounce`/`max_wait` are parameters so tests can run in milliseconds;
+/// production passes [`NUDGE_DEBOUNCE`]/[`NUDGE_MAX_WAIT`].
+pub async fn orchestrator_nudge_loop(
+    store: Arc<Store>,
+    debounce: Duration,
+    max_wait: Duration,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    use tokio::sync::broadcast::error::RecvError;
+
+    let mut events = store.subscribe_events();
+    loop {
+        let first = tokio::select! {
+            _ = shutdown.changed() => return,
+            received = events.recv() => match received {
+                Ok(event) if orchestrator::nudge_worthy(&event.payload) => event,
+                Ok(_) => continue,
+                Err(RecvError::Lagged(missed)) => {
+                    warn!(missed, "orchestrator nudge feed lagged; events skipped");
+                    continue;
+                }
+                Err(RecvError::Closed) => return,
+            },
+        };
+
+        // Collect the rest of the burst.
+        let mut batch = vec![first];
+        let deadline = tokio::time::Instant::now() + max_wait;
+        loop {
+            let quiet = tokio::time::sleep(debounce);
+            tokio::select! {
+                _ = shutdown.changed() => break,
+                _ = quiet => break,
+                _ = tokio::time::sleep_until(deadline) => break,
+                received = events.recv() => match received {
+                    Ok(event) if orchestrator::nudge_worthy(&event.payload) => batch.push(event),
+                    Ok(_) => {}
+                    Err(RecvError::Lagged(missed)) => {
+                        warn!(missed, "orchestrator nudge feed lagged; events skipped");
+                    }
+                    Err(RecvError::Closed) => break,
+                },
+            }
+        }
+
+        let content = orchestrator::format_nudge(&store, &batch).await;
+        info!(events = batch.len(), "nudging orchestrator");
+        if let Err(e) = store
+            .append_orchestrator_message(ChatRole::Event, &content)
+            .await
+        {
+            warn!(error = %e, "failed to append orchestrator nudge");
         }
     }
 }

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -1891,21 +1891,66 @@ impl Store {
             .collect()
     }
 
-    /// The user turns the orchestrator has not answered yet: every message
-    /// after the last assistant turn. Empty when the conversation is settled.
-    /// This is the tick condition — DB-derived, so a crash between a user
-    /// message and its reply just means the next loop pass answers it.
+    /// The input turns (user + event) the orchestrator has not answered yet:
+    /// everything above the `answered_through` watermark. Empty when the
+    /// conversation is settled. This is the tick condition — DB-derived, so a
+    /// crash between an input and its reply just means the next pass answers
+    /// it again. The watermark (not "since the last assistant turn") is what
+    /// keeps input appended *during* a multi-minute agent turn unanswered:
+    /// it lands below the reply's seq but above the watermark.
     pub async fn unanswered_orchestrator_messages(
         &self,
     ) -> Result<Vec<OrchestratorMessage>, StoreError> {
-        let last_assistant: i64 = sqlx::query(
-            "SELECT COALESCE(MAX(seq), 0) AS s FROM orchestrator_messages WHERE role = ?",
+        let watermark: i64 = sqlx::query("SELECT answered_through FROM orchestrator WHERE id = 1")
+            .fetch_one(&self.pool)
+            .await?
+            .try_get("answered_through")?;
+        Ok(self
+            .orchestrator_messages_since(watermark)
+            .await?
+            .into_iter()
+            .filter(|m| m.role != ChatRole::Assistant)
+            .collect())
+    }
+
+    /// Append the assistant's reply and advance the answered watermark to
+    /// `answered_through` (the highest input seq the prompt covered) in one
+    /// transaction, so a crash can't record the reply without settling the
+    /// input it answered.
+    pub async fn append_orchestrator_reply(
+        &self,
+        content: &str,
+        answered_through: i64,
+    ) -> Result<OrchestratorMessage, StoreError> {
+        let now = Utc::now();
+        let mut tx = self.pool.begin().await?;
+        let result = sqlx::query(
+            "INSERT INTO orchestrator_messages (role, content, created_at) VALUES (?, ?, ?)",
         )
         .bind(ChatRole::Assistant.as_str())
-        .fetch_one(&self.pool)
-        .await?
-        .try_get("s")?;
-        self.orchestrator_messages_since(last_assistant).await
+        .bind(content)
+        .bind(now.to_rfc3339())
+        .execute(&mut *tx)
+        .await?;
+        let seq = result.last_insert_rowid();
+        sqlx::query(
+            "UPDATE orchestrator SET answered_through = MAX(answered_through, ?) WHERE id = 1",
+        )
+        .bind(answered_through)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        self.append_event(EventPayload::OrchestratorMessage {
+            seq,
+            role: ChatRole::Assistant,
+        })
+        .await?;
+        Ok(OrchestratorMessage {
+            seq,
+            role: ChatRole::Assistant,
+            content: content.to_string(),
+            created_at: now,
+        })
     }
 
     pub async fn orchestrator_cc_session(&self) -> Result<Option<String>, StoreError> {

--- a/crates/tasks/tests/orchestrator.rs
+++ b/crates/tasks/tests/orchestrator.rs
@@ -5,9 +5,13 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tasks::models::ChatRole;
+use chrono::Utc;
+use tasks::events::EventPayload;
+use tasks::models::{ChatRole, GhState, Project, ProjectId, Task, TaskId, TaskState};
 use tasks::orchestrator::{Orchestrator, OrchestratorConfig};
+use tasks::run::orchestrator_nudge_loop;
 use tasks::store::Store;
+use tokio::sync::watch;
 
 mod common;
 
@@ -261,6 +265,168 @@ async fn an_agent_failure_lands_in_the_chat_and_settles_the_tick() {
     // fresh session before giving up.
     let log = tokio::fs::read_to_string(&args_log).await.unwrap();
     assert!(log.lines().count() >= 1);
+}
+
+/// The watermark contract: input appended while the agent is mid-turn (its
+/// seq below the eventual reply's) must stay unanswered, because the prompt
+/// that turn was built from never included it.
+#[tokio::test]
+async fn input_arriving_mid_turn_stays_unanswered() {
+    let store = Store::open_in_memory().await.unwrap();
+    let first = store
+        .append_orchestrator_message(ChatRole::User, "first")
+        .await
+        .unwrap();
+    // The agent is "mid-turn" on `first` when more input lands:
+    let late = store
+        .append_orchestrator_message(ChatRole::Event, "[pipeline] spec landed")
+        .await
+        .unwrap();
+    // The reply only covered `first`.
+    store
+        .append_orchestrator_reply("done", first.seq)
+        .await
+        .unwrap();
+
+    let pending = store.unanswered_orchestrator_messages().await.unwrap();
+    assert_eq!(
+        pending.iter().map(|m| m.seq).collect::<Vec<_>>(),
+        vec![late.seq],
+        "the mid-turn event turn is still pending; the answered one is not"
+    );
+}
+
+/// End to end: pipeline events debounce into ONE `event` turn with
+/// human-readable detail (issue number + title, not ids), noise events don't
+/// nudge at all, and the next tick answers the nudge like any other input.
+#[tokio::test]
+async fn pipeline_events_become_one_event_turn_the_tick_answers() {
+    let tmp = tempfile::tempdir().unwrap();
+    let args_log = tmp.path().join("args.log");
+    let stub = write_stub(tmp.path(), &args_log, false).await;
+    let store = Arc::new(Store::open_in_memory().await.unwrap());
+    let orch = orchestrator(store.clone(), &stub, tmp.path());
+
+    let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let nudge_loop = tokio::spawn(orchestrator_nudge_loop(
+        store.clone(),
+        Duration::from_millis(100),
+        Duration::from_secs(2),
+        shutdown_rx,
+    ));
+    // Let the loop subscribe before anything is published.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let project = Project {
+        id: ProjectId::new(),
+        repo_owner: "test".into(),
+        repo_name: "repo".into(),
+        added_at: Utc::now(),
+    };
+    store.insert_project(&project).await.unwrap();
+    let insert = async |number: u64, title: &str| {
+        let now = Utc::now();
+        let task = Task {
+            id: TaskId::new(),
+            project_id: project.id.clone(),
+            gh_issue_number: number,
+            title: title.into(),
+            body: String::new(),
+            labels: vec![],
+            gh_state: GhState::Open,
+            state: TaskState::Backlog,
+            priority: 0,
+            manual_rank: None,
+            dispatch_attempts: 0,
+            ingested_at: now,
+            updated_at: now,
+        };
+        store.insert_task(&task).await.unwrap();
+        task
+    };
+    let dark_mode = insert(12, "Add dark mode").await;
+    let fix_login = insert(13, "Fix login redirect").await;
+
+    for task in [&dark_mode, &fix_login] {
+        store
+            .append_event(EventPayload::TaskIngested {
+                task_id: task.id.clone(),
+                project_id: project.id.clone(),
+            })
+            .await
+            .unwrap();
+    }
+    // No store lookups needed for this one — pure formatting.
+    store
+        .append_event(EventPayload::PullRequestOpened {
+            build_id: tasks::models::BuildId::from_raw("build_x"),
+            pr_number: 42,
+        })
+        .await
+        .unwrap();
+    // Noise: must not nudge (and must not appear in the turn).
+    store
+        .append_event(EventPayload::QueueReordered { task_ids: vec![] })
+        .await
+        .unwrap();
+
+    // Wait for the debounced event turn.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let event_turns = loop {
+        let turns: Vec<_> = store
+            .orchestrator_messages_since(0)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|m| m.role == ChatRole::Event)
+            .collect();
+        if !turns.is_empty() {
+            // Debounce settled — give a beat to catch an (incorrect) second
+            // turn before asserting there is exactly one.
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            break store
+                .orchestrator_messages_since(0)
+                .await
+                .unwrap()
+                .into_iter()
+                .filter(|m| m.role == ChatRole::Event)
+                .collect::<Vec<_>>();
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "no event turn appeared within 5s"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+    assert_eq!(event_turns.len(), 1, "burst debounced into one turn");
+    let turn = &event_turns[0];
+    assert!(turn.content.starts_with("[pipeline]"), "{}", turn.content);
+    assert!(
+        turn.content.contains("#12 \"Add dark mode\""),
+        "{}",
+        turn.content
+    );
+    assert!(
+        turn.content.contains("#13 \"Fix login redirect\""),
+        "{}",
+        turn.content
+    );
+    assert!(turn.content.contains("PR #42 opened"), "{}", turn.content);
+    assert!(!turn.content.contains("reorder"), "{}", turn.content);
+
+    // The tick answers the nudge like any other input.
+    assert!(orch.tick().await.unwrap());
+    let messages = store.orchestrator_messages_since(0).await.unwrap();
+    let last = messages.last().unwrap();
+    assert_eq!(last.role, ChatRole::Assistant);
+    assert!(
+        last.content.contains("reply to: [pipeline]"),
+        "{}",
+        last.content
+    );
+    assert!(!orch.tick().await.unwrap(), "settled after the reply");
+
+    nudge_loop.abort();
 }
 
 #[tokio::test]

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -72,13 +72,17 @@ the server only.
   duplicated set, a non-approved spec, specs from two projects, or a spec
   already in an active build. Watch `build_*` events or poll.
 - `POST /orchestrator/messages` `{"content"}` — say something to the
-  orchestrator (a persistent server-side Claude Code session that can inspect
-  and drive the pipeline over this same API, but only when asked). **202**
-  with your message; the reply arrives asynchronously as an
-  `orchestrator_message` event — refetch on it. `GET
-  /orchestrator/messages?since=N` returns turns with `seq > N`, oldest first:
-  `{seq, role: "user"|"assistant", content, created_at}`. Render an
-  "answering…" affordance while the newest turn is the user's.
+  orchestrator (a persistent server-side Claude Code session that inspects
+  and drives the pipeline over this same API). **202** with your message; the
+  reply arrives asynchronously as an `orchestrator_message` event — refetch
+  on it. `GET /orchestrator/messages?since=N` returns turns with `seq > N`,
+  oldest first: `{seq, role: "user"|"assistant"|"event", content,
+  created_at}`. `event` turns are automated pipeline notifications the server
+  injects (specs landing, builds finishing, tasks ingested — debounced into
+  one turn per burst); the orchestrator answers them proactively like user
+  turns. Render them as compact system lines, not chat bubbles, and render an
+  "answering…" affordance while the newest turn is a `user` or `event` turn.
+  Tolerate unknown roles.
 - `GET /orchestrator/stream` — SSE live view of the in-flight tick, one JSON
   frame per `data:` line: `{"kind":"delta","text"}` (assistant text in
   generation order), `{"kind":"tool","label"}` (a tool call, e.g.


### PR DESCRIPTION
The orchestrator only woke when the human messaged it — blind to the pipeline it's supposed to help run. Now it gets nudged (per Nate's direction: the orchestrator SHOULD be proactive, reversing the MVP's act-only-on-instruction posture).

## What

- **`event` chat role + nudge loop.** A new `orchestrator_nudge_loop` subscribes to the event log, filters to the moments a coworker would flag — task ingests, specs landing for review, scout failures, human review verdicts, build completions (with exit reason), PRs opened, mode changes — debounces bursts (5s quiet, 30s cap) into ONE turn, and appends it with store-looked-up detail (`#12 "Add dark mode"`, not `task_9f3…`). The existing tick answers it like any input, into the same long-lived CC session. Excluded: the orchestrator's own messages (feedback loop), derivative state transitions, dispatch noise.
- **`answered_through` watermark (migration 0009).** "Unanswered" used to mean "after the last assistant turn", so any input landing during a multi-minute agent turn was silently marked answered by the reply's higher seq. The tick now records the highest seq its prompt actually covered, atomically with the reply. This fixes lost mid-turn *user* messages too.
- **Prompt: proactive + adversarial.** `[pipeline]` turns are the cue to act — read landed specs and review them adversarially (hunt for defects, zoom out: does this fit the larger picture, is the task worth doing at all — "why are we doing this?" gets asked here), investigate failures, one-liners for routine events. Same adversarial posture for any human-requested review: never congratulatory; "looks solid" only after trying hard to break it. Gates unchanged: verdicts and merges stay the human's.
- **App**: `event` turns render as compact system lines (bolt icon, secondary caption, preamble stripped), not chat bubbles; the "answering…" indicator now also shows after an event turn.

## Testing

- `input_arriving_mid_turn_stays_unanswered` — the watermark contract.
- `pipeline_events_become_one_event_turn_the_tick_answers` — end to end with millisecond debounce: burst → one event turn with human-readable detail, noise events don't nudge, tick answers and settles.
- `nudges_are_selective` — the include/exclude table.
- Full tasks-crate suites green (96 lib + 30 integration); app builds clean.

Implements #744 (proactive orchestrator direction).