### PR TITLE
tasks-client: typed blocking client with reconnecting SSE streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/scout-supervisor",
     "crates/tasks",
     "crates/tasks-api",
+    "crates/tasks-client",
     "crates/tasks-protocol",
     "crates/vm-pool/client",
     "crates/vm-pool/pool",
@@ -51,6 +52,9 @@ axum = "0.8"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tempfile = "3"
 base64 = "0.22"
+# Blocking HTTP for tasks-client: the API is loopback-only plain http, so no
+# TLS and no async runtime — a GUI client calls from its own worker threads.
+ureq = { version = "2", default-features = false, features = ["json"] }
 
 dirs = "6"
 
@@ -64,3 +68,4 @@ vm-pool-manager = { path = "crates/vm-pool/pool", version = "0.1.0-alpha.1" }
 # tasks internal
 tasks-protocol = { path = "crates/tasks-protocol" }
 tasks-api = { path = "crates/tasks-api" }
+tasks = { path = "crates/tasks" }

--- a/crates/tasks-client/Cargo.toml
+++ b/crates/tasks-client/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tasks-client"
+description = "Typed blocking client for the tasks HTTP API"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+tasks-api.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+ureq.workspace = true
+
+[dev-dependencies]
+tasks.workspace = true
+tokio.workspace = true
+axum.workspace = true
+chrono.workspace = true

--- a/crates/tasks-client/src/lib.rs
+++ b/crates/tasks-client/src/lib.rs
@@ -1,0 +1,413 @@
+//! Typed blocking client for the tasks HTTP API.
+//!
+//! Blocking on purpose: the API is loopback-only plain http, so calls are
+//! sub-millisecond and there is nothing to overlap — a GUI client runs them
+//! on its own worker threads (gpui's background executor) without dragging
+//! an async runtime into the app. Streams ([`Client::stream_events`] and
+//! friends) block their thread between frames; give each one a dedicated
+//! thread.
+//!
+//! Types come from `tasks-api` — the same definitions the server serializes,
+//! so there is no hand-mirrored wire layer and version skew is a build error.
+
+mod sse;
+
+pub use sse::{EventStream, EventStreamItem, OrchestratorFeed, TranscriptTail};
+pub use tasks_api as api;
+
+use std::time::Duration;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tasks_api::events::Event;
+use tasks_api::http::{
+    BriefingStatus, BuildDetail, BuildRequest, CreateProject, ErrorResponse, ModeResponse,
+    ReorderQueue, ReorderSpecQueue, ReviewRequest, SendMessage, SetMode,
+};
+use tasks_api::models::{
+    Build, BuildId, Mode, OrchestratorMessage, OrchestratorSessionInfo, Project, Session,
+    SessionId, Spec, SpecId, SpecQueueItem, SpecQueueStatus, Task, TaskId, TranscriptLine,
+};
+use thiserror::Error;
+
+/// The server's default port (`TASKS_SERVER_PORT`).
+pub const DEFAULT_PORT: u16 = 4800;
+
+/// Overall budget for one API call. Loopback answers in microseconds; a call
+/// that takes seconds means the server is wedged, and hanging a GUI worker
+/// on it helps nobody.
+const CALL_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Read timeout for SSE streams. The server sends a keep-alive comment every
+/// 15s, so 60s of silence means the connection is dead, not idle.
+const STREAM_READ_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    /// The server answered non-2xx; `message` is its `{"error"}` body.
+    #[error("api error ({status}): {message}")]
+    Api { status: u16, message: String },
+    /// The request never got an HTTP answer (refused, reset, timed out).
+    #[error("transport: {0}")]
+    Transport(String),
+    /// The response body didn't parse as the expected type — a version-skewed
+    /// server, given that both ends ship these types from one repo.
+    #[error("decode: {0}")]
+    Decode(#[from] serde_json::Error),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl ClientError {
+    /// Errors that retrying the same request cannot fix (the server answered
+    /// and said no). Streams stop on these instead of reconnect-looping.
+    fn is_terminal(&self) -> bool {
+        matches!(self, ClientError::Api { .. })
+    }
+}
+
+pub type Result<T, E = ClientError> = std::result::Result<T, E>;
+
+fn map_ureq(err: ureq::Error) -> ClientError {
+    match err {
+        ureq::Error::Status(status, response) => {
+            let body = response.into_string().unwrap_or_default();
+            let message = serde_json::from_str::<ErrorResponse>(&body)
+                .map(|e| e.error)
+                .unwrap_or(body);
+            ClientError::Api { status, message }
+        }
+        ureq::Error::Transport(transport) => ClientError::Transport(transport.to_string()),
+    }
+}
+
+/// A handle on one tasks server. Cheap to clone (the connection pools are
+/// shared); all methods are blocking.
+#[derive(Clone)]
+pub struct Client {
+    base: String,
+    /// Agent for plain calls, with an overall timeout.
+    calls: ureq::Agent,
+    /// Agent for SSE streams: no overall timeout (streams are open-ended),
+    /// read timeout tuned to the server's keep-alive cadence.
+    pub(crate) streams: ureq::Agent,
+}
+
+impl Client {
+    pub fn new(port: u16) -> Self {
+        Self::with_base(format!("http://127.0.0.1:{port}"))
+    }
+
+    /// Base URL like `http://127.0.0.1:4800` (trailing slashes tolerated).
+    pub fn with_base(base: impl Into<String>) -> Self {
+        let mut base = base.into();
+        while base.ends_with('/') {
+            base.pop();
+        }
+        Self {
+            base,
+            calls: ureq::AgentBuilder::new().timeout(CALL_TIMEOUT).build(),
+            streams: ureq::AgentBuilder::new()
+                .timeout_read(STREAM_READ_TIMEOUT)
+                .build(),
+        }
+    }
+
+    /// Port from `TASKS_SERVER_PORT` — the same variable the server reads —
+    /// falling back to [`DEFAULT_PORT`].
+    pub fn from_env() -> Self {
+        let port = std::env::var("TASKS_SERVER_PORT")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(DEFAULT_PORT);
+        Self::new(port)
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base
+    }
+
+    pub(crate) fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base)
+    }
+
+    // --- plumbing ---
+
+    fn get_json<T: DeserializeOwned>(&self, path: &str, query: &[(&str, String)]) -> Result<T> {
+        let mut request = self.calls.get(&self.url(path));
+        for (key, value) in query {
+            request = request.query(key, value);
+        }
+        Ok(request.call().map_err(map_ureq)?.into_json()?)
+    }
+
+    fn post_json<B: Serialize, T: DeserializeOwned>(&self, path: &str, body: &B) -> Result<T> {
+        Ok(self
+            .calls
+            .post(&self.url(path))
+            .send_json(body)
+            .map_err(map_ureq)?
+            .into_json()?)
+    }
+
+    fn post_empty<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        Ok(self
+            .calls
+            .post(&self.url(path))
+            .call()
+            .map_err(map_ureq)?
+            .into_json()?)
+    }
+
+    // --- projects ---
+
+    pub fn projects(&self) -> Result<Vec<Project>> {
+        self.get_json("/projects", &[])
+    }
+
+    pub fn create_project(
+        &self,
+        repo_owner: impl Into<String>,
+        repo_name: impl Into<String>,
+    ) -> Result<Project> {
+        self.post_json(
+            "/projects",
+            &CreateProject {
+                repo_owner: repo_owner.into(),
+                repo_name: repo_name.into(),
+            },
+        )
+    }
+
+    // --- tasks ---
+
+    /// The working set, in queue order (closed-intake noise hidden).
+    pub fn tasks(&self) -> Result<Vec<Task>> {
+        self.get_json("/tasks", &[])
+    }
+
+    /// Every row, including retired-behind-closed-issue ones.
+    pub fn all_tasks(&self) -> Result<Vec<Task>> {
+        self.get_json("/tasks", &[("all", "true".into())])
+    }
+
+    /// Serves retired tasks too — the title lookup for old builds.
+    pub fn task(&self, id: &TaskId) -> Result<Task> {
+        self.get_json(&format!("/tasks/{id}"), &[])
+    }
+
+    pub fn queue_task(&self, id: &TaskId) -> Result<Task> {
+        self.post_empty(&format!("/tasks/{id}/queue"))
+    }
+
+    pub fn dequeue_task(&self, id: &TaskId) -> Result<Task> {
+        self.post_empty(&format!("/tasks/{id}/dequeue"))
+    }
+
+    /// "Scout now": queue at the front; the dispatch loop picks it up.
+    pub fn scout_task_now(&self, id: &TaskId) -> Result<Task> {
+        self.post_empty(&format!("/tasks/{id}/scout"))
+    }
+
+    /// `task_ids` is the complete queue order, front to back. Returns the
+    /// same projection as [`Client::tasks`] — apply it in place of the list.
+    pub fn reorder_queue(&self, task_ids: Vec<TaskId>) -> Result<Vec<Task>> {
+        self.post_json("/queue/reorder", &ReorderQueue { task_ids })
+    }
+
+    // --- sessions & transcripts ---
+
+    pub fn sessions(&self) -> Result<Vec<Session>> {
+        self.get_json("/sessions", &[])
+    }
+
+    pub fn session(&self, id: &SessionId) -> Result<Session> {
+        self.get_json(&format!("/sessions/{id}"), &[])
+    }
+
+    /// Catch-up read. `since` is inclusive — a tailing caller passes
+    /// `last_seq + 1`. Prefer [`Client::stream_transcript`] for live tails.
+    pub fn transcript(
+        &self,
+        id: &SessionId,
+        since: Option<i64>,
+        limit: Option<i64>,
+    ) -> Result<Vec<TranscriptLine>> {
+        let mut query = Vec::new();
+        if let Some(since) = since {
+            query.push(("since", since.to_string()));
+        }
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        self.get_json(&format!("/sessions/{id}/transcript"), &query)
+    }
+
+    // --- specs & the review queue ---
+
+    pub fn specs(&self) -> Result<Vec<Spec>> {
+        self.get_json("/specs", &[])
+    }
+
+    pub fn spec(&self, id: &SpecId) -> Result<Spec> {
+        self.get_json(&format!("/specs/{id}"), &[])
+    }
+
+    pub fn spec_queue(&self) -> Result<Vec<SpecQueueItem>> {
+        self.get_json("/spec-queue", &[])
+    }
+
+    pub fn reorder_spec_queue(&self, spec_ids: Vec<SpecId>) -> Result<Vec<SpecQueueItem>> {
+        self.post_json("/spec-queue/reorder", &ReorderSpecQueue { spec_ids })
+    }
+
+    /// Render a verdict. The server accepts `Approved`, `NeedsRevision`
+    /// (feedback is what the re-scout sees) and `Rejected`; anything else is
+    /// its 400, not ours.
+    pub fn review_spec(
+        &self,
+        id: &SpecId,
+        verdict: SpecQueueStatus,
+        feedback: Option<String>,
+    ) -> Result<SpecQueueItem> {
+        self.post_json(
+            &format!("/spec-queue/{id}/review"),
+            &ReviewRequest {
+                status: verdict.as_str().to_string(),
+                feedback,
+            },
+        )
+    }
+
+    // --- builds ---
+
+    /// Newest first.
+    pub fn builds(&self) -> Result<Vec<Build>> {
+        self.get_json("/builds", &[])
+    }
+
+    /// The build joined with its batch's spec ids, in position order.
+    pub fn build(&self, id: &BuildId) -> Result<BuildDetail> {
+        self.get_json(&format!("/builds/{id}"), &[])
+    }
+
+    /// 202: queued, not started — builds are serial. Watch `build_started` /
+    /// `build_completed` events. `base_branch` defaults to `main`.
+    pub fn request_build(
+        &self,
+        spec_ids: Vec<SpecId>,
+        base_branch: Option<String>,
+    ) -> Result<BuildDetail> {
+        self.post_json(
+            "/builds",
+            &BuildRequest {
+                spec_ids,
+                base_branch,
+            },
+        )
+    }
+
+    // --- mode ---
+
+    pub fn mode(&self) -> Result<Mode> {
+        let response: ModeResponse = self.get_json("/mode", &[])?;
+        Ok(response.mode)
+    }
+
+    /// Mode gates *new* work only — pausing never interrupts a running scout.
+    pub fn set_mode(&self, mode: Mode) -> Result<Mode> {
+        let response: ModeResponse = self.post_json(
+            "/mode",
+            &SetMode {
+                mode: mode.as_str().to_string(),
+            },
+        )?;
+        Ok(response.mode)
+    }
+
+    // --- briefings ---
+
+    /// Stale-while-revalidate: this read *is* the regeneration demand signal.
+    /// Refetch on `briefing_updated` events; never poll on a timer.
+    pub fn briefings(&self) -> Result<Vec<BriefingStatus>> {
+        self.get_json("/briefings", &[])
+    }
+
+    // --- events ---
+
+    /// Catch-up read of the event log. With `since` (inclusive), forward from
+    /// that seq; without it, the newest `limit` (server default 100).
+    pub fn events(&self, since: Option<i64>, limit: Option<i64>) -> Result<Vec<Event>> {
+        let mut query = Vec::new();
+        if let Some(since) = since {
+            query.push(("since", since.to_string()));
+        }
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        self.get_json("/events", &query)
+    }
+
+    // --- orchestrator ---
+
+    /// Messages with `seq > since`.
+    pub fn orchestrator_messages(&self, since: i64) -> Result<Vec<OrchestratorMessage>> {
+        self.get_json("/orchestrator/messages", &[("since", since.to_string())])
+    }
+
+    /// 202: the reply arrives asynchronously — watch `orchestrator_message`
+    /// events (or [`Client::stream_orchestrator`] for the live feed).
+    pub fn send_orchestrator_message(
+        &self,
+        content: impl Into<String>,
+    ) -> Result<OrchestratorMessage> {
+        self.post_json(
+            "/orchestrator/messages",
+            &SendMessage {
+                content: content.into(),
+            },
+        )
+    }
+
+    pub fn orchestrator_session(&self) -> Result<OrchestratorSessionInfo> {
+        self.get_json("/orchestrator/session", &[])
+    }
+
+    /// Claim the interactive checkout. Re-POST at least every 5 minutes to
+    /// keep the heartbeat fresh; 409 when no CC session exists yet.
+    pub fn checkout_orchestrator_session(&self) -> Result<OrchestratorSessionInfo> {
+        self.post_empty("/orchestrator/session/checkout")
+    }
+
+    /// Idempotent.
+    pub fn release_orchestrator_session(&self) -> Result<OrchestratorSessionInfo> {
+        self.post_empty("/orchestrator/session/release")
+    }
+
+    // --- streams ---
+
+    /// The invalidation feed. The iterator connects on first `next()`,
+    /// reconnects with a delay after drops, and never ends (unless the
+    /// server answers with an HTTP error — that's terminal). The contract:
+    /// on every [`EventStreamItem::Connected`], snapshot the lists you care
+    /// about — it fires *before* any event from the new connection, so
+    /// nothing that happened while disconnected can slip between.
+    pub fn stream_events(&self) -> EventStream {
+        EventStream::new(self.clone())
+    }
+
+    /// Live tail of a session's transcript, gapless: the server replays from
+    /// `since` (inclusive) before going live, and reconnects resume from the
+    /// last delivered seq. Ends only on a terminal (HTTP) error — the caller
+    /// decides when a completed session's tail is no longer worth holding.
+    pub fn stream_transcript(&self, id: &SessionId, since: i64) -> TranscriptTail {
+        TranscriptTail::new(self.clone(), id.clone(), since)
+    }
+
+    /// The in-flight orchestrator tick (deltas, tool labels, done).
+    /// Ephemeral: no backfill exists, so after a drop just resync the
+    /// durable state via [`Client::orchestrator_messages`].
+    pub fn stream_orchestrator(&self) -> OrchestratorFeed {
+        OrchestratorFeed::new(self.clone())
+    }
+}

--- a/crates/tasks-client/src/sse.rs
+++ b/crates/tasks-client/src/sse.rs
@@ -1,0 +1,318 @@
+//! Blocking SSE readers with reconnection built in.
+//!
+//! The server emits bare single-line `data: <json>` frames (no `event:`
+//! names, no `id:` fields, no `Last-Event-ID` replay) plus keep-alive
+//! comments. Each iterator here owns one connection, blocks its thread
+//! between frames, and on a transport drop sleeps and reconnects on the
+//! next `next()` call. HTTP-level errors are terminal: the server answered
+//! and said no, so the iterator yields the error once and then ends.
+
+use std::io::{BufRead, BufReader, Read};
+use std::thread;
+use std::time::Duration;
+
+use tasks_api::events::Event;
+use tasks_api::models::{OrchestratorFeedEvent, SessionId, TranscriptLine};
+
+use crate::{Client, ClientError, Result, map_ureq};
+
+/// Pause before each reconnection attempt (the first connect is immediate).
+const RECONNECT_DELAY: Duration = Duration::from_secs(3);
+
+type Body = BufReader<Box<dyn Read + Send + Sync + 'static>>;
+
+/// One SSE connection's frame reader.
+struct Frames {
+    body: Body,
+}
+
+impl Frames {
+    fn open(client: &Client, path_and_query: &str) -> Result<Self> {
+        let response = client
+            .streams
+            .get(&client.url(path_and_query))
+            .call()
+            .map_err(map_ureq)?;
+        Ok(Self {
+            body: BufReader::new(Box::new(response.into_reader())),
+        })
+    }
+
+    /// The next frame's `data` payload. Accumulates multi-line `data:`
+    /// fields per the SSE spec (the server sends single lines today);
+    /// comments and other fields are skipped. `None` means EOF.
+    fn next_data(&mut self) -> std::io::Result<Option<String>> {
+        let mut data: Option<String> = None;
+        let mut line = String::new();
+        loop {
+            line.clear();
+            if self.body.read_line(&mut line)? == 0 {
+                return Ok(None);
+            }
+            let trimmed = line.trim_end_matches(['\r', '\n']);
+            if trimmed.is_empty() {
+                // Frame boundary. Dataless frames (keep-alives) don't count.
+                if data.is_some() {
+                    return Ok(data);
+                }
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix("data:") {
+                let rest = rest.strip_prefix(' ').unwrap_or(rest);
+                match &mut data {
+                    Some(data) => {
+                        data.push('\n');
+                        data.push_str(rest);
+                    }
+                    None => data = Some(rest.to_string()),
+                }
+            }
+        }
+    }
+}
+
+/// Connection state shared by the three stream iterators.
+enum Link {
+    /// Never connected, or told to reconnect immediately (first attempt).
+    Start,
+    Up(Frames),
+    /// Dropped; the next attempt sleeps [`RECONNECT_DELAY`] first.
+    Down,
+    /// A terminal error was yielded; the iterator is over.
+    Ended,
+}
+
+impl Link {
+    /// Drive toward `Up`, sleeping first when reconnecting. `Ok(frames)` to
+    /// read from; `Err` when this attempt failed (state already updated).
+    fn connect(&mut self, client: &Client, path_and_query: &str) -> Result<&mut Frames> {
+        if matches!(self, Link::Down) {
+            thread::sleep(RECONNECT_DELAY);
+        }
+        match Frames::open(client, path_and_query) {
+            Ok(frames) => {
+                *self = Link::Up(frames);
+                match self {
+                    Link::Up(frames) => Ok(frames),
+                    _ => unreachable!(),
+                }
+            }
+            Err(err) => {
+                *self = if err.is_terminal() {
+                    Link::Ended
+                } else {
+                    Link::Down
+                };
+                Err(err)
+            }
+        }
+    }
+}
+
+/// What [`EventStream`] yields.
+#[derive(Debug)]
+pub enum EventStreamItem {
+    /// The stream (re)connected. Snapshot state now: this fires before any
+    /// event from the new connection, so everything that happened while
+    /// disconnected is reflected in fetches made after it.
+    Connected,
+    /// Something happened. Events are invalidation signals — refetch the
+    /// entity, don't fold the payload into state.
+    Event(Event),
+    /// The connection dropped; the iterator sleeps and retries on the next
+    /// `next()`. Terminal errors end the iterator after this item.
+    Disconnected(ClientError),
+}
+
+/// Reconnecting iterator over `GET /events/stream`. Never ends except on a
+/// terminal (HTTP-level) error.
+pub struct EventStream {
+    client: Client,
+    link: Link,
+    last_seq: i64,
+}
+
+impl EventStream {
+    pub(crate) fn new(client: Client) -> Self {
+        Self {
+            client,
+            link: Link::Start,
+            last_seq: 0,
+        }
+    }
+
+    /// Highest event seq delivered so far (0 before the first event) — the
+    /// cursor for a `GET /events?since=` catch-up read, should the caller
+    /// want gapless history rather than snapshot-on-`Connected`.
+    pub fn last_seq(&self) -> i64 {
+        self.last_seq
+    }
+}
+
+impl Iterator for EventStream {
+    type Item = EventStreamItem;
+
+    fn next(&mut self) -> Option<EventStreamItem> {
+        loop {
+            match &mut self.link {
+                Link::Ended => return None,
+                Link::Start | Link::Down => {
+                    match self.link.connect(&self.client, "/events/stream") {
+                        Ok(_) => return Some(EventStreamItem::Connected),
+                        Err(err) => return Some(EventStreamItem::Disconnected(err)),
+                    }
+                }
+                Link::Up(frames) => match frames.next_data() {
+                    Ok(Some(data)) => match serde_json::from_str::<Event>(&data) {
+                        Ok(event) => {
+                            // The live broadcast never replays, so a seq at
+                            // or below the high water is a reconnect echo.
+                            if event.seq <= self.last_seq {
+                                continue;
+                            }
+                            self.last_seq = event.seq;
+                            return Some(EventStreamItem::Event(event));
+                        }
+                        Err(err) => {
+                            self.link = Link::Down;
+                            return Some(EventStreamItem::Disconnected(err.into()));
+                        }
+                    },
+                    Ok(None) => {
+                        self.link = Link::Down;
+                        return Some(EventStreamItem::Disconnected(ClientError::Transport(
+                            "event stream closed".into(),
+                        )));
+                    }
+                    Err(err) => {
+                        self.link = Link::Down;
+                        return Some(EventStreamItem::Disconnected(err.into()));
+                    }
+                },
+            }
+        }
+    }
+}
+
+/// Gapless live tail of one session's transcript: the server replays from
+/// `since` before going live, and every reconnect resumes from the last
+/// delivered seq, so nothing is skipped. Yields `Err` on drops (the caller's
+/// "connection lost" signal) and keeps going; ends on terminal errors.
+pub struct TranscriptTail {
+    client: Client,
+    session_id: SessionId,
+    /// Next seq to ask for — last delivered + 1 (`since` is inclusive).
+    next_since: i64,
+    link: Link,
+}
+
+impl TranscriptTail {
+    pub(crate) fn new(client: Client, session_id: SessionId, since: i64) -> Self {
+        Self {
+            client,
+            session_id,
+            next_since: since,
+            link: Link::Start,
+        }
+    }
+}
+
+impl Iterator for TranscriptTail {
+    type Item = Result<TranscriptLine>;
+
+    fn next(&mut self) -> Option<Result<TranscriptLine>> {
+        loop {
+            match &mut self.link {
+                Link::Ended => return None,
+                Link::Start | Link::Down => {
+                    let path = format!(
+                        "/sessions/{}/transcript/stream?since={}",
+                        self.session_id, self.next_since
+                    );
+                    if let Err(err) = self.link.connect(&self.client, &path) {
+                        return Some(Err(err));
+                    }
+                    // Connected: the replay arrives as ordinary frames.
+                    continue;
+                }
+                Link::Up(frames) => match frames.next_data() {
+                    Ok(Some(data)) => match serde_json::from_str::<TranscriptLine>(&data) {
+                        Ok(line) => {
+                            self.next_since = line.seq + 1;
+                            return Some(Ok(line));
+                        }
+                        Err(err) => {
+                            self.link = Link::Down;
+                            return Some(Err(err.into()));
+                        }
+                    },
+                    Ok(None) => {
+                        self.link = Link::Down;
+                        return Some(Err(ClientError::Transport(
+                            "transcript stream closed".into(),
+                        )));
+                    }
+                    Err(err) => {
+                        self.link = Link::Down;
+                        return Some(Err(err.into()));
+                    }
+                },
+            }
+        }
+    }
+}
+
+/// Reconnecting iterator over the ephemeral orchestrator feed. There is no
+/// backfill: after an `Err`, resync durable state via
+/// `GET /orchestrator/messages` — whatever deltas were missed are already
+/// part of a finished message there.
+pub struct OrchestratorFeed {
+    client: Client,
+    link: Link,
+}
+
+impl OrchestratorFeed {
+    pub(crate) fn new(client: Client) -> Self {
+        Self {
+            client,
+            link: Link::Start,
+        }
+    }
+}
+
+impl Iterator for OrchestratorFeed {
+    type Item = Result<OrchestratorFeedEvent>;
+
+    fn next(&mut self) -> Option<Result<OrchestratorFeedEvent>> {
+        loop {
+            match &mut self.link {
+                Link::Ended => return None,
+                Link::Start | Link::Down => {
+                    if let Err(err) = self.link.connect(&self.client, "/orchestrator/stream") {
+                        return Some(Err(err));
+                    }
+                    continue;
+                }
+                Link::Up(frames) => match frames.next_data() {
+                    Ok(Some(data)) => match serde_json::from_str::<OrchestratorFeedEvent>(&data) {
+                        Ok(event) => return Some(Ok(event)),
+                        Err(err) => {
+                            self.link = Link::Down;
+                            return Some(Err(err.into()));
+                        }
+                    },
+                    Ok(None) => {
+                        self.link = Link::Down;
+                        return Some(Err(ClientError::Transport(
+                            "orchestrator stream closed".into(),
+                        )));
+                    }
+                    Err(err) => {
+                        self.link = Link::Down;
+                        return Some(Err(err.into()));
+                    }
+                },
+            }
+        }
+    }
+}

--- a/crates/tasks-client/tests/client.rs
+++ b/crates/tasks-client/tests/client.rs
@@ -1,0 +1,252 @@
+//! Integration tests against the real server: real router, real in-memory
+//! SQLite store, real TCP on an OS-assigned port (repo convention — no
+//! mocks). The async server runs on a tokio runtime held by the test; the
+//! blocking client calls it from the test thread like any GUI worker would.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use tasks::server::router;
+use tasks::store::Store;
+use tasks_api::events::EventPayload;
+use tasks_api::models::{
+    GhState, Mode, Project, Session, SessionId, SessionStatus, Task, TaskId, TaskState,
+    TranscriptStream,
+};
+use tasks_client::{Client, ClientError, EventStreamItem};
+
+struct TestServer {
+    client: Client,
+    store: Arc<Store>,
+    /// Keeps the server's executor alive for the test's duration.
+    runtime: tokio::runtime::Runtime,
+}
+
+fn spawn_server() -> TestServer {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let (store, addr) = runtime.block_on(async {
+        let store = Arc::new(Store::open_in_memory().await.unwrap());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let serve_store = store.clone();
+        tokio::spawn(async move {
+            axum::serve(listener, router(serve_store)).await.unwrap();
+        });
+        (store, addr)
+    });
+    TestServer {
+        client: Client::with_base(format!("http://{addr}")),
+        store,
+        runtime,
+    }
+}
+
+impl TestServer {
+    fn seed_task(&self, project: &Project, number: u64) -> Task {
+        let now = Utc::now();
+        let task = Task {
+            id: TaskId::new(),
+            project_id: project.id.clone(),
+            gh_issue_number: number,
+            title: format!("task {number}"),
+            body: "body".into(),
+            labels: vec![],
+            gh_state: GhState::Open,
+            state: TaskState::Backlog,
+            priority: 0,
+            manual_rank: None,
+            dispatch_attempts: 0,
+            ingested_at: now,
+            updated_at: now,
+        };
+        self.runtime
+            .block_on(self.store.insert_task(&task))
+            .unwrap();
+        task
+    }
+}
+
+#[test]
+fn projects_round_trip() {
+    let server = spawn_server();
+    let created = server.client.create_project("iamnbutler", "tasks").unwrap();
+    assert_eq!(created.repo_owner, "iamnbutler");
+
+    let listed = server.client.projects().unwrap();
+    assert_eq!(listed, vec![created]);
+}
+
+#[test]
+fn api_errors_carry_the_servers_message() {
+    let server = spawn_server();
+
+    // 404 with the server's own phrasing.
+    let err = server
+        .client
+        .task(&TaskId::from_raw("task_missing"))
+        .unwrap_err();
+    match err {
+        ClientError::Api { status, message } => {
+            assert_eq!(status, 404);
+            assert!(message.contains("task_missing"), "message: {message}");
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+
+    // 400: validation text comes through the {"error"} body.
+    let err = server.client.create_project("", "").unwrap_err();
+    match err {
+        ClientError::Api { status, message } => {
+            assert_eq!(status, 400);
+            assert!(message.contains("non-empty"), "message: {message}");
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+}
+
+#[test]
+fn queue_flow_round_trips_typed_states() {
+    let server = spawn_server();
+    let project = server.client.create_project("iamnbutler", "tasks").unwrap();
+    let task = server.seed_task(&project, 7);
+
+    let queued = server.client.queue_task(&task.id).unwrap();
+    assert_eq!(queued.state, TaskState::Queued);
+    assert_eq!(queued.manual_rank, Some(1));
+
+    let reordered = server.client.reorder_queue(vec![task.id.clone()]).unwrap();
+    assert_eq!(reordered.len(), 1);
+
+    let back = server.client.dequeue_task(&task.id).unwrap();
+    assert_eq!(back.state, TaskState::Backlog);
+    assert_eq!(back.manual_rank, None);
+}
+
+#[test]
+fn mode_round_trip() {
+    let server = spawn_server();
+    // A fresh store starts paused — going live is a human decision.
+    assert_eq!(server.client.mode().unwrap(), Mode::Pause);
+    assert_eq!(server.client.set_mode(Mode::Play).unwrap(), Mode::Play);
+    assert_eq!(server.client.mode().unwrap(), Mode::Play);
+}
+
+#[test]
+fn event_stream_connects_then_delivers_typed_events() {
+    let server = spawn_server();
+    let mut stream = server.client.stream_events();
+
+    // Connected fires before any event from the connection — the signal to
+    // snapshot. It must arrive before we cause the first event.
+    match stream.next() {
+        Some(EventStreamItem::Connected) => {}
+        other => panic!("expected Connected first, got {other:?}"),
+    }
+
+    let project = server.client.create_project("iamnbutler", "tasks").unwrap();
+
+    match stream.next() {
+        Some(EventStreamItem::Event(event)) => {
+            assert!(event.seq > 0);
+            match event.payload {
+                EventPayload::ProjectAdded { project_id } => {
+                    assert_eq!(project_id, project.id);
+                }
+                other => panic!("expected project_added, got {other:?}"),
+            }
+            assert_eq!(stream.last_seq(), event.seq);
+        }
+        other => panic!("expected the project_added event, got {other:?}"),
+    }
+}
+
+#[test]
+fn transcript_tail_replays_then_follows() {
+    let server = spawn_server();
+    let project = server.client.create_project("iamnbutler", "tasks").unwrap();
+    let task = server.seed_task(&project, 9);
+
+    let session = Session {
+        id: SessionId::new(),
+        task_id: task.id.clone(),
+        vm_id: None,
+        branch: "scout/9".into(),
+        status: SessionStatus::Running,
+        started_at: Utc::now(),
+        completed_at: None,
+        exit_reason: None,
+        usage: None,
+    };
+    server
+        .runtime
+        .block_on(server.store.insert_session(&session))
+        .unwrap();
+    server
+        .runtime
+        .block_on(server.store.append_transcript_lines(
+            &session.id,
+            &[
+                (TranscriptStream::Stdout, "first".into()),
+                (TranscriptStream::Stderr, "second".into()),
+            ],
+        ))
+        .unwrap();
+
+    let mut tail = server.client.stream_transcript(&session.id, 0);
+
+    // Replay: the two persisted lines, in order, typed.
+    let first = tail.next().unwrap().unwrap();
+    assert_eq!((first.seq, first.line.as_str()), (1, "first"));
+    assert_eq!(first.stream, TranscriptStream::Stdout);
+    let second = tail.next().unwrap().unwrap();
+    assert_eq!((second.seq, second.line.as_str()), (2, "second"));
+    assert_eq!(second.stream, TranscriptStream::Stderr);
+
+    // Live: a line appended after the tail attached still arrives.
+    server
+        .runtime
+        .block_on(
+            server.store.append_transcript_lines(
+                &session.id,
+                &[(TranscriptStream::Stdout, "third".into())],
+            ),
+        )
+        .unwrap();
+    let third = tail.next().unwrap().unwrap();
+    assert_eq!((third.seq, third.line.as_str()), (3, "third"));
+}
+
+#[test]
+fn transcript_stream_for_unknown_session_is_terminal() {
+    let server = spawn_server();
+    let mut tail = server
+        .client
+        .stream_transcript(&SessionId::from_raw("sess_missing"), 0);
+
+    match tail.next() {
+        Some(Err(ClientError::Api { status, .. })) => assert_eq!(status, 404),
+        other => panic!("expected a 404, got {other:?}"),
+    }
+    // Terminal: the iterator ends instead of reconnect-looping on a 404.
+    assert!(tail.next().is_none());
+}
+
+#[test]
+fn orchestrator_message_send_and_list() {
+    let server = spawn_server();
+    let sent = server
+        .client
+        .send_orchestrator_message("hello orchestrator")
+        .unwrap();
+    assert_eq!(sent.content, "hello orchestrator");
+
+    let listed = server.client.orchestrator_messages(0).unwrap();
+    assert_eq!(listed, vec![sent]);
+
+    let empty = server.client.send_orchestrator_message("   ").unwrap_err();
+    assert!(matches!(empty, ClientError::Api { status: 400, .. }));
+}


### PR DESCRIPTION
Stacked on #806. The second piece toward the gpui client: `crates/tasks-client`.

## What

- **Every endpoint, typed** — all the routes over the `tasks-api` shapes (`review_spec` takes a real `SpecQueueStatus`, `mode`/`set_mode` unwrap `ModeResponse`, `build()` returns `BuildDetail` with its `spec_ids`). `ClientError::Api` carries the server's `{"error"}` message.
- **SSE as blocking iterators with the contract baked in**:
  - `stream_events()` → `Connected` / `Event` / `Disconnected` items. `Connected` fires before any event from the new connection, so a consumer that snapshots on every `Connected` and treats events as invalidation signals can never miss state — no `?since=` replay bookkeeping needed.
  - `stream_transcript()` is gapless: server-side replay from `?since=`, reconnects resume from the last delivered seq.
  - `stream_orchestrator()` is the ephemeral tick feed; consumers resync via `/orchestrator/messages` after drops.
  - Transport errors reconnect with a 3s delay; HTTP errors are terminal (the server answered and said no — a 404'd session tail ends instead of hammering).
- **Blocking by design** (`ureq`, `default-features = false`, no TLS): the API is loopback-only plain http, so the gpui app can run calls on its background executor without embedding a tokio runtime. Streams each expect a dedicated thread; read timeout is 60s against the server's 15s keep-alives so dead links get noticed.

## Verification

8 integration tests per repo convention — real router, real in-memory SQLite, real TCP on `127.0.0.1:0`, no mocks: round-trips for projects/queue/mode/orchestrator messages, error-body mapping (404 + 400), the Connected-before-events ordering, transcript replay→live tailing, and terminal-404 stream behavior. `cargo test --workspace` green, fmt + clippy clean.

One behavior surfaced while testing: a fresh store's mode defaults to **pause**, not play — the test now documents that (going live is a human decision).