### PR TITLE
Home tab: project dashboard from the held event log

### DIFF
--- a/app/Tasks/AppModel.swift
+++ b/app/Tasks/AppModel.swift
@@ -16,8 +16,23 @@ final class AppModel {
     var chat: [ChatMessage] = []
     var specQueue: [SpecQueueItem] = []
     var mode: Mode?
-    /// Recent event log, newest first, for the Activity feed.
-    var events: [ActivityEvent] = []
+    /// The whole event log, held client-side, oldest first. Backfilled once
+    /// by paging `/events?since=1` and extended with one delta request per
+    /// refresh. Held rather than refetched because `GET /events` without
+    /// `since` returns the newest N — a velocity fold over that page would
+    /// fabricate a quiet week the moment in-window events scroll off it.
+    var eventLog: [ActivityEvent] = []
+    /// Whether the initial backfill finished; velocity renders nothing (not
+    /// zeros) until it has the whole log to count.
+    var eventLogComplete = false
+
+    /// What the Activity feed renders: the newest 200, newest first. A slice,
+    /// not the whole log — the unread badge below is counted over what the
+    /// feed will actually show.
+    var events: [ActivityEvent] {
+        Array(eventLog.suffix(200).reversed())
+    }
+
     /// Highest event seq the user has seen in Activity; drives the unread
     /// divider and the sidebar badge. Persisted so "while you were away"
     /// survives relaunch.
@@ -279,7 +294,6 @@ final class AppModel {
         async let chat = Self.attempt { try await c.orchestratorMessages() }
         async let specQueue = Self.attempt { try await c.specQueue() }
         async let mode = Self.attempt { try await c.mode() }
-        async let events = Self.attempt { try await c.events() }
 
         var firstError: String?
         func apply<T>(_ result: Result<T, any Error>?, _ assign: (T) -> Void) {
@@ -305,10 +319,158 @@ final class AppModel {
         }
         apply(await specQueue) { self.specQueue = $0 }
         apply(await mode) { self.mode = $0 }
-        apply(await events) { self.events = $0.sorted { $0.seq > $1.seq } }
 
         connectionError = firstError
+        // Delta-extend the held log (backfilling on the first pass), then
+        // name any newly on-screen shipped work.
+        await extendEventLog()
+        await resolveRetiredTitles()
         lastRefreshed = Date()
+    }
+
+    // MARK: Event log
+
+    /// Backfill (first call) then extend the held log. Pages at 500; `since`
+    /// is inclusive so the loop asks for `high_water + 1` and ALSO filters
+    /// the page on `> high_water` — two interleaved refreshes must not
+    /// double-count an event into velocity.
+    func extendEventLog() async {
+        do {
+            while true {
+                let since = (eventLog.last?.seq ?? 0) + 1
+                let page = try await client.events(since: since, limit: 500)
+                // Re-read the tail AFTER the await: a second refresh can
+                // interleave on the main actor, and filtering against the
+                // pre-await watermark would append its events twice.
+                let tail = eventLog.last?.seq ?? 0
+                let fresh = page.filter { $0.seq > tail }.sorted { $0.seq < $1.seq }
+                eventLog.append(contentsOf: fresh)
+                if page.count < 500 {
+                    eventLogComplete = true
+                    return
+                }
+            }
+        } catch is CancellationError {
+        } catch {
+            if connectionError == nil { connectionError = error.localizedDescription }
+        }
+    }
+
+    /// The five headline counts over a trailing window — a pure fold over the
+    /// held log. `nil` until the backfill finished: rendering zeros off a
+    /// partial log would be the dashboard lying.
+    func velocity(days: Int = 7, now: Date = Date()) -> Velocity? {
+        guard eventLogComplete else { return nil }
+        let cutoff = now.addingTimeInterval(-Double(days) * 86_400)
+        var v = Velocity()
+        for event in eventLog where event.timestamp >= cutoff {
+            switch event.kind {
+            case "task_ingested": v.ingested += 1
+            case "spec_created": v.specsProduced += 1
+            case "spec_queue_status_changed" where event.to == "approved":
+                v.specsApproved += 1
+            case "build_completed": v.buildsFinished += 1
+            case "pull_request_opened": v.prsOpened += 1
+            default: break
+            }
+        }
+        return v
+    }
+
+    // MARK: Home
+
+    var runningSessions: [ScoutSession] {
+        sessions.filter { $0.status == .running }.sorted { $0.startedAt < $1.startedAt }
+    }
+
+    var specsAwaitingReview: [SpecQueueItem] {
+        specQueue.filter { $0.status == .pendingReview }
+    }
+
+    /// When a pending spec landed — a join through `/specs`; nil (rendered as
+    /// nothing, not a fabricated age) when the join misses.
+    func waitingSince(specId: String) -> Date? {
+        spec(specId)?.createdAt
+    }
+
+    var failedBuilds: [BuildItem] {
+        builds.filter { $0.status == .failed }
+            .sorted { $0.finishedOrCreatedAt > $1.finishedOrCreatedAt }
+    }
+
+    var recentPullRequests: [BuildItem] {
+        builds.filter { $0.status == .succeeded && $0.prNumber != nil }
+            .sorted { $0.finishedOrCreatedAt > $1.finishedOrCreatedAt }
+    }
+
+    func pullRequestURL(for build: BuildItem) -> URL? {
+        guard let pr = build.prNumber,
+            let project = projects.first(where: { $0.id == build.projectId })
+        else { return nil }
+        return URL(string: "https://github.com/\(project.slug)/pull/\(pr)")
+    }
+
+    /// The tasks a build serves: its `build_requested` event names the specs
+    /// (the listing projection doesn't), and specs name their tasks.
+    func servedTaskIds(for build: BuildItem) -> [String] {
+        guard
+            let requested = eventLog.last(where: {
+                $0.kind == "build_requested" && $0.buildId == build.id
+            }),
+            let specIds = requested.specIds
+        else { return [] }
+        return specIds.compactMap { spec($0)?.taskId }
+    }
+
+    /// Titles of retired tasks, resolved on demand via `GET /tasks/{id}` and
+    /// cached forever — a retired task's title doesn't change.
+    private var retiredTitles: [String: String] = [:]
+    private var retiredTitleFetchesInFlight: Set<String> = []
+
+    /// `#N title` for a task id, whether it's in the working set or retired.
+    /// A miss returns nil now and triggers a bounded background resolve.
+    func title(forTask id: String) -> String? {
+        if let live = task(id) {
+            return "#\(live.ghIssueNumber) \(live.title)"
+        }
+        return retiredTitles[id]
+    }
+
+    /// One line naming a build's work, falling back to its branch when the
+    /// joins miss (never a dead `build/<uuid>` row if we can help it).
+    func label(for build: BuildItem) -> String {
+        let titles = servedTaskIds(for: build).compactMap { title(forTask: $0) }
+        return titles.isEmpty ? build.branch : titles.joined(separator: " · ")
+    }
+
+    /// Fill `retiredTitles` for the builds Home is showing. Shipped work is
+    /// exactly the work whose issue closed, so a shipped build's task is
+    /// precisely what `GET /tasks` reconciles away — without this, "Recent
+    /// pull requests" shows `build/<uuid>` for almost every row. Bounded by
+    /// what's on screen; the steady state is zero requests.
+    func resolveRetiredTitles() async {
+        let onScreen = recentPullRequests.prefix(8)
+        var missing: Set<String> = []
+        for build in onScreen {
+            for taskId in servedTaskIds(for: build)
+            where task(taskId) == nil
+                && retiredTitles[taskId] == nil
+                && !retiredTitleFetchesInFlight.contains(taskId)
+            {
+                missing.insert(taskId)
+            }
+        }
+        guard !missing.isEmpty else { return }
+        retiredTitleFetchesInFlight.formUnion(missing)
+        for id in missing {
+            do {
+                let retired = try await client.task(id)
+                retiredTitles[id] = "#\(retired.ghIssueNumber) \(retired.title)"
+            } catch {
+                // Leave unresolved; the row falls back to the branch name.
+            }
+            retiredTitleFetchesInFlight.remove(id)
+        }
     }
 
     /// Nil on cancellation (mid-teardown — not an error, not a result).

--- a/app/Tasks/ContentView.swift
+++ b/app/Tasks/ContentView.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
 enum NavSection: Hashable {
-    case tasks, queue, activity, chat
+    case home, tasks, queue, activity, chat
 }
 
 struct ContentView: View {
     @Environment(AppModel.self) private var model
-    @State private var section: NavSection? = .queue
+    @State private var section: NavSection? = .home
     @State private var selectedTask: TaskItem.ID?
     @State private var showTaskInspector = false
     @State private var selectedQueueTask: TaskItem.ID?
@@ -29,13 +29,15 @@ struct ContentView: View {
             }
     }
 
-    /// Queue is list + detail (its detail is where review happens). Tasks,
-    /// Activity, and Chat are single full-width surfaces — Tasks opens its
-    /// detail as a click-to-open, Esc-to-close inspector instead of a
-    /// permanently reserved pane.
+    /// Queue is list + detail (its detail is where review happens). Home,
+    /// Tasks, Activity, and Chat are single full-width surfaces — Tasks opens
+    /// its detail as a click-to-open, Esc-to-close inspector instead of a
+    /// permanently reserved pane. A nil selection means Home — `split`,
+    /// `sectionList`, and `detail` must all agree on that, or the layout and
+    /// its content disagree about which section is showing.
     @ViewBuilder
     private var split: some View {
-        if section == .queue || section == nil {
+        if section == .queue {
             NavigationSplitView {
                 sidebar
                     .navigationSplitViewColumnWidth(min: 150, ideal: 180)
@@ -51,7 +53,10 @@ struct ContentView: View {
                 sidebar
                     .navigationSplitViewColumnWidth(min: 150, ideal: 180)
             } detail: {
-                sectionList
+                // listColumn, not sectionList: full-width sections show
+                // "Connecting…" before the first refresh instead of an
+                // empty shell.
+                listColumn
                     .frame(minWidth: 500)
             }
         }
@@ -86,6 +91,8 @@ struct ContentView: View {
 
     private var sidebar: some View {
         List(selection: $section) {
+            Label("Home", systemImage: "house")
+                .tag(NavSection.home)
             Label("Tasks", systemImage: "tray.full")
                 .tag(NavSection.tasks)
             Label("Queue", systemImage: "list.number")
@@ -127,6 +134,8 @@ struct ContentView: View {
     @ViewBuilder
     private var sectionList: some View {
         switch section {
+        case .home, nil:
+            HomeView(openQueue: { section = .queue })
         case .tasks:
             TasksTable(selection: $selectedTask)
                 .onChange(of: selectedTask) { _, selected in
@@ -136,7 +145,7 @@ struct ContentView: View {
                     taskInspector
                         .inspectorColumnWidth(min: 360, ideal: 460, max: 700)
                 }
-        case .queue, nil:
+        case .queue:
             queueList
         case .activity:
             ActivityFeed(unreadBoundary: unreadBoundary)
@@ -268,9 +277,9 @@ struct ContentView: View {
     @ViewBuilder
     private var detail: some View {
         switch section {
-        case .queue, nil:
+        case .queue:
             queueDetail
-        case .tasks, .activity, .chat:
+        case .home, .tasks, .activity, .chat, nil:
             // Unreachable — these sections use the full-width layout.
             EmptyView()
         }

--- a/app/Tasks/HomeView.swift
+++ b/app/Tasks/HomeView.swift
@@ -1,0 +1,275 @@
+import SwiftUI
+
+/// The launch surface: "what is this project doing right now?" in four
+/// read-only blocks — in flight, needs you, velocity, recent PRs. Every row
+/// points into Queue (or out to GitHub); no review/build/queue actions live
+/// here, so Home and Queue can't become two answers to the same question.
+struct HomeView: View {
+    @Environment(AppModel.self) private var model
+    /// Rows are pointers, not surfaces: this flips the sidebar to Queue.
+    let openQueue: () -> Void
+
+    // `static` on purpose: a `private let` instance property would make the
+    // memberwise `HomeView(openQueue:)` init private too.
+    private static let windowDays = 7
+
+    var body: some View {
+        ScrollView {
+            // Bounded content: a handful of rows per block — plain VStack,
+            // not lazy (see Markdown.swift on lazy-container churn).
+            VStack(alignment: .leading, spacing: 28) {
+                inFlight
+                needsYou
+                velocity
+                recentPullRequests
+            }
+            .padding(24)
+            .frame(maxWidth: 760, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .navigationTitle("Home")
+    }
+
+    // MARK: In flight
+
+    @ViewBuilder
+    private var inFlight: some View {
+        HomeSection("In flight") {
+            let scouts = model.runningSessions
+            let build = model.runningBuild
+            if scouts.isEmpty && build == nil {
+                EmptyLine("Nothing running")
+            }
+            ForEach(scouts) { session in
+                HomeRow(action: openQueue) {
+                    HomeRowBody(
+                        icon: "binoculars",
+                        title: model.title(forTask: session.taskId) ?? "Scout",
+                        subtitle: session.branch,
+                        trailing: elapsed(since: session.startedAt))
+                }
+            }
+            if let build {
+                HomeRow(action: openQueue) {
+                    HomeRowBody(
+                        icon: "hammer",
+                        title: model.label(for: build),
+                        subtitle: build.branch,
+                        trailing: build.startedAt.map { elapsed(since: $0) })
+                }
+            }
+        }
+    }
+
+    // MARK: Needs you
+
+    @ViewBuilder
+    private var needsYou: some View {
+        HomeSection("Needs you") {
+            let pending = model.specsAwaitingReview
+            let failed = model.failedBuilds.prefix(5)
+            if pending.isEmpty && failed.isEmpty {
+                EmptyLine("Nothing needs you")
+            }
+            ForEach(pending) { entry in
+                HomeRow(action: openQueue) {
+                    HomeRowBody(
+                        icon: "doc.text.magnifyingglass",
+                        title: model.title(forTask: entry.taskId) ?? "Spec awaiting review",
+                        subtitle: "Spec awaiting your verdict",
+                        trailing: model.waitingSince(specId: entry.specId)
+                            .map { "waiting \(elapsed(since: $0))" })
+                }
+            }
+            ForEach(failed) { build in
+                HomeRow(action: openQueue) {
+                    HomeRowBody(
+                        icon: "exclamationmark.triangle",
+                        title: "Build failed — \(model.label(for: build))",
+                        subtitle: build.exitReason ?? build.branch,
+                        trailing: elapsed(since: build.finishedOrCreatedAt))
+                }
+            }
+        }
+    }
+
+    // MARK: Velocity
+
+    @ViewBuilder
+    private var velocity: some View {
+        HomeSection("Velocity", caption: "Last \(Self.windowDays) days") {
+            if let v = model.velocity(days: Self.windowDays) {
+                // A KPI row, not a chart: five headline numbers in ordinary
+                // ink. No per-counter color (none is good or bad on its own)
+                // and no delta (the wire carries no comparison period, and
+                // inventing one would be the dashboard's first lie).
+                HStack(spacing: 12) {
+                    StatTile(value: v.ingested, label: "Tasks ingested")
+                    StatTile(value: v.specsProduced, label: "Specs produced")
+                    StatTile(value: v.specsApproved, label: "Specs approved")
+                    StatTile(
+                        value: v.buildsFinished, label: "Builds finished",
+                        help: "Trips through the Builder, failures included")
+                    StatTile(
+                        value: v.prsOpened, label: "PRs opened",
+                        help: "Opened, not merged — merge state lives on GitHub")
+                }
+            } else {
+                // Backfill in progress: no numbers beats wrong zeros.
+                EmptyLine("Counting…")
+            }
+        }
+    }
+
+    // MARK: Recent pull requests
+
+    @ViewBuilder
+    private var recentPullRequests: some View {
+        HomeSection("Recent pull requests") {
+            let recent = model.recentPullRequests.prefix(8)
+            if recent.isEmpty {
+                EmptyLine("No pull requests yet")
+            }
+            ForEach(recent) { build in
+                if let pr = build.prNumber, let url = model.pullRequestURL(for: build) {
+                    Link(destination: url) {
+                        HomeRowBody(
+                            icon: "arrow.triangle.pull",
+                            title: model.label(for: build),
+                            subtitle: "PR #\(pr) · \(build.branch)",
+                            trailing: elapsed(since: build.finishedOrCreatedAt))
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    // Can't navigate (project vanished): plain text beats a
+                    // dead control.
+                    HomeRowBody(
+                        icon: "arrow.triangle.pull",
+                        title: model.label(for: build),
+                        subtitle: build.branch,
+                        trailing: elapsed(since: build.finishedOrCreatedAt))
+                }
+            }
+        }
+    }
+
+    private func elapsed(since date: Date) -> String {
+        date.formatted(.relative(presentation: .named))
+    }
+}
+
+// MARK: - Building blocks
+
+/// A titled block with an optional right-aligned caption.
+private struct HomeSection<Content: View>: View {
+    let title: String
+    let caption: String?
+    @ViewBuilder let content: Content
+
+    init(_ title: String, caption: String? = nil, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.caption = caption
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(title)
+                    .font(.headline)
+                Spacer()
+                if let caption {
+                    Text(caption)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            content
+        }
+    }
+}
+
+/// A row that navigates (into Queue). The whole row is the hit target.
+private struct HomeRow<Content: View>: View {
+    let action: () -> Void
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        Button(action: action) {
+            content
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Icon + title/subtitle + trailing detail, the shape every Home row shares.
+private struct HomeRowBody: View {
+    let icon: String
+    let title: String
+    let subtitle: String?
+    let trailing: String?
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Image(systemName: icon)
+                .frame(width: 18)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .lineLimit(1)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+            if let trailing {
+                Text(trailing)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+        }
+        .padding(.vertical, 5)
+        .padding(.horizontal, 8)
+        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 8))
+        .contentShape(Rectangle())
+    }
+}
+
+/// One large number over its label, in ordinary text ink.
+private struct StatTile: View {
+    let value: Int
+    let label: String
+    var help: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(value)")
+                .font(.title2.weight(.semibold))
+                .monospacedDigit()
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 8))
+        .help(help ?? label)
+    }
+}
+
+/// A quiet placeholder line for an empty block.
+private struct EmptyLine: View {
+    let text: String
+
+    init(_ text: String) { self.text = text }
+
+    var body: some View {
+        Text(text)
+            .font(.callout)
+            .foregroundStyle(.tertiary)
+    }
+}

--- a/app/Tasks/Models.swift
+++ b/app/Tasks/Models.swift
@@ -333,6 +333,9 @@ struct ActivityEvent: Decodable, Identifiable, Hashable {
     let buildId: String?
     let status: String?
     let prNumber: Int64?
+    /// `build_requested` only: the specs the build serves — the one place
+    /// the wire names a build's work without fetching `/builds/{id}`.
+    let specIds: [String]?
 
     var id: Int64 { seq }
 
@@ -341,7 +344,7 @@ struct ActivityEvent: Decodable, Identifiable, Hashable {
     }
     enum PayloadKeys: String, CodingKey {
         case kind, taskId, sessionId, specId, from, to, source, message
-        case buildId, status, prNumber
+        case buildId, status, prNumber, specIds
     }
 
     init(from decoder: any Decoder) throws {
@@ -360,7 +363,18 @@ struct ActivityEvent: Decodable, Identifiable, Hashable {
         buildId = try? p.decodeIfPresent(String.self, forKey: .buildId)
         status = try? p.decodeIfPresent(String.self, forKey: .status)
         prNumber = try? p.decodeIfPresent(Int64.self, forKey: .prNumber)
+        specIds = try? p.decodeIfPresent([String].self, forKey: .specIds)
     }
+}
+
+/// Five headline counts over a trailing window of the held event log —
+/// a pure fold, no server surface. See `AppModel.velocity(days:now:)`.
+struct Velocity: Equatable {
+    var ingested = 0
+    var specsProduced = 0
+    var specsApproved = 0
+    var buildsFinished = 0
+    var prsOpened = 0
 }
 
 /// One serial Builder run over a batch of approved specs. `prNumber` is an
@@ -380,6 +394,10 @@ struct BuildItem: Decodable, Identifiable, Hashable {
     let createdAt: Date
     let startedAt: Date?
     let completedAt: Date?
+
+    /// Sort key for "recent" lists: `completedAt` is null while a build runs,
+    /// and sorting on it alone shuffles in-flight work to the bottom.
+    var finishedOrCreatedAt: Date { completedAt ?? createdAt }
 }
 
 enum BuildStatus: WireEnum {

--- a/app/Tasks/TasksClient.swift
+++ b/app/Tasks/TasksClient.swift
@@ -30,6 +30,9 @@ struct TasksClient: Sendable {
     func specs() async throws -> [Spec] { try await get("specs") }
     func specQueue() async throws -> [SpecQueueItem] { try await get("spec-queue") }
     func spec(_ id: String) async throws -> Spec { try await get("specs/\(id)") }
+    /// One task by id. Unlike the `tasks()` working set, this serves retired
+    /// work too — Home uses it to name shipped builds.
+    func task(_ id: String) async throws -> TaskItem { try await get("tasks/\(id)") }
 
     func mode() async throws -> Mode {
         let response: ModeResponse = try await get("mode")

--- a/crates/tasks/src/events.rs
+++ b/crates/tasks/src/events.rs
@@ -111,3 +111,195 @@ pub enum EventPayload {
         message: String,
     },
 }
+
+impl EventPayload {
+    /// The wire `kind` of this payload — the same string serde's
+    /// `tag = "kind"` emits. Exhaustive on purpose: clients count events by
+    /// matching these strings (the app's velocity fold, docs/clients.md), so
+    /// adding or renaming a variant must not compile until this list — and
+    /// therefore the conversation about who consumes the string — is updated.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            EventPayload::ProjectAdded { .. } => "project_added",
+            EventPayload::TaskIngested { .. } => "task_ingested",
+            EventPayload::TaskStateChanged { .. } => "task_state_changed",
+            EventPayload::TaskGhStateChanged { .. } => "task_gh_state_changed",
+            EventPayload::SessionStarted { .. } => "session_started",
+            EventPayload::SessionCompleted { .. } => "session_completed",
+            EventPayload::SpecCreated { .. } => "spec_created",
+            EventPayload::SpecQueueStatusChanged { .. } => "spec_queue_status_changed",
+            EventPayload::QueueReordered { .. } => "queue_reordered",
+            EventPayload::SpecQueueReordered { .. } => "spec_queue_reordered",
+            EventPayload::BuildRequested { .. } => "build_requested",
+            EventPayload::BuildStarted { .. } => "build_started",
+            EventPayload::BuildCompleted { .. } => "build_completed",
+            EventPayload::PullRequestOpened { .. } => "pull_request_opened",
+            EventPayload::OrchestratorMessage { .. } => "orchestrator_message",
+            EventPayload::ModeChanged { .. } => "mode_changed",
+            EventPayload::Note { .. } => "note",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{
+        BuildId, BuildStatus, ChatRole, GhState, Mode, ProjectId, SessionId, SessionStatus, SpecId,
+        SpecQueueStatus, TaskId, TaskState,
+    };
+
+    fn task() -> TaskId {
+        TaskId::from_raw("task_1")
+    }
+
+    /// Every declared kind matches what serde actually puts on the wire.
+    /// This is the forcing function for clients that count by string.
+    #[test]
+    fn declared_kinds_match_the_wire() {
+        let samples = vec![
+            EventPayload::ProjectAdded {
+                project_id: ProjectId::from_raw("proj_1"),
+            },
+            EventPayload::TaskIngested {
+                task_id: task(),
+                project_id: ProjectId::from_raw("proj_1"),
+            },
+            EventPayload::TaskStateChanged {
+                task_id: task(),
+                from: TaskState::Backlog,
+                to: TaskState::Queued,
+            },
+            EventPayload::TaskGhStateChanged {
+                task_id: task(),
+                gh_state: GhState::Closed,
+            },
+            EventPayload::SessionStarted {
+                session_id: SessionId::from_raw("sess_1"),
+                task_id: task(),
+            },
+            EventPayload::SessionCompleted {
+                session_id: SessionId::from_raw("sess_1"),
+                task_id: task(),
+                status: SessionStatus::ScoutSucceeded,
+            },
+            EventPayload::SpecCreated {
+                spec_id: SpecId::from_raw("spec_1"),
+                task_id: task(),
+                session_id: SessionId::from_raw("sess_1"),
+            },
+            EventPayload::SpecQueueStatusChanged {
+                spec_id: SpecId::from_raw("spec_1"),
+                from: None,
+                to: SpecQueueStatus::PendingReview,
+            },
+            EventPayload::QueueReordered { task_ids: vec![] },
+            EventPayload::SpecQueueReordered { spec_ids: vec![] },
+            EventPayload::BuildRequested {
+                build_id: BuildId::from_raw("build_1"),
+                spec_ids: vec![SpecId::from_raw("spec_1")],
+            },
+            EventPayload::BuildStarted {
+                build_id: BuildId::from_raw("build_1"),
+            },
+            EventPayload::BuildCompleted {
+                build_id: BuildId::from_raw("build_1"),
+                status: BuildStatus::Succeeded,
+            },
+            EventPayload::PullRequestOpened {
+                build_id: BuildId::from_raw("build_1"),
+                pr_number: 7,
+            },
+            EventPayload::OrchestratorMessage {
+                seq: 1,
+                role: ChatRole::User,
+            },
+            EventPayload::ModeChanged {
+                from: Mode::Play,
+                to: Mode::Pause,
+            },
+            EventPayload::Note {
+                source: "test".into(),
+                message: "hi".into(),
+            },
+        ];
+        for payload in samples {
+            let wire: serde_json::Value = serde_json::to_value(&payload).unwrap();
+            assert_eq!(
+                wire["kind"],
+                payload.kind(),
+                "declared kind diverges from the wire for {payload:?}"
+            );
+        }
+    }
+
+    /// The five kinds the app's velocity fold counts, pinned by name — and
+    /// the subtlety that an approval and a rejection are the SAME kind,
+    /// distinguished only by `to`.
+    #[test]
+    fn velocity_vocabulary_is_the_client_contract() {
+        for kind in [
+            "task_ingested",
+            "spec_created",
+            "spec_queue_status_changed",
+            "build_completed",
+            "pull_request_opened",
+        ] {
+            // The vocabulary exists: at least one variant declares it.
+            // (A rename upstream breaks `declared_kinds_match_the_wire`
+            // first; this pins the client-facing five explicitly.)
+            assert!(
+                KINDS.contains(&kind),
+                "velocity counts `{kind}` but no variant declares it"
+            );
+        }
+        let approved = EventPayload::SpecQueueStatusChanged {
+            spec_id: SpecId::from_raw("spec_1"),
+            from: Some(SpecQueueStatus::PendingReview),
+            to: SpecQueueStatus::Approved,
+        };
+        let rejected = EventPayload::SpecQueueStatusChanged {
+            spec_id: SpecId::from_raw("spec_1"),
+            from: Some(SpecQueueStatus::PendingReview),
+            to: SpecQueueStatus::Rejected,
+        };
+        let approved_wire = serde_json::to_value(&approved).unwrap();
+        let rejected_wire = serde_json::to_value(&rejected).unwrap();
+        assert_eq!(approved_wire["kind"], rejected_wire["kind"]);
+        assert_eq!(approved_wire["to"], "approved");
+        assert_eq!(rejected_wire["to"], "rejected");
+    }
+
+    /// `build_requested` carries the spec ids — the only place the wire says
+    /// which work a build serves without fetching `/builds/{id}`.
+    #[test]
+    fn build_requested_carries_spec_ids() {
+        let wire = serde_json::to_value(EventPayload::BuildRequested {
+            build_id: BuildId::from_raw("build_1"),
+            spec_ids: vec![SpecId::from_raw("spec_a"), SpecId::from_raw("spec_b")],
+        })
+        .unwrap();
+        assert_eq!(wire["spec_ids"], serde_json::json!(["spec_a", "spec_b"]));
+    }
+
+    /// Every kind string, for the vocabulary test.
+    const KINDS: &[&str] = &[
+        "project_added",
+        "task_ingested",
+        "task_state_changed",
+        "task_gh_state_changed",
+        "session_started",
+        "session_completed",
+        "spec_created",
+        "spec_queue_status_changed",
+        "queue_reordered",
+        "spec_queue_reordered",
+        "build_requested",
+        "build_started",
+        "build_completed",
+        "pull_request_opened",
+        "orchestrator_message",
+        "mode_changed",
+        "note",
+    ];
+}

--- a/crates/tasks/src/orchestrator.rs
+++ b/crates/tasks/src/orchestrator.rs
@@ -488,7 +488,12 @@ fn system_prompt(port: u16) -> String {
            Builder run (serial; one at a time)\n\
          - GET /builds, GET /builds/{{id}} — build state, PR number\n\
          - GET /events?since=N — the activity log, newest last; your best \
-           source for \"what happened\"\n\
+           source for \"what happened\". Without ?since it returns only the \
+           newest 100 — page from since=1 before counting anything. Retired \
+           tasks are hidden from GET /tasks but reachable at GET /tasks/{{id}}. \
+           Nothing on the wire counts merged PRs — pull_request_opened fires \
+           at open; check merge state via gh, or say \"opened\", not \
+           \"shipped\"\n\
          - GET /mode, POST /mode {{\"mode\":\"play|pause|stop\"}} — play runs \
            scouts+builds, pause only polls, stop is everything off\n\n\
          Rules:\n\

--- a/crates/tasks/src/server.rs
+++ b/crates/tasks/src/server.rs
@@ -1674,4 +1674,167 @@ mod tests {
             "no duplicate or skipped seq at the handoff"
         );
     }
+
+    /// `GET /events` without `since` returns the newest N — a fold over that
+    /// page fabricates a quiet week once real events scroll off it. This test
+    /// first proves the naive read genuinely undercounts (otherwise it proves
+    /// nothing), then runs the client's exact paging loop and asserts it
+    /// reconstructs the log gap-free and dupe-free.
+    #[tokio::test]
+    async fn paging_events_reconstructs_the_log_that_newest_n_truncates() {
+        let store = Arc::new(Store::open_in_memory().await.unwrap());
+        // 3 countable ingests, then enough noise to push them off a
+        // newest-100 default page.
+        for i in 0..3 {
+            store
+                .append_event(EventPayload::TaskIngested {
+                    task_id: TaskId::from_raw(format!("task_{i}")),
+                    project_id: ProjectId::from_raw("proj_1"),
+                })
+                .await
+                .unwrap();
+        }
+        for i in 0..150 {
+            store
+                .append_event(EventPayload::Note {
+                    source: "test".into(),
+                    message: format!("noise {i}"),
+                })
+                .await
+                .unwrap();
+        }
+        let base = spawn(store).await;
+        let http = reqwest::Client::new();
+
+        let newest_page: Vec<Value> = http
+            .get(format!("{base}/events"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let naive_count = newest_page
+            .iter()
+            .filter(|e| e["payload"]["kind"] == "task_ingested")
+            .count();
+        assert_eq!(
+            naive_count, 0,
+            "the naive newest-N fold must genuinely undercount for this test to prove anything"
+        );
+
+        // The client's paging loop: since = high_water + 1, filter > high_water.
+        let mut log: Vec<Value> = Vec::new();
+        let mut high_water: i64 = 0;
+        loop {
+            let page: Vec<Value> = http
+                .get(format!("{base}/events?since={}&limit=50", high_water + 1))
+                .send()
+                .await
+                .unwrap()
+                .json()
+                .await
+                .unwrap();
+            let fresh: Vec<Value> = page
+                .iter()
+                .filter(|e| e["seq"].as_i64().unwrap() > high_water)
+                .cloned()
+                .collect();
+            if let Some(last) = fresh.last() {
+                high_water = last["seq"].as_i64().unwrap();
+            }
+            let done = page.len() < 50;
+            log.extend(fresh);
+            if done {
+                break;
+            }
+        }
+        assert_eq!(log.len(), 153, "gap-free and dupe-free");
+        let seqs: Vec<i64> = log.iter().map(|e| e["seq"].as_i64().unwrap()).collect();
+        assert_eq!(seqs, (1..=153).collect::<Vec<_>>(), "contiguous from 1");
+        let paged_count = log
+            .iter()
+            .filter(|e| e["payload"]["kind"] == "task_ingested")
+            .count();
+        assert_eq!(paged_count, 3, "matches the hand count");
+    }
+
+    /// `GET /tasks` reconciles away closed+concluded work; `GET /tasks/{id}`
+    /// must not — shipped work is exactly the work whose issue has closed,
+    /// and dashboards still need its title.
+    #[tokio::test]
+    async fn retired_tasks_stay_reachable_by_id() {
+        let (store, project) = store_with_project().await;
+        let now = Utc::now();
+        let retired = Task {
+            id: TaskId::new(),
+            project_id: project.id.clone(),
+            gh_issue_number: 900,
+            title: "shipped and closed".into(),
+            body: String::new(),
+            labels: vec![],
+            gh_state: GhState::Closed,
+            state: TaskState::Done,
+            priority: 0,
+            manual_rank: None,
+            dispatch_attempts: 0,
+            ingested_at: now,
+            updated_at: now,
+        };
+        store.insert_task(&retired).await.unwrap();
+        let base = spawn(store).await;
+        let http = reqwest::Client::new();
+
+        let listed: Vec<Task> = http
+            .get(format!("{base}/tasks"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert!(
+            !listed.iter().any(|t| t.id == retired.id),
+            "the working set hides retired work"
+        );
+
+        let fetched: Task = http
+            .get(format!("{base}/tasks/{}", retired.id))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(fetched.title, "shipped and closed");
+    }
+
+    /// The wire timestamp form the Swift date decoder is written against:
+    /// RFC3339 with a `Z` suffix (chrono's serde), not `+00:00`.
+    #[tokio::test]
+    async fn event_timestamps_are_rfc3339_zulu_on_the_wire() {
+        let store = Arc::new(Store::open_in_memory().await.unwrap());
+        store
+            .append_event(EventPayload::Note {
+                source: "test".into(),
+                message: "tick".into(),
+            })
+            .await
+            .unwrap();
+        let base = spawn(store).await;
+
+        let events: Vec<Value> = reqwest::Client::new()
+            .get(format!("{base}/events"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let ts = events[0]["timestamp"].as_str().unwrap();
+        assert!(
+            ts.ends_with('Z') && ts.contains('T'),
+            "expected RFC3339 Zulu, got {ts}"
+        );
+    }
 }

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -113,6 +113,30 @@ the server only.
 - `GET /events?since=&limit=` — catch-up (default limit 100);
   `GET /events/stream` — SSE, each `data:` line is one Event JSON.
 
+## Counting the event log
+
+Dashboards that answer "what happened this week" must count the **event log**,
+not the entity lists, and must hold the **whole** log:
+
+- **Don't count from `/tasks`.** The working set reconciles away work whose
+  issue closed — which is exactly the shipped work a dashboard wants to count.
+  (`GET /tasks/{id}` still serves retired tasks; use it to name old work.)
+- **Don't trust `updated_at`** as an activity timestamp — any poll can touch it.
+- **The newest-N trap:** `GET /events` without `since` returns the newest
+  `limit` events. A fold over that page silently undercounts the moment
+  in-window events scroll off it — a fabricated quiet week, not an error.
+  Instead, backfill once by paging `?since=1&limit=500` (advance
+  `since = high_water + 1`; `since` is inclusive, so *also* filter the page on
+  `seq > high_water` — two interleaved syncs must not double-count), then
+  extend with one delta request per refresh.
+- **The counted kinds** are `task_ingested`, `spec_created`,
+  `spec_queue_status_changed` (an approval is `to == "approved"`; a rejection
+  is the **same kind** with a different `to`), `build_completed` (failures
+  included — it counts trips through the pipeline), and `pull_request_opened`.
+- **Nothing on the wire counts merged pull requests.** `pull_request_opened`
+  fires at open; merged/closed state is GitHub's, queried at render time or
+  not shown. Don't present opened PRs as shipped work.
+
 ## Session transcripts
 
 Agent output is a **separate channel from the event log**, on purpose (see


### PR DESCRIPTION
Implements the approved-for-pickup re-scout spec for #789 (spec_6441c8c7), built directly per Nate.

## What

- **Four read-only blocks**: In flight (running scouts + build, branch, elapsed), Needs you (specs awaiting verdict with waiting-since, failed builds with exit reason — every row clicks through to Queue), Velocity (five-number KPI row, trailing 7 days), Recent pull requests (succeeded builds → GitHub PR links, named by the tasks they served).
- **Zero new wire shapes** — no endpoint, no model, no migration; cannot conflict with open PR #785 (verified: none of its files/symbols touched; `Models.swift` edits are additive in different regions).
- **The held event log**: `GET /events` without `since` returns newest-N, so a fold over it fabricates a quiet week once in-window events scroll off the page. The app backfills the whole log once (paging `?since=1&limit=500`) and extends with one delta request per refresh — which also makes the Activity feed's refetch incremental (it used to refetch 200 rows on every SSE event). Interleaved-refresh dedupe re-reads the log tail *after* the await.
- **Velocity honesty**: nothing until the backfill completes (no fake zeros), "Builds finished" includes failures (tooltip), "PRs opened" is opened-not-merged (tooltip; nothing on the wire counts merges and no honest number exists to show), no invented deltas.
- **Naming shipped work**: a build's specs come from its `build_requested` event; shipped tasks are exactly what `GET /tasks` reconciles away, so titles resolve via `GET /tasks/{id}`, bounded to on-screen rows (≤8), cached forever.
- **Server forcing functions**: `EventPayload::kind()` (exhaustive match — new variants don't compile until the string-vocabulary conversation happens) + tests pinning declared kinds vs the wire, the approval/rejection same-kind subtlety, `build_requested.spec_ids`, the newest-N truncation trap with the exact paging recipe, retired-task reachability, and RFC3339-Zulu timestamps. `docs/clients.md` gains a "Counting the event log" section; the orchestrator prompt gets the compressed version.
- **Nav**: Home first in the sidebar and the default; `nil` selection now means Home in all three switch sites; full-width sections render the connecting state before first refresh.

## Verification

- 107 lib tests + all integration suites green; clippy clean in touched files; app builds clean.
- Live-verified against the running server (screenshot flow next).

## Deviations from the spec

None of substance. The spec's own live-verified numbers (event counts) naturally differ now; the paging test seeds its own 153-event log instead.