### PR TITLE
Open in Claude Code: interactive checkout of the orchestrator session

### DIFF
--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 
@@ -109,6 +110,45 @@ final class AppModel {
         } catch {
             connectionError = error.localizedDescription
         }
+    }
+
+    /// Resume the orchestrator's Claude Code session in Terminal. The wrapper
+    /// script checks the session out (suspending headless ticks — CC sessions
+    /// have no file locking), renews the checkout every minute, and releases
+    /// on exit so nudges queued meanwhile get answered.
+    func openOrchestratorInTerminal() async {
+        do {
+            let info = try await client.orchestratorSession()
+            guard let sessionId = info.ccSessionId else {
+                connectionError = "No orchestrator session yet — say something in Chat first."
+                return
+            }
+            let base = client.baseURL.absoluteString
+            let workdir = info.workdir ?? FileManager.default.homeDirectoryForCurrentUser.path
+            let script = """
+                #!/bin/zsh -li
+                # Interactive checkout of the Tasks orchestrator session.
+                BASE=\(shellQuoted(base))
+                trap 'kill $HEARTBEAT 2>/dev/null; curl -s -X POST "$BASE/orchestrator/session/release" > /dev/null' EXIT
+                curl -s -X POST "$BASE/orchestrator/session/checkout" > /dev/null
+                ( while :; do sleep 60; curl -s -X POST "$BASE/orchestrator/session/checkout" > /dev/null; done ) &
+                HEARTBEAT=$!
+                cd \(shellQuoted(workdir))
+                claude --resume \(shellQuoted(sessionId))
+                """
+            let dir = FileManager.default.temporaryDirectory
+            let file = dir.appending(path: "tasks-orchestrator.command")
+            try script.write(to: file, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: file.path)
+            NSWorkspace.shared.open(file)
+        } catch {
+            connectionError = error.localizedDescription
+        }
+    }
+
+    private func shellQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     /// Queue a one-spec Builder run (the API takes a batch; the UI's unit is

--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -623,6 +623,18 @@ struct ChatView: View {
             .frame(maxWidth: .infinity)
         }
         .navigationTitle("Chat")
+        .toolbar {
+            ToolbarItem {
+                Button {
+                    Task { await model.openOrchestratorInTerminal() }
+                } label: {
+                    Label("Open in Claude Code", systemImage: "terminal")
+                }
+                .help(
+                    "Resume this conversation interactively in Claude Code. "
+                        + "Pipeline nudges pause while you have it open.")
+            }
+        }
     }
 
     /// The last turn is input (human or pipeline event): a reply is on its way.

--- a/app/Tasks/Models.swift
+++ b/app/Tasks/Models.swift
@@ -417,6 +417,16 @@ struct ChatMessage: Decodable, Identifiable, Hashable {
     var id: Int64 { seq }
 }
 
+/// `GET /orchestrator/session` — enough to resume the orchestrator's Claude
+/// Code session interactively (`cd workdir && claude --resume ccSessionId`).
+struct OrchestratorSessionInfo: Decodable, Sendable {
+    /// `nil` until the first tick creates the session.
+    let ccSessionId: String?
+    let workdir: String?
+    /// Someone already holds an interactive checkout.
+    let checkedOut: Bool
+}
+
 /// One frame of `/orchestrator/stream` — the live view of an in-flight tick.
 /// Loose by design: unknown kinds are skipped, and nothing here is durable
 /// (the finished message arrives via `/orchestrator/messages`).

--- a/app/Tasks/TasksClient.swift
+++ b/app/Tasks/TasksClient.swift
@@ -181,6 +181,11 @@ struct TasksClient: Sendable {
         return try await post("orchestrator/messages", body: Body(content: content))
     }
 
+    /// The orchestrator's CC session — enough to resume it interactively.
+    func orchestratorSession() async throws -> OrchestratorSessionInfo {
+        try await get("orchestrator/session")
+    }
+
     /// SSE feed of the in-flight orchestrator tick: text deltas, tool-call
     /// labels, and `done`. Ephemeral — no backfill; a (re)connect only sees
     /// what happens next, and the durable reply always arrives via

--- a/crates/tasks/migrations/0010_orchestrator_checkout.sql
+++ b/crates/tasks/migrations/0010_orchestrator_checkout.sql
@@ -1,0 +1,13 @@
+-- "Open in Claude Code": the orchestrator's CC session is a normal Claude
+-- Code session a human can resume interactively (`claude --resume <id>`).
+-- Sessions have no file locking, so while a human has it checked out the
+-- headless tick must not write to it.
+--
+-- `workdir` is the effective ORCHESTRATOR_WORKDIR, written at startup so the
+-- API can tell clients where to `cd` before resuming (resume-from-elsewhere
+-- works, but would hand the agent a different cwd mid-session).
+-- `checked_out_at` is a heartbeat, not a flag: the interactive wrapper
+-- renews it every minute and ticks stay suspended while it's fresh, so a
+-- killed terminal un-suspends by itself instead of wedging the loop.
+ALTER TABLE orchestrator ADD COLUMN workdir TEXT;
+ALTER TABLE orchestrator ADD COLUMN checked_out_at TEXT;

--- a/crates/tasks/src/models.rs
+++ b/crates/tasks/src/models.rs
@@ -501,6 +501,21 @@ impl ChatRole {
     }
 }
 
+/// The orchestrator's Claude Code session as clients see it
+/// (`GET /orchestrator/session`): enough to resume it interactively
+/// (`cd <workdir> && claude --resume <cc_session_id>`) and whether someone
+/// already has.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrchestratorSessionInfo {
+    /// `None` until the first tick creates the session.
+    pub cc_session_id: Option<String>,
+    /// The agent's working directory, written at server startup.
+    pub workdir: Option<String>,
+    /// A human holds an interactive checkout (fresh heartbeat); headless
+    /// ticks are suspended while true.
+    pub checked_out: bool,
+}
+
 /// One moment of an in-flight orchestrator tick, streamed over
 /// `GET /orchestrator/stream`. Ephemeral by design: nothing here is
 /// persisted — the durable record is the finished message in

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -815,15 +815,24 @@ pub async fn orchestrator_loop(
     config: Config,
     mut shutdown: watch::Receiver<bool>,
 ) {
+    let workdir = config
+        .orchestrator_workdir
+        .clone()
+        .unwrap_or_else(|| config.data_dir.join("orchestrator"));
+    // Advertise the effective workdir so `GET /orchestrator/session` can
+    // tell clients where to `cd` for an interactive resume.
+    if let Err(e) = store
+        .set_orchestrator_workdir(&workdir.display().to_string())
+        .await
+    {
+        warn!(error = %e, "failed to record orchestrator workdir");
+    }
     let orchestrator = Orchestrator::new(
-        store,
+        store.clone(),
         OrchestratorConfig {
             command: config.orchestrator_cmd.clone(),
             timeout: config.orchestrator_timeout,
-            workdir: config
-                .orchestrator_workdir
-                .clone()
-                .unwrap_or_else(|| config.data_dir.join("orchestrator")),
+            workdir,
             api_port: config.port,
         },
     );
@@ -831,8 +840,18 @@ pub async fn orchestrator_loop(
         if *shutdown.borrow() {
             return;
         }
-        if let Err(e) = orchestrator.tick().await {
-            warn!(error = %e, "orchestrator tick failed");
+        // While a human has the session checked out interactively, do not
+        // touch it — CC sessions have no file locking, and a headless turn
+        // would interleave with theirs. Input keeps accumulating as
+        // unanswered turns and is answered once the checkout lapses.
+        match store.orchestrator_checked_out().await {
+            Ok(true) => {}
+            Ok(false) => {
+                if let Err(e) = orchestrator.tick().await {
+                    warn!(error = %e, "orchestrator tick failed");
+                }
+            }
+            Err(e) => warn!(error = %e, "orchestrator checkout state unreadable; skipping tick"),
         }
         tokio::select! {
             _ = tokio::time::sleep(ORCHESTRATOR_TICK) => {}

--- a/crates/tasks/src/server.rs
+++ b/crates/tasks/src/server.rs
@@ -29,8 +29,9 @@ use tracing::{error, info, warn};
 
 use crate::events::{Event, EventPayload};
 use crate::models::{
-    Build, BuildId, ChatRole, Mode, OrchestratorMessage, Project, ProjectId, Session, SessionId,
-    Spec, SpecId, SpecQueueItem, SpecQueueStatus, Task, TaskId, TranscriptLine,
+    Build, BuildId, ChatRole, Mode, OrchestratorMessage, OrchestratorSessionInfo, Project,
+    ProjectId, Session, SessionId, Spec, SpecId, SpecQueueItem, SpecQueueStatus, Task, TaskId,
+    TranscriptLine,
 };
 use crate::store::{Store, StoreError};
 
@@ -52,6 +53,8 @@ pub enum ApiError {
     NotFound(String),
     #[error("{0}")]
     BadRequest(String),
+    #[error("{0}")]
+    Conflict(String),
     #[error("{0}")]
     Internal(String),
 }
@@ -77,6 +80,7 @@ impl IntoResponse for ApiError {
         let status = match self {
             ApiError::NotFound(_) => StatusCode::NOT_FOUND,
             ApiError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            ApiError::Conflict(_) => StatusCode::CONFLICT,
             ApiError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
         (status, Json(json!({ "error": self.to_string() }))).into_response()
@@ -114,6 +118,15 @@ pub fn router(store: Arc<Store>) -> Router {
             get(list_orchestrator_messages).post(send_orchestrator_message),
         )
         .route("/orchestrator/stream", get(stream_orchestrator))
+        .route("/orchestrator/session", get(get_orchestrator_session))
+        .route(
+            "/orchestrator/session/checkout",
+            post(checkout_orchestrator_session),
+        )
+        .route(
+            "/orchestrator/session/release",
+            post(release_orchestrator_session),
+        )
         .route("/mode", get(get_mode).post(set_mode))
         .route("/queue/reorder", post(reorder_queue))
         .route("/events", get(list_events))
@@ -416,6 +429,41 @@ async fn list_orchestrator_messages(
     Query(q): Query<MessagesQuery>,
 ) -> ApiResult<Json<Vec<OrchestratorMessage>>> {
     Ok(Json(store.orchestrator_messages_since(q.since).await?))
+}
+
+/// The orchestrator's CC session, for interactive resume
+/// (`cd <workdir> && claude --resume <cc_session_id>`).
+async fn get_orchestrator_session(
+    State(store): State<Arc<Store>>,
+) -> ApiResult<Json<OrchestratorSessionInfo>> {
+    Ok(Json(store.orchestrator_session_info().await?))
+}
+
+/// Renew the interactive-checkout heartbeat. While it's fresh, headless
+/// ticks are suspended (CC sessions have no file locking); nudges still
+/// accumulate as unanswered turns and are answered after release. Callers
+/// re-POST at least once per [`crate::store::ORCHESTRATOR_CHECKOUT_TTL`].
+/// 409 when no CC session exists yet — there is nothing to check out.
+async fn checkout_orchestrator_session(
+    State(store): State<Arc<Store>>,
+) -> ApiResult<Json<OrchestratorSessionInfo>> {
+    let info = store.orchestrator_session_info().await?;
+    if info.cc_session_id.is_none() {
+        return Err(ApiError::Conflict(
+            "no orchestrator session exists yet".into(),
+        ));
+    }
+    store.orchestrator_checkout().await?;
+    Ok(Json(store.orchestrator_session_info().await?))
+}
+
+/// End the interactive checkout; the next tick may resume the session.
+/// Idempotent — releasing an unclaimed session is fine.
+async fn release_orchestrator_session(
+    State(store): State<Arc<Store>>,
+) -> ApiResult<Json<OrchestratorSessionInfo>> {
+    store.orchestrator_release().await?;
+    Ok(Json(store.orchestrator_session_info().await?))
 }
 
 /// SSE feed of the in-flight orchestrator tick: `delta` chunks as the reply

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -1,6 +1,7 @@
 //! SQLite-backed persistence.
 
 use std::path::Path;
+use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use sqlx::Row;
@@ -12,9 +13,9 @@ use crate::events::{Event, EventPayload};
 use crate::github::GhIssue;
 use crate::models::{
     Build, BuildId, BuildStatus, ChatRole, Complexity, GhState, Mode, OrchestratorFeedEvent,
-    OrchestratorMessage, Project, ProjectId, ReviewedSpec, Session, SessionId, SessionStatus,
-    SessionUsage, Spec, SpecId, SpecQueueEntry, SpecQueueItem, SpecQueueStatus, Task, TaskId,
-    TaskState, TranscriptLine, TranscriptStream,
+    OrchestratorMessage, OrchestratorSessionInfo, Project, ProjectId, ReviewedSpec, Session,
+    SessionId, SessionStatus, SessionUsage, Spec, SpecId, SpecQueueEntry, SpecQueueItem,
+    SpecQueueStatus, Task, TaskId, TaskState, TranscriptLine, TranscriptStream,
 };
 
 /// Result of upserting an external record into our domain.
@@ -54,6 +55,24 @@ const ORCHESTRATOR_FEED_CAPACITY: usize = 4096;
 /// `exit_reason` written to sessions that were still `running` when the server
 /// came back up.
 const ORPHANED_EXIT_REASON: &str = "orphaned by server restart";
+
+/// How long an interactive checkout of the orchestrator session stays fresh
+/// without a heartbeat renewal. The wrapper script renews every minute, so
+/// this only expires when the interactive client died without releasing —
+/// a killed terminal un-wedges the tick loop by itself within this window.
+pub const ORCHESTRATOR_CHECKOUT_TTL: Duration = Duration::from_secs(5 * 60);
+
+/// Whether a checkout heartbeat timestamp is still within
+/// [`ORCHESTRATOR_CHECKOUT_TTL`]. An unparseable timestamp counts as stale —
+/// failing open (ticks resume) beats wedging the loop on bad data.
+fn checkout_heartbeat_fresh(ts: &str) -> bool {
+    DateTime::parse_from_rfc3339(ts)
+        .map(|t| {
+            Utc::now().signed_duration_since(t.with_timezone(&Utc))
+                < chrono::Duration::from_std(ORCHESTRATOR_CHECKOUT_TTL).expect("ttl fits")
+        })
+        .unwrap_or(false)
+}
 
 /// What [`Store::reconcile_orphaned_work`] cleaned up: rows that a previous
 /// process left mid-flight.
@@ -1969,6 +1988,61 @@ impl Store {
             .execute(&self.pool)
             .await?;
         Ok(())
+    }
+
+    /// Record the orchestrator agent's effective working directory. Written
+    /// at startup (it's config, not state) so `GET /orchestrator/session`
+    /// can tell clients where to `cd` before an interactive resume.
+    pub async fn set_orchestrator_workdir(&self, workdir: &str) -> Result<(), StoreError> {
+        sqlx::query("UPDATE orchestrator SET workdir = ? WHERE id = 1")
+            .bind(workdir)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// The orchestrator session as clients see it: the CC session id (if one
+    /// exists yet), the agent's workdir, and whether a human currently has
+    /// the session checked out for interactive use.
+    pub async fn orchestrator_session_info(&self) -> Result<OrchestratorSessionInfo, StoreError> {
+        let row = sqlx::query(
+            "SELECT cc_session_id, workdir, checked_out_at FROM orchestrator WHERE id = 1",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        let checked_out_at: Option<String> = row.try_get("checked_out_at")?;
+        Ok(OrchestratorSessionInfo {
+            cc_session_id: row.try_get("cc_session_id")?,
+            workdir: row.try_get("workdir")?,
+            checked_out: checked_out_at
+                .as_deref()
+                .is_some_and(checkout_heartbeat_fresh),
+        })
+    }
+
+    /// Renew the interactive-checkout heartbeat. While it's fresh
+    /// ([`ORCHESTRATOR_CHECKOUT_TTL`]) the headless tick must not run — CC
+    /// sessions have no file locking, so a tick would interleave writes with
+    /// the human's interactive client.
+    pub async fn orchestrator_checkout(&self) -> Result<(), StoreError> {
+        sqlx::query("UPDATE orchestrator SET checked_out_at = ? WHERE id = 1")
+            .bind(Utc::now().to_rfc3339())
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// End the interactive checkout; the next tick may resume the session.
+    pub async fn orchestrator_release(&self) -> Result<(), StoreError> {
+        sqlx::query("UPDATE orchestrator SET checked_out_at = NULL WHERE id = 1")
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Whether a human currently has the orchestrator session checked out.
+    pub async fn orchestrator_checked_out(&self) -> Result<bool, StoreError> {
+        Ok(self.orchestrator_session_info().await?.checked_out)
     }
 
     // --- mode ---

--- a/crates/tasks/tests/orchestrator.rs
+++ b/crates/tasks/tests/orchestrator.rs
@@ -429,6 +429,70 @@ async fn pipeline_events_become_one_event_turn_the_tick_answers() {
     nudge_loop.abort();
 }
 
+/// The interactive-checkout lifecycle over HTTP: no session → 409; with a
+/// session, checkout marks it held (suspending ticks) and release clears it.
+#[tokio::test]
+async fn orchestrator_session_checkout_flows_over_http() {
+    let store = Arc::new(Store::open_in_memory().await.unwrap());
+    let app = tasks::server::router(store.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let http = reqwest::Client::new();
+
+    let info: serde_json::Value = http
+        .get(format!("{base}/orchestrator/session"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(info["cc_session_id"], serde_json::Value::Null);
+    assert_eq!(info["checked_out"], false);
+
+    // Nothing to check out yet.
+    let resp = http
+        .post(format!("{base}/orchestrator/session/checkout"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 409);
+
+    store
+        .set_orchestrator_cc_session(Some("cc-session-1"))
+        .await
+        .unwrap();
+    store
+        .set_orchestrator_workdir("/tmp/checkout")
+        .await
+        .unwrap();
+
+    let info: serde_json::Value = http
+        .post(format!("{base}/orchestrator/session/checkout"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(info["cc_session_id"], "cc-session-1");
+    assert_eq!(info["workdir"], "/tmp/checkout");
+    assert_eq!(info["checked_out"], true);
+    assert!(store.orchestrator_checked_out().await.unwrap());
+
+    let info: serde_json::Value = http
+        .post(format!("{base}/orchestrator/session/release"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(info["checked_out"], false);
+    assert!(!store.orchestrator_checked_out().await.unwrap());
+}
+
 #[tokio::test]
 async fn messages_flow_over_http() {
     let store = Arc::new(Store::open_in_memory().await.unwrap());

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -83,6 +83,16 @@ the server only.
   turns. Render them as compact system lines, not chat bubbles, and render an
   "answering…" affordance while the newest turn is a `user` or `event` turn.
   Tolerate unknown roles.
+- `GET /orchestrator/session` — `{cc_session_id, workdir, checked_out}`: the
+  orchestrator's Claude Code session, resumable interactively with
+  `cd <workdir> && claude --resume <cc_session_id>`. `cc_session_id` is null
+  until the first tick. `POST /orchestrator/session/checkout` (409 while
+  there's no session) marks it interactively held — headless ticks suspend,
+  nudges queue as unanswered turns — and must be re-POSTed at least every 5
+  minutes (it's a heartbeat; a dead client lapses on its own). `POST
+  /orchestrator/session/release` ends the hold; queued input is answered on
+  the next tick. Wrap interactive use: checkout + renew loop, run `claude
+  --resume`, release on exit.
 - `GET /orchestrator/stream` — SSE live view of the in-flight tick, one JSON
   frame per `data:` line: `{"kind":"delta","text"}` (assistant text in
   generation order), `{"kind":"tool","label"}` (a tool call, e.g.


### PR DESCRIPTION
Follow-up to the client-strategy discussion: instead of growing the Chat pane into a full agent client, jump into the real one. The orchestrator's session is a normal CC session — this adds the affordance to resume it interactively, safely.

- `GET /orchestrator/session` → `{cc_session_id, workdir, checked_out}`; workdir recorded at startup (migration 0010).
- `POST /orchestrator/session/checkout` (heartbeat, 5 min TTL, 409 with no session) / `release`. While fresh, `orchestrator_loop` skips ticks — CC sessions have no file locking, so a headless turn must not interleave with the human's. Nudges keep accumulating as unanswered turns and are answered after release; a killed terminal lapses via the TTL.
- App: Chat toolbar button writes a `.command` wrapper (checkout + 60s renew loop + `cd workdir && claude --resume <id>` + release-on-exit trap) and opens it in Terminal.

Tested: `orchestrator_session_checkout_flows_over_http` (409 → checkout → release over a real server); lib + orchestrator suites green; app builds clean.