### PR TITLE
Restore clippy-clean workspace under the 1.97 toolchain

### DIFF
--- a/crates/scout-supervisor/src/main.rs
+++ b/crates/scout-supervisor/src/main.rs
@@ -289,7 +289,7 @@ fn make_workdir(task_id: &str) -> Result<PathBuf> {
         .unwrap_or_else(|_| std::env::temp_dir());
     let dir = base.join(format!(
         "scout-{task_id}-{}",
-        Uuid::new_v4().simple().to_string()[..8].to_string()
+        &Uuid::new_v4().simple().to_string()[..8]
     ));
     std::fs::create_dir_all(&dir).context("create workdir")?;
     Ok(dir)

--- a/crates/tasks/src/models.rs
+++ b/crates/tasks/src/models.rs
@@ -1,4 +1,11 @@
 //! Core domain types.
+//!
+//! The wire enums here deliberately carry an inherent `from_str -> Option`
+//! rather than implementing `std::str::FromStr`: the callers (store row
+//! mappers, API handlers) want an Option to turn into a typed BadEnum error,
+//! not a FromStr::Err, and `parse()` inference noise buys nothing at this
+//! size. Suppressed module-wide because every wire enum hits the same lint.
+#![allow(clippy::should_implement_trait)]
 
 use std::fmt;
 
@@ -13,6 +20,10 @@ macro_rules! id_newtype {
         pub struct $name(String);
 
         impl $name {
+            /// Mint a fresh random id. Deliberately no `Default`: a default
+            /// that returns a different value every call would be a lie —
+            /// two "default" ids must not silently differ.
+            #[allow(clippy::new_without_default)]
             pub fn new() -> Self {
                 Self(format!("{}_{}", $prefix, Uuid::new_v4().simple()))
             }

--- a/crates/tasks/src/run.rs
+++ b/crates/tasks/src/run.rs
@@ -886,8 +886,6 @@ fn is_disconnect(error: &ScoutError) -> bool {
     )
 }
 
-/// Where a scout clones from. Derived per project; the token, when set, rides
-/// along as basic auth so private repos clone without a credential helper.
 // --- orchestrator loop ---
 
 /// Answer pending orchestrator turns until `shutdown` flips.
@@ -1111,6 +1109,8 @@ pub async fn build_loop(store: Arc<Store>, config: Config, mut shutdown: watch::
     }
 }
 
+/// Where a scout clones from. Derived per project; the token, when set, rides
+/// along as basic auth so private repos clone without a credential helper.
 fn clone_url(config: &Config, project: &Project) -> String {
     clone_url_for(
         &config.clone_url_base,

--- a/crates/tasks/src/store.rs
+++ b/crates/tasks/src/store.rs
@@ -4107,20 +4107,20 @@ mod tests {
             .await
             .unwrap();
         let err = store
-            .create_build(&[pending.id.clone()], "main")
+            .create_build(std::slice::from_ref(&pending.id), "main")
             .await
             .unwrap_err();
         assert!(format!("{err}").contains("rejected"), "{err}");
 
         // A spec already in an active build.
         let build = store
-            .create_build(&[spec.id.clone()], "main")
+            .create_build(std::slice::from_ref(&spec.id), "main")
             .await
             .unwrap();
         assert_eq!(build.status, BuildStatus::Queued);
         assert_eq!(build.branch, format!("build/{}", build.id));
         let err = store
-            .create_build(&[spec.id.clone()], "main")
+            .create_build(std::slice::from_ref(&spec.id), "main")
             .await
             .unwrap_err();
         assert!(format!("{err}").contains("already part of"), "{err}");
@@ -4158,11 +4158,11 @@ mod tests {
         let (_tb, spec_b) = approved_spec(&store, &project, 2).await;
 
         let first = store
-            .create_build(&[spec_a.id.clone()], "main")
+            .create_build(std::slice::from_ref(&spec_a.id), "main")
             .await
             .unwrap();
         let _second = store
-            .create_build(&[spec_b.id.clone()], "main")
+            .create_build(std::slice::from_ref(&spec_b.id), "main")
             .await
             .unwrap();
 
@@ -4209,7 +4209,7 @@ mod tests {
         store.insert_project(&project).await.unwrap();
         let (task, spec) = approved_spec(&store, &project, 1).await;
         let build = store
-            .create_build(&[spec.id.clone()], "main")
+            .create_build(std::slice::from_ref(&spec.id), "main")
             .await
             .unwrap();
         store.claim_next_queued_build().await.unwrap().unwrap();
@@ -4243,7 +4243,7 @@ mod tests {
             TaskState::Done
         );
         let err = store
-            .create_build(&[spec.id.clone()], "main")
+            .create_build(std::slice::from_ref(&spec.id), "main")
             .await
             .unwrap_err();
         assert!(format!("{err}").contains("built"), "{err}");

--- a/crates/tasks/tests/builder.rs
+++ b/crates/tasks/tests/builder.rs
@@ -229,20 +229,22 @@ async fn a_batch_of_two_specs_lands_as_one_branch_and_one_pr() {
     assert!(listing.contains("src/built.rs"));
     assert!(!listing.contains("PROMPT.md") && !listing.contains("SUMMARY.md"));
 
-    // The PR request the fake GitHub saw.
-    let prs = h.seen_prs.lock().unwrap();
-    assert_eq!(prs.len(), 1);
-    let pr = &prs[0];
-    assert_eq!(pr["head"], json!(done.branch));
-    assert_eq!(pr["base"], json!("main"));
-    assert_eq!(pr["title"], json!("Build: #7, #9"));
-    let body = pr["body"].as_str().unwrap();
-    assert!(body.contains("Implements #7") && body.contains("Implements #9"));
-    assert!(
-        !body.contains("Closes"),
-        "closing an issue is not ours to write"
-    );
-    drop(prs);
+    // The PR request the fake GitHub saw. Block-scoped (not `drop()`) so the
+    // guard is provably not held across the awaits below.
+    {
+        let prs = h.seen_prs.lock().unwrap();
+        assert_eq!(prs.len(), 1);
+        let pr = &prs[0];
+        assert_eq!(pr["head"], json!(done.branch));
+        assert_eq!(pr["base"], json!("main"));
+        assert_eq!(pr["title"], json!("Build: #7, #9"));
+        let body = pr["body"].as_str().unwrap();
+        assert!(body.contains("Implements #7") && body.contains("Implements #9"));
+        assert!(
+            !body.contains("Closes"),
+            "closing an issue is not ours to write"
+        );
+    }
 
     // The batch drained: specs built, tasks done.
     for (task, spec) in [(&task_a, &spec_a), (&task_b, &spec_b)] {
@@ -270,7 +272,7 @@ async fn a_failed_build_returns_the_work_without_wedging_the_queue() {
 
     let build = h
         .store
-        .create_build(&[spec.id.clone()], "main")
+        .create_build(std::slice::from_ref(&spec.id), "main")
         .await
         .unwrap();
     let claimed = h.store.claim_next_queued_build().await.unwrap().unwrap();

--- a/crates/vm-pool/pool/src/images.rs
+++ b/crates/vm-pool/pool/src/images.rs
@@ -156,7 +156,7 @@ impl ImageStore {
             }
         }
 
-        images.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        images.sort_by_key(|a| a.created_at);
         Ok(images)
     }
 

--- a/crates/vm-pool/pool/src/snapshot.rs
+++ b/crates/vm-pool/pool/src/snapshot.rs
@@ -87,7 +87,7 @@ impl SnapshotStore {
             }
         }
 
-        snapshots.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        snapshots.sort_by_key(|a| a.created_at);
         Ok(snapshots)
     }
 

--- a/crates/vm-pool/pool/src/transport.rs
+++ b/crates/vm-pool/pool/src/transport.rs
@@ -43,11 +43,12 @@ impl<P: AppProtocol> VmTransport<P> {
         let stdin = child
             .stdin
             .take()
-            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "failed to get stdin"))?;
+            .ok_or_else(|| std::io::Error::other("failed to get stdin"))?;
 
-        let stdout = child.stdout.take().ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::Other, "failed to get stdout")
-        })?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| std::io::Error::other("failed to get stdout"))?;
 
         let (events_tx, events_rx) = mpsc::channel(64);
         tokio::spawn(read_events::<P>(stdout, events_tx));

--- a/crates/vm-pool/protocol/src/lib.rs
+++ b/crates/vm-pool/protocol/src/lib.rs
@@ -164,23 +164,20 @@ pub struct LogLine {
 
 /// Priority level for VM allocation. Higher priority VMs can evict
 /// lower priority ones when the pool is full.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum Priority {
     /// Background/batch work. First to be evicted.
     Low = 0,
     /// Normal interactive work.
+    #[default]
     Normal = 1,
     /// Urgent work. Can evict Low and Normal.
     High = 2,
     /// Critical work. Can evict anything below.
     Critical = 3,
-}
-
-impl Default for Priority {
-    fn default() -> Self {
-        Priority::Normal
-    }
 }
 
 impl fmt::Display for Priority {


### PR DESCRIPTION
Toolchain drift left ~39 warnings on main, so every branch inherited the noise while CLAUDE.md says clippy-clean before committing.

- Machine-applicable fixes taken as-is: `io::Error::other`, `sort_by_key`, `slice::from_ref` (tests), `to_string_in_format_args`, derived `Default` for vm-pool `Priority` (folded into the existing derive list).
- The doc comment for `clone_url` had drifted to the top of the orchestrator-loop section (empty_line_after_doc_comments was right to complain) — reattached to the function.
- tests/builder.rs held a `MutexGuard` across awaits (await_holding_lock): already explicitly dropped first, but clippy's drop-tracking doesn't credit `drop()` — now block-scoped, which is also clearer.
- Two allows with written justification rather than API churn: `should_implement_trait` module-wide in models.rs (inherent `from_str -> Option` is the deliberate wire-enum shape; FromStr's Result buys nothing at the call sites) and `new_without_default` in the id_newtype macro (a Default that mints a different random id per call would be misleading).

`cargo clippy --workspace --all-targets`: 0 warnings. `cargo test --workspace`: all 27 binaries green. No behavior changes.