### PR TITLE
app-gpui: live server data via tasks-client

### DIFF
--- a/app-gpui/Cargo.toml
+++ b/app-gpui/Cargo.toml
@@ -13,3 +13,8 @@ smallvec = "1"
 # The server's wire types (models, events, request/response bodies) — the
 # whole point of living in this repo. Path dep so type changes are atomic.
 tasks-api = { path = "../crates/tasks-api" }
+tasks-client = { path = "../crates/tasks-client" }
+# Bridges the client's blocking streams/calls into gpui: unbounded channel
+# from the SSE thread, StreamExt::next on the foreground executor.
+futures = "0.3"
+chrono = "0.4"

--- a/app-gpui/README.md
+++ b/app-gpui/README.md
@@ -2,32 +2,54 @@
 
 The gpui port of the Tasks app (`tasks/app`, the Swift client). Built on
 [gpui-unofficial](https://github.com/iamnbutler/gpui-unofficial) 1.14.2 and
-[gpuikit](https://github.com/iamnbutler/gpuikit) 0.5.0.
+[gpuikit](https://github.com/iamnbutler/gpuikit), talking to the tasks
+server through the workspace's own crates: `tasks-api` (shared wire types)
+and `tasks-client` (typed blocking client + reconnecting SSE streams).
 
 ## Architecture
 
 Follows Zed's workspace patterns (Zed is the source of truth for how
 components are built and how data moves):
 
-- **`workspace.rs`** — the root view. Owns all UI state (active section,
-  per-sidebar open/width, resize-drag tracking) and registers action
-  handlers. Actions: `workspace::ToggleLeftDock` (`cmd-b`),
-  `workspace::ToggleRightDock` (`cmd-r`, `cmd-alt-b`) — Zed's defaults.
+- **`state.rs`** — `AppState`, the server state entity (the Swift app's
+  `AppModel`). One dedicated thread runs the reconnecting event stream and
+  feeds a channel; a foreground task drains it. The sync contract is
+  snapshot-on-`Connected` + refetch-on-event — events are invalidation
+  signals, never folded into state. Snapshots and mutations run blocking
+  `tasks-client` calls on gpui's background executor (loopback is
+  sub-millisecond). Mutation failures surface the server's own error
+  message in the sidebar banner; the server stays the authority on which
+  transitions are legal.
+- **`workspace.rs`** — the root view. Owns UI state (active section,
+  per-sidebar open/width, selection, resize-drag tracking), observes
+  `AppState`, and registers action handlers. Actions:
+  `workspace::ToggleLeftDock` (`cmd-b`), `workspace::ToggleRightDock`
+  (`cmd-r`, `cmd-alt-b`) — Zed's defaults. Title bar carries play/pause
+  (mode gates *new* work only) and refresh.
+- **`sections/`** — one file per sidebar section (`impl Workspace` blocks):
+  Tasks (Linear-style rows → inspector), Queue (attention-ordered groups:
+  Needs you / Running / Building / Up next / Ready to build, with live
+  elapsed clocks — a clock reads as working, a spinner reads as hung),
+  Home (briefing slots + needs-you rows), Activity (typed event sentences —
+  exhaustive match, so a new event kind is a compile error), Chat
+  (orchestrator conversation, read-only so far), and `detail.rs` (the
+  inspector with per-state actions: queue/dequeue/scout, approve/reject).
 - **`components/`** — presentation-only chrome. Components never reach into
   workspace state; they talk back by dispatching actions (title bar toggle
   buttons) or via callbacks the workspace hands them (sidebar resize).
   - `titlebar.rs` — 28px fixed height, 1px bottom border, whole bar is a
     `WindowControlArea::Drag` region, double-click zooms, content inset past
-    the macOS traffic lights (Zed's 71px constant), left/center/right slots.
+    the macOS traffic lights, left/center/right slots.
   - `sidebar.rs` — dockable panel with a drag-to-resize handle on its inner
     edge. The handle only reports drag-start; the workspace tracks movement
     at the window level because the pointer outruns the handle immediately.
+  - `status_badge.rs` — the status→color vocabulary and capsule badges
+    (colored text on a 15% wash), matching the Swift app.
+
 Theming is gpuikit's system (`gpuikit::theme`): a `Themeable` trait contract
-accessed via `cx.theme()`, initialized with `gpuikit::theme::init`. We add
-to or override that theme as the port needs rather than keeping a parallel
-palette. Icons and the input stack (`InputState` + `text_area`) also come
-from gpuikit; SVG assets are served by
-`Application::with_assets(gpuikit::assets())`.
+accessed via `cx.theme()`, initialized with `gpuikit::theme::init`. Icons
+and the input stack (`InputState` + `text_area`) also come from gpuikit;
+SVG assets are served by `Application::with_assets(gpuikit::assets())`.
 
 ## Running
 
@@ -35,5 +57,7 @@ from gpuikit; SVG assets are served by
 cargo run
 ```
 
-Builds without the Xcode Metal toolchain (gpui-platform's `runtime_shaders`
-feature compiles shaders at runtime).
+Connects to `http://127.0.0.1:$TASKS_SERVER_PORT` (default 4800 — the same
+variable the server reads). Without a server it shows the connecting state
+and retries every 3s. Builds without the Xcode Metal toolchain
+(gpui-platform's `runtime_shaders` feature compiles shaders at runtime).

--- a/app-gpui/src/components/mod.rs
+++ b/app-gpui/src/components/mod.rs
@@ -1,7 +1,9 @@
 //! Reusable UI components for the Tasks app.
 
 mod sidebar;
+mod status_badge;
 mod titlebar;
 
 pub use sidebar::{sidebar, SidebarSide, SidebarState};
+pub use status_badge::{status_badge, task_state_color, title_case};
 pub use titlebar::title_bar;

--- a/app-gpui/src/components/status_badge.rs
+++ b/app-gpui/src/components/status_badge.rs
@@ -1,0 +1,50 @@
+//! Capsule status badges and the status→color vocabulary, matching the
+//! Swift app: colored text on the same color at 15% opacity.
+
+use gpui::prelude::*;
+use gpui::{div, hsla, px, Hsla};
+use tasks_client::api::models::TaskState;
+
+fn color(hue_degrees: f32, saturation: f32, lightness: f32) -> Hsla {
+    hsla(hue_degrees / 360., saturation, lightness, 1.)
+}
+
+pub fn task_state_color(state: TaskState) -> Hsla {
+    match state {
+        TaskState::Backlog => color(0., 0., 0.55),
+        TaskState::Queued => color(30., 0.90, 0.60),
+        TaskState::Scouting => color(210., 0.90, 0.62),
+        TaskState::InReview => color(280., 0.70, 0.68),
+        TaskState::ReadyToBuild => color(175., 0.60, 0.50),
+        TaskState::Building => color(240., 0.65, 0.68),
+        TaskState::Done => color(135., 0.55, 0.52),
+        TaskState::Rejected => color(0., 0.80, 0.62),
+    }
+}
+
+/// Human labels: `in_review` → "In Review".
+pub fn title_case(wire: &str) -> String {
+    wire.split('_')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().chain(chars).collect::<String>(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// A capsule badge: `label` in `color` on a 15%-opacity wash of it.
+pub fn status_badge(label: impl Into<String>, color: Hsla) -> impl IntoElement {
+    div()
+        .px(px(7.))
+        .py(px(1.))
+        .rounded_full()
+        .bg(color.opacity(0.15))
+        .text_color(color)
+        .text_xs()
+        .flex_none()
+        .child(label.into())
+}

--- a/app-gpui/src/main.rs
+++ b/app-gpui/src/main.rs
@@ -1,4 +1,7 @@
 mod components;
+mod sections;
+mod state;
+mod time;
 mod workspace;
 
 use gpui::{

--- a/app-gpui/src/sections/activity.rs
+++ b/app-gpui/src/sections/activity.rs
@@ -1,0 +1,136 @@
+//! The Activity section: the newest slice of the event log, newest first.
+//! Sentences are built from the typed `EventPayload` — exhaustive on
+//! purpose, so a new event kind is a compile error here, not a mystery row.
+
+use gpui::prelude::*;
+use gpui::{div, px, Context};
+use gpuikit::theme::{ActiveTheme, Themeable};
+use tasks_client::api::events::EventPayload;
+
+use crate::components::title_case;
+use crate::time;
+use crate::workspace::Workspace;
+
+impl Workspace {
+    pub(crate) fn render_activity(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme().clone();
+        let state = self.app_state.read(cx);
+
+        let title_for = |task_id: &tasks_client::api::models::TaskId| {
+            state
+                .task(task_id)
+                .map(|task| task.title.clone())
+                .unwrap_or_else(|| task_id.to_string())
+        };
+
+        let rows: Vec<(i64, String, String)> = state
+            .activity
+            .iter()
+            .map(|event| {
+                let sentence = match &event.payload {
+                    EventPayload::ProjectAdded { .. } => "Project added".to_string(),
+                    EventPayload::TaskIngested { task_id, .. } => {
+                        format!("Ingested “{}”", title_for(task_id))
+                    }
+                    EventPayload::TaskStateChanged { task_id, from, to } => format!(
+                        "“{}” moved {} → {}",
+                        title_for(task_id),
+                        title_case(from.as_str()),
+                        title_case(to.as_str())
+                    ),
+                    EventPayload::TaskGhStateChanged { task_id, gh_state } => format!(
+                        "GitHub issue for “{}” is now {}",
+                        title_for(task_id),
+                        gh_state.as_str()
+                    ),
+                    EventPayload::SessionStarted { task_id, .. } => {
+                        format!("Scout started on “{}”", title_for(task_id))
+                    }
+                    EventPayload::SessionCompleted {
+                        task_id, status, ..
+                    } => format!(
+                        "Scout {} on “{}”",
+                        title_case(status.as_str()).to_lowercase(),
+                        title_for(task_id)
+                    ),
+                    EventPayload::SpecCreated { task_id, .. } => {
+                        format!("Spec landed for “{}”", title_for(task_id))
+                    }
+                    EventPayload::SpecQueueStatusChanged { to, .. } => {
+                        format!("Spec review: {}", title_case(to.as_str()))
+                    }
+                    EventPayload::QueueReordered { task_ids } => {
+                        format!("Queue reordered ({} tasks)", task_ids.len())
+                    }
+                    EventPayload::SpecQueueReordered { spec_ids } => {
+                        format!("Spec queue reordered ({} specs)", spec_ids.len())
+                    }
+                    EventPayload::BuildRequested { spec_ids, .. } => {
+                        format!("Build requested over {} spec(s)", spec_ids.len())
+                    }
+                    EventPayload::BuildStarted { .. } => "Build started".to_string(),
+                    EventPayload::BuildCompleted { status, .. } => {
+                        format!("Build {}", status.as_str())
+                    }
+                    EventPayload::PullRequestOpened { pr_number, .. } => {
+                        format!("Opened PR #{pr_number}")
+                    }
+                    EventPayload::OrchestratorMessage { role, .. } => {
+                        format!("Orchestrator: {} turn", role.as_str())
+                    }
+                    EventPayload::ModeChanged { from, to } => {
+                        format!("Mode {} → {}", from.as_str(), to.as_str())
+                    }
+                    EventPayload::BriefingUpdated { section } => {
+                        format!("Briefing updated: {}", title_case(section.as_str()))
+                    }
+                    EventPayload::Note { source, message } => format!("[{source}] {message}"),
+                };
+                (event.seq, sentence, time::relative(event.timestamp))
+            })
+            .collect();
+
+        div()
+            .id("activity-list")
+            .flex()
+            .flex_col()
+            .size_full()
+            .overflow_y_scroll()
+            .py(px(4.))
+            .when(rows.is_empty() && state.loaded, |el| {
+                el.child(
+                    div()
+                        .p(px(16.))
+                        .text_sm()
+                        .text_color(theme.fg_muted())
+                        .child("Nothing has happened yet."),
+                )
+            })
+            .children(rows.into_iter().map(|(seq, sentence, when)| {
+                div()
+                    .id(seq as usize)
+                    .flex()
+                    .flex_row()
+                    .items_start()
+                    .gap(px(8.))
+                    .mx(px(6.))
+                    .px(px(10.))
+                    .py(px(4.))
+                    .child(
+                        div()
+                            .flex_1()
+                            .overflow_hidden()
+                            .text_sm()
+                            .text_color(theme.fg())
+                            .child(sentence),
+                    )
+                    .child(
+                        div()
+                            .flex_none()
+                            .text_xs()
+                            .text_color(theme.fg_muted())
+                            .child(when),
+                    )
+            }))
+    }
+}

--- a/app-gpui/src/sections/detail.rs
+++ b/app-gpui/src/sections/detail.rs
@@ -1,0 +1,332 @@
+//! The inspector: detail + actions for the selected task, rendered in the
+//! right sidebar. The server is the authority on which transitions are
+//! legal — buttons are offered by state, and a rejected action surfaces the
+//! server's own error message in the banner.
+
+use gpui::prelude::*;
+use gpui::{div, px, AnyElement, ClickEvent, Context, Hsla};
+use gpuikit::theme::{ActiveTheme, Themeable};
+use tasks_client::api::models::{Complexity, GhState, SpecId, SpecQueueStatus, TaskId, TaskState};
+
+use crate::components::{status_badge, task_state_color, title_case};
+use crate::time;
+use crate::workspace::Workspace;
+
+/// Owned projection of the selected task — extracted up front so no borrow
+/// of the app state entity is held while listeners are created.
+struct TaskView {
+    id: TaskId,
+    title: String,
+    number: u64,
+    state: TaskState,
+    gh_state: GhState,
+    labels: Vec<String>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    body: String,
+    github_url: Option<String>,
+    /// `(spec id, complexity, content)` when the task sits in review with a
+    /// pending verdict.
+    pending_spec: Option<(SpecId, Complexity, String)>,
+}
+
+impl Workspace {
+    /// Content for the right sidebar. Placeholder when nothing is selected.
+    pub(crate) fn render_inspector(&self, cx: &mut Context<Self>) -> AnyElement {
+        let view: Option<TaskView> = {
+            let state = self.app_state.read(cx);
+            self.selected_task
+                .as_ref()
+                .and_then(|id| state.task(id))
+                .map(|task| TaskView {
+                    id: task.id.clone(),
+                    title: task.title.clone(),
+                    number: task.gh_issue_number,
+                    state: task.state,
+                    gh_state: task.gh_state,
+                    labels: task.labels.clone(),
+                    updated_at: task.updated_at,
+                    body: task.body.clone(),
+                    github_url: state.project(task).map(|project| {
+                        format!(
+                            "https://github.com/{}/{}/issues/{}",
+                            project.repo_owner, project.repo_name, task.gh_issue_number
+                        )
+                    }),
+                    pending_spec: (task.state == TaskState::InReview)
+                        .then(|| state.latest_spec(&task.id))
+                        .flatten()
+                        .filter(|spec| {
+                            state.spec_queue.iter().any(|item| {
+                                item.entry.spec_id == spec.id
+                                    && item.entry.status == SpecQueueStatus::PendingReview
+                            })
+                        })
+                        .map(|spec| (spec.id.clone(), spec.complexity, spec.content.clone())),
+                })
+        };
+
+        let theme = cx.theme().clone();
+        let Some(task) = view else {
+            return div()
+                .p(px(12.))
+                .text_sm()
+                .text_color(theme.fg_muted())
+                .child("Select a task to inspect it.")
+                .into_any_element();
+        };
+
+        let mut pane = div()
+            .id("inspector-scroll")
+            .flex()
+            .flex_col()
+            .size_full()
+            .overflow_y_scroll()
+            .p(px(12.))
+            .gap(px(10.));
+
+        pane = pane.child(
+            div()
+                .flex()
+                .flex_row()
+                .items_start()
+                .gap(px(8.))
+                .child(
+                    div()
+                        .flex_1()
+                        .text_sm()
+                        .text_color(theme.fg())
+                        .child(task.title.clone()),
+                )
+                .child(
+                    div()
+                        .id("close-inspector")
+                        .flex_none()
+                        .cursor_pointer()
+                        .text_xs()
+                        .text_color(theme.fg_muted())
+                        .hover(|el| el.opacity(0.7))
+                        .on_click(cx.listener(|this, _event, _window, cx| {
+                            this.clear_selection(cx);
+                        }))
+                        .child("✕"),
+                ),
+        );
+
+        pane = pane.child(
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(6.))
+                .child(status_badge(
+                    title_case(task.state.as_str()),
+                    task_state_color(task.state),
+                ))
+                .child(status_badge(
+                    task.gh_state.as_str().to_string(),
+                    match task.gh_state {
+                        GhState::Open => gpui::hsla(135. / 360., 0.55, 0.52, 1.),
+                        GhState::Closed => gpui::hsla(280. / 360., 0.70, 0.68, 1.),
+                    },
+                ))
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(theme.fg_muted())
+                        .child(format!("#{}", task.number)),
+                )
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(theme.fg_muted())
+                        .child(format!("updated {}", time::relative(task.updated_at))),
+                ),
+        );
+
+        if !task.labels.is_empty() {
+            pane = pane.child(
+                div()
+                    .text_xs()
+                    .text_color(theme.fg_muted())
+                    .child(task.labels.join(", ")),
+            );
+        }
+
+        // Actions by state; the server enforces legality.
+        let mut actions = div().flex().flex_row().flex_wrap().gap(px(6.));
+        let mut any_action = false;
+        match task.state {
+            TaskState::Backlog => {
+                any_action = true;
+                actions = actions
+                    .child(self.action_button(
+                        "queue-task",
+                        "Add to Queue",
+                        None,
+                        cx.listener({
+                            let id = task.id.clone();
+                            move |this, _: &ClickEvent, _window, cx| {
+                                let id = id.clone();
+                                this.app_state
+                                    .update(cx, |state, cx| state.queue_task(id, cx));
+                            }
+                        }),
+                        cx,
+                    ))
+                    .child(self.action_button(
+                        "scout-task",
+                        "Scout Now",
+                        None,
+                        cx.listener({
+                            let id = task.id.clone();
+                            move |this, _: &ClickEvent, _window, cx| {
+                                let id = id.clone();
+                                this.app_state
+                                    .update(cx, |state, cx| state.scout_task_now(id, cx));
+                            }
+                        }),
+                        cx,
+                    ));
+            }
+            TaskState::Queued => {
+                any_action = true;
+                actions = actions
+                    .child(self.action_button(
+                        "scout-task",
+                        "Scout Now",
+                        None,
+                        cx.listener({
+                            let id = task.id.clone();
+                            move |this, _: &ClickEvent, _window, cx| {
+                                let id = id.clone();
+                                this.app_state
+                                    .update(cx, |state, cx| state.scout_task_now(id, cx));
+                            }
+                        }),
+                        cx,
+                    ))
+                    .child(self.action_button(
+                        "dequeue-task",
+                        "Remove from Queue",
+                        None,
+                        cx.listener({
+                            let id = task.id.clone();
+                            move |this, _: &ClickEvent, _window, cx| {
+                                let id = id.clone();
+                                this.app_state
+                                    .update(cx, |state, cx| state.dequeue_task(id, cx));
+                            }
+                        }),
+                        cx,
+                    ));
+            }
+            _ => {}
+        }
+        if let Some((spec_id, _, _)) = &task.pending_spec {
+            any_action = true;
+            // Needs-revision requires written feedback (it's the message the
+            // re-scout sees) — that lands with the review form slice.
+            actions = actions
+                .child(self.action_button(
+                    "approve-spec",
+                    "Approve",
+                    Some(gpui::hsla(135. / 360., 0.55, 0.45, 1.)),
+                    cx.listener({
+                        let id = spec_id.clone();
+                        move |this, _: &ClickEvent, _window, cx| {
+                            let id = id.clone();
+                            this.app_state.update(cx, |state, cx| {
+                                state.review_spec(id, SpecQueueStatus::Approved, None, cx)
+                            });
+                        }
+                    }),
+                    cx,
+                ))
+                .child(self.action_button(
+                    "reject-spec",
+                    "Reject",
+                    Some(gpui::hsla(0., 0.75, 0.55, 1.)),
+                    cx.listener({
+                        let id = spec_id.clone();
+                        move |this, _: &ClickEvent, _window, cx| {
+                            let id = id.clone();
+                            this.app_state.update(cx, |state, cx| {
+                                state.review_spec(id, SpecQueueStatus::Rejected, None, cx)
+                            });
+                        }
+                    }),
+                    cx,
+                ));
+        }
+        if let Some(url) = task.github_url.clone() {
+            any_action = true;
+            actions = actions.child(self.action_button(
+                "open-github",
+                "Open on GitHub",
+                None,
+                move |_: &ClickEvent, _window, cx| cx.open_url(&url),
+                cx,
+            ));
+        }
+        if any_action {
+            pane = pane.child(actions);
+        }
+
+        if let Some((_, complexity, content)) = task.pending_spec {
+            pane = pane
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(theme.fg_muted())
+                        .child(format!("SPEC · {}", complexity.as_str().to_uppercase())),
+                )
+                .child(
+                    div()
+                        .p(px(8.))
+                        .rounded(px(6.))
+                        .bg(theme.bg())
+                        .text_xs()
+                        .text_color(theme.fg())
+                        .child(content),
+                );
+        } else if !task.body.is_empty() {
+            pane = pane.child(
+                div()
+                    .text_xs()
+                    .text_color(theme.fg_muted())
+                    .child(task.body.clone()),
+            );
+        }
+
+        pane.into_any_element()
+    }
+
+    fn action_button(
+        &self,
+        id: &'static str,
+        label: &'static str,
+        color: Option<Hsla>,
+        on_click: impl Fn(&ClickEvent, &mut gpui::Window, &mut gpui::App) + 'static,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let theme = cx.theme().clone();
+        let text = color.unwrap_or_else(|| theme.fg());
+        div()
+            .id(id)
+            .px(px(8.))
+            .py(px(3.))
+            .rounded(px(5.))
+            .border_1()
+            .border_color(theme.border_secondary())
+            .cursor_pointer()
+            .text_xs()
+            .text_color(text)
+            .hover({
+                let hover_bg = theme.surface_secondary();
+                move |el| el.bg(hover_bg)
+            })
+            .on_click(on_click)
+            .child(label)
+            .into_any_element()
+    }
+}

--- a/app-gpui/src/sections/home.rs
+++ b/app-gpui/src/sections/home.rs
@@ -1,0 +1,129 @@
+//! The Home section: the three LLM briefing slots plus what needs a human,
+//! reading-width capped. Plain text for now — markdown rendering is its own
+//! later slice.
+
+use gpui::prelude::*;
+use gpui::{div, px, Context};
+use gpuikit::theme::{ActiveTheme, Themeable};
+use tasks_client::api::models::TaskState;
+
+use crate::time;
+use crate::workspace::Workspace;
+
+impl Workspace {
+    pub(crate) fn render_home(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme().clone();
+        let state = self.app_state.read(cx);
+
+        let mut column = div()
+            .flex()
+            .flex_col()
+            .gap(px(16.))
+            .w_full()
+            .max_w(px(760.))
+            .mx_auto()
+            .p(px(16.));
+
+        // Needs you: specs awaiting a verdict.
+        let waiting: Vec<_> = state
+            .tasks
+            .iter()
+            .filter(|task| task.state == TaskState::InReview)
+            .map(|task| (task.title.clone(), task.updated_at))
+            .collect();
+        if !waiting.is_empty() {
+            let mut section = div().flex().flex_col().gap(px(4.)).child(
+                div()
+                    .text_xs()
+                    .text_color(theme.fg_muted())
+                    .child("NEEDS YOU"),
+            );
+            for (title, updated) in waiting {
+                section = section.child(
+                    div()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap(px(8.))
+                        .p(px(10.))
+                        .rounded(px(8.))
+                        .bg(theme.surface())
+                        .child(
+                            div()
+                                .flex_1()
+                                .overflow_hidden()
+                                .child(
+                                    div()
+                                        .text_sm()
+                                        .text_color(theme.fg())
+                                        .truncate()
+                                        .child(title),
+                                )
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(theme.fg_muted())
+                                        .child("Spec awaiting your verdict"),
+                                ),
+                        )
+                        .child(
+                            div()
+                                .flex_none()
+                                .text_xs()
+                                .text_color(theme.fg_muted())
+                                .child(format!("waiting {}", time::relative(updated))),
+                        ),
+                );
+            }
+            column = column.child(section);
+        }
+
+        // Briefing slots, in server display order.
+        for briefing in &state.briefings {
+            let label = crate::components::title_case(briefing.section.as_str()).to_uppercase();
+            let provenance = match (&briefing.generated_at, briefing.regenerating) {
+                (Some(at), true) => format!("as of {} ago · refreshing…", time::relative(*at)),
+                (Some(at), false) => format!("as of {} ago", time::relative(*at)),
+                (None, true) => "Writing the first briefing…".to_string(),
+                (None, false) => "No briefing yet".to_string(),
+            };
+            column = column.child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(4.))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .justify_between()
+                            .child(div().text_xs().text_color(theme.fg_muted()).child(label))
+                            .child(
+                                div()
+                                    .text_xs()
+                                    .text_color(theme.fg_muted())
+                                    .child(provenance),
+                            ),
+                    )
+                    .when_some(briefing.content.clone(), |el, content| {
+                        el.child(div().text_sm().text_color(theme.fg()).child(content))
+                    }),
+            );
+        }
+
+        if state.briefings.is_empty() && state.loaded {
+            column = column.child(
+                div()
+                    .text_sm()
+                    .text_color(theme.fg_muted())
+                    .child("No briefings yet."),
+            );
+        }
+
+        div()
+            .id("home-scroll")
+            .size_full()
+            .overflow_y_scroll()
+            .child(column)
+    }
+}

--- a/app-gpui/src/sections/mod.rs
+++ b/app-gpui/src/sections/mod.rs
@@ -1,0 +1,9 @@
+//! Per-section center surfaces. Each file extends `Workspace` with the
+//! render method for one sidebar section; they read `AppState` and talk
+//! back through workspace listeners — no state of their own.
+
+mod activity;
+mod detail;
+mod home;
+mod queue;
+mod tasks;

--- a/app-gpui/src/sections/queue.rs
+++ b/app-gpui/src/sections/queue.rs
@@ -1,0 +1,215 @@
+//! The Queue section: picked-up work grouped in attention order, mirroring
+//! the Swift app — Needs you / Running / Building / Up next / Ready to build.
+
+use gpui::prelude::*;
+use gpui::{div, px, AnyElement, Context};
+use gpuikit::theme::{ActiveTheme, Themeable};
+use tasks_client::api::models::{BuildStatus, TaskId, TaskState};
+
+use crate::time;
+use crate::workspace::Workspace;
+
+struct QueueRow {
+    task_id: TaskId,
+    number: u64,
+    title: String,
+    /// Trailing accessory: complexity word, or a live elapsed clock.
+    trailing: Option<String>,
+    /// Trailing is a live clock (styled as active work).
+    live: bool,
+}
+
+impl Workspace {
+    pub(crate) fn render_queue(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme().clone();
+        let state = self.app_state.read(cx);
+        let selected = self.selected_task.clone();
+
+        let row = |task: &tasks_client::api::models::Task| QueueRow {
+            task_id: task.id.clone(),
+            number: task.gh_issue_number,
+            title: task.title.clone(),
+            trailing: None,
+            live: false,
+        };
+
+        let mut groups: Vec<(&'static str, Vec<QueueRow>)> = Vec::new();
+
+        let needs_you: Vec<_> = state
+            .tasks
+            .iter()
+            .filter(|task| task.state == TaskState::InReview)
+            .map(|task| {
+                let mut item = row(task);
+                item.trailing = state
+                    .latest_spec(&task.id)
+                    .map(|spec| spec.complexity.as_str().to_string());
+                item
+            })
+            .collect();
+        groups.push(("Needs you", needs_you));
+
+        let running: Vec<_> = state
+            .tasks
+            .iter()
+            .filter(|task| task.state == TaskState::Scouting)
+            .map(|task| {
+                let mut item = row(task);
+                if let Some(session) = state.running_session(&task.id) {
+                    item.trailing = Some(time::elapsed(session.started_at));
+                    item.live = true;
+                }
+                item
+            })
+            .collect();
+        groups.push(("Running", running));
+
+        let building: Vec<_> = state
+            .tasks
+            .iter()
+            .filter(|task| task.state == TaskState::Building)
+            .map(|task| {
+                let mut item = row(task);
+                if let Some(build) = state
+                    .builds
+                    .iter()
+                    .find(|build| build.status == BuildStatus::Running)
+                {
+                    if let Some(started) = build.started_at {
+                        item.trailing = Some(time::elapsed(started));
+                        item.live = true;
+                    }
+                }
+                item
+            })
+            .collect();
+        groups.push(("Building", building));
+
+        let up_next: Vec<_> = state
+            .tasks
+            .iter()
+            .filter(|task| task.state == TaskState::Queued)
+            .map(row)
+            .collect();
+        groups.push(("Up next", up_next));
+
+        let ready: Vec<_> = state
+            .tasks
+            .iter()
+            .filter(|task| task.state == TaskState::ReadyToBuild)
+            .map(|task| {
+                let mut item = row(task);
+                item.trailing = state
+                    .latest_spec(&task.id)
+                    .map(|spec| spec.complexity.as_str().to_string());
+                item
+            })
+            .collect();
+        groups.push(("Ready to build", ready));
+
+        let all_empty = groups.iter().all(|(_, rows)| rows.is_empty()) && state.loaded;
+
+        let mut list = div()
+            .id("queue-list")
+            .flex()
+            .flex_col()
+            .size_full()
+            .overflow_y_scroll()
+            .py(px(4.));
+
+        if all_empty {
+            list = list.child(
+                div()
+                    .p(px(16.))
+                    .text_sm()
+                    .text_color(theme.fg_muted())
+                    .child("Nothing queued — pick tasks up from the Tasks list."),
+            );
+        }
+
+        for (label, rows) in groups {
+            if rows.is_empty() {
+                continue;
+            }
+            list = list.child(
+                div()
+                    .px(px(16.))
+                    .pt(px(10.))
+                    .pb(px(4.))
+                    .text_xs()
+                    .text_color(theme.fg_muted())
+                    .child(label.to_uppercase()),
+            );
+            for (ix, item) in rows.into_iter().enumerate() {
+                list = list.child(self.queue_row(label, ix, item, selected.as_ref(), cx));
+            }
+        }
+
+        list
+    }
+
+    fn queue_row(
+        &self,
+        group: &'static str,
+        ix: usize,
+        item: QueueRow,
+        selected: Option<&TaskId>,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let theme = cx.theme().clone();
+        let is_selected = selected == Some(&item.task_id);
+        let task_id = item.task_id.clone();
+
+        div()
+            .id((group, ix))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(8.))
+            .mx(px(6.))
+            .px(px(10.))
+            .py(px(5.))
+            .rounded(px(5.))
+            .cursor_pointer()
+            .when(!is_selected, |el| {
+                let hover_bg = theme.surface_secondary();
+                el.hover(move |el| el.bg(hover_bg))
+            })
+            .when(is_selected, |el| el.bg(theme.surface_tertiary()))
+            .on_click(cx.listener(move |this, _event, _window, cx| {
+                this.select_task(task_id.clone(), cx);
+            }))
+            .child(
+                div()
+                    .flex_1()
+                    .overflow_hidden()
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(theme.fg())
+                            .truncate()
+                            .child(item.title),
+                    )
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(theme.fg_muted())
+                            .child(format!("#{}", item.number)),
+                    ),
+            )
+            .when_some(item.trailing, |el, trailing| {
+                el.child(
+                    div()
+                        .flex_none()
+                        .text_xs()
+                        .text_color(if item.live {
+                            theme.accent()
+                        } else {
+                            theme.fg_muted()
+                        })
+                        .child(trailing),
+                )
+            })
+            .into_any_element()
+    }
+}

--- a/app-gpui/src/sections/tasks.rs
+++ b/app-gpui/src/sections/tasks.rs
@@ -1,0 +1,104 @@
+//! The Tasks section: every task in the working set, Linear-style rows.
+//! Click a row to open it in the inspector (right sidebar).
+
+use gpui::prelude::*;
+use gpui::{div, px, Context};
+use gpuikit::theme::{ActiveTheme, Themeable};
+use tasks_client::api::models::TaskState;
+
+use crate::components::{status_badge, task_state_color, title_case};
+use crate::time;
+use crate::workspace::Workspace;
+
+impl Workspace {
+    pub(crate) fn render_tasks(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme().clone();
+        let state = self.app_state.read(cx);
+        let selected = self.selected_task.clone();
+
+        let rows: Vec<_> = state
+            .tasks
+            .iter()
+            .map(|task| {
+                (
+                    task.id.clone(),
+                    task.gh_issue_number,
+                    task.title.clone(),
+                    task.state,
+                    task.updated_at,
+                )
+            })
+            .collect();
+        let empty = rows.is_empty() && state.loaded;
+
+        div()
+            .id("tasks-list")
+            .flex()
+            .flex_col()
+            .size_full()
+            .overflow_y_scroll()
+            .py(px(4.))
+            .when(empty, |el| {
+                el.child(
+                    div()
+                        .p(px(16.))
+                        .text_sm()
+                        .text_color(theme.fg_muted())
+                        .child("No tasks yet — the poller fills this from open GitHub issues."),
+                )
+            })
+            .children(rows.into_iter().enumerate().map(
+                |(ix, (id, number, title, task_state, updated))| {
+                    let is_selected = selected.as_ref() == Some(&id);
+                    let color = task_state_color(task_state);
+                    div()
+                        .id(ix)
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap(px(8.))
+                        .mx(px(6.))
+                        .px(px(10.))
+                        .py(px(4.))
+                        .rounded(px(5.))
+                        .cursor_pointer()
+                        .when(!is_selected, |el| {
+                            let hover_bg = theme.surface_secondary();
+                            el.hover(move |el| el.bg(hover_bg))
+                        })
+                        .when(is_selected, |el| el.bg(theme.surface_tertiary()))
+                        .on_click(cx.listener(move |this, _event, _window, cx| {
+                            this.select_task(id.clone(), cx);
+                        }))
+                        .child(
+                            div()
+                                .w(px(52.))
+                                .flex_none()
+                                .text_xs()
+                                .text_color(theme.fg_muted())
+                                .child(format!("#{number}")),
+                        )
+                        .child(
+                            div()
+                                .flex_1()
+                                .overflow_hidden()
+                                .text_sm()
+                                .text_color(theme.fg())
+                                .truncate()
+                                .child(title),
+                        )
+                        .when(task_state != TaskState::Backlog, |el| {
+                            el.child(status_badge(title_case(task_state.as_str()), color))
+                        })
+                        .child(
+                            div()
+                                .w(px(36.))
+                                .flex_none()
+                                .text_xs()
+                                .text_color(theme.fg_muted())
+                                .child(time::relative(updated)),
+                        )
+                },
+            ))
+    }
+}

--- a/app-gpui/src/state.rs
+++ b/app-gpui/src/state.rs
@@ -1,0 +1,319 @@
+//! App-wide server state, following the Swift app's `AppModel` and the
+//! clients.md contract: one event-stream loop drives everything, events are
+//! invalidation signals, and every refresh is a full snapshot of the lists.
+//!
+//! Threading: `tasks-client` is blocking by design. The SSE iterator lives on
+//! its own OS thread and feeds an unbounded channel; a foreground task drains
+//! the channel into entity updates. Snapshot fetches and mutations run on
+//! gpui's background executor (loopback calls are sub-millisecond).
+
+use futures::channel::mpsc;
+use futures::StreamExt;
+use gpui::Context;
+use tasks_client::api::events::Event;
+use tasks_client::api::http::BriefingStatus;
+use tasks_client::api::models::{
+    Build, Mode, OrchestratorMessage, Project, Session, Spec, SpecId, SpecQueueItem,
+    SpecQueueStatus, Task, TaskId,
+};
+use tasks_client::{Client, ClientError, EventStreamItem};
+
+/// Activity keeps the newest slice, refetched per event — the client never
+/// holds the whole log (the Swift app did, to reconstruct joins the API now
+/// serves directly).
+const ACTIVITY_LIMIT: i64 = 200;
+
+pub struct AppState {
+    client: Client,
+
+    pub projects: Vec<Project>,
+    pub tasks: Vec<Task>,
+    pub sessions: Vec<Session>,
+    pub specs: Vec<Spec>,
+    pub spec_queue: Vec<SpecQueueItem>,
+    pub builds: Vec<Build>,
+    /// Newest [`ACTIVITY_LIMIT`] events, newest first.
+    pub activity: Vec<Event>,
+    pub briefings: Vec<BriefingStatus>,
+    pub orchestrator_messages: Vec<OrchestratorMessage>,
+    pub mode: Option<Mode>,
+
+    /// The event stream is up. `false` after a drop, until reconnect.
+    pub connected: bool,
+    /// First snapshot applied — before this the UI shows "connecting".
+    pub loaded: bool,
+    /// Last transport/API failure worth a banner. Cleared on reconnect and
+    /// on any fully-successful refresh.
+    pub error: Option<String>,
+
+    refreshing: bool,
+    /// An event arrived while a refresh was in flight — go again after.
+    dirty: bool,
+}
+
+/// One full read of every list the UI shows. Fields are per-endpoint options
+/// so one failing read doesn't blank the others (the Swift app's policy).
+#[derive(Default)]
+struct Snapshot {
+    projects: Option<Vec<Project>>,
+    tasks: Option<Vec<Task>>,
+    sessions: Option<Vec<Session>>,
+    specs: Option<Vec<Spec>>,
+    spec_queue: Option<Vec<SpecQueueItem>>,
+    builds: Option<Vec<Build>>,
+    activity: Option<Vec<Event>>,
+    briefings: Option<Vec<BriefingStatus>>,
+    orchestrator_messages: Option<Vec<OrchestratorMessage>>,
+    mode: Option<Mode>,
+    /// The first failure, if any read failed.
+    error: Option<String>,
+}
+
+impl Snapshot {
+    fn fetch(client: &Client) -> Self {
+        let mut snapshot = Self::default();
+        let mut error: Option<String> = None;
+        fn take<T>(
+            slot: &mut Option<T>,
+            error: &mut Option<String>,
+            result: Result<T, ClientError>,
+        ) {
+            match result {
+                Ok(value) => *slot = Some(value),
+                Err(err) => {
+                    if error.is_none() {
+                        *error = Some(err.to_string());
+                    }
+                }
+            }
+        }
+        take(&mut snapshot.projects, &mut error, client.projects());
+        take(&mut snapshot.tasks, &mut error, client.tasks());
+        take(&mut snapshot.sessions, &mut error, client.sessions());
+        take(&mut snapshot.specs, &mut error, client.specs());
+        take(&mut snapshot.spec_queue, &mut error, client.spec_queue());
+        take(&mut snapshot.builds, &mut error, client.builds());
+        take(
+            &mut snapshot.activity,
+            &mut error,
+            client.events(None, Some(ACTIVITY_LIMIT)).map(|mut events| {
+                events.reverse(); // newest first for the feed
+                events
+            }),
+        );
+        take(&mut snapshot.briefings, &mut error, client.briefings());
+        take(
+            &mut snapshot.orchestrator_messages,
+            &mut error,
+            client.orchestrator_messages(0),
+        );
+        take(&mut snapshot.mode, &mut error, client.mode());
+        snapshot.error = error;
+        snapshot
+    }
+}
+
+impl AppState {
+    /// Creates the state and starts the sync loop: a dedicated OS thread runs
+    /// the reconnecting SSE iterator, and every `Connected` triggers a full
+    /// snapshot — so nothing that happened while disconnected is missed.
+    pub fn new(cx: &mut Context<Self>) -> Self {
+        let client = Client::from_env();
+
+        let (tx, mut rx) = mpsc::unbounded();
+        {
+            let client = client.clone();
+            std::thread::Builder::new()
+                .name("tasks-event-stream".into())
+                .spawn(move || {
+                    for item in client.stream_events() {
+                        if tx.unbounded_send(item).is_err() {
+                            return; // app side gone
+                        }
+                    }
+                })
+                .expect("spawn event-stream thread");
+        }
+        cx.spawn(async move |this, cx| {
+            while let Some(item) = rx.next().await {
+                let alive = this
+                    .update(cx, |state: &mut AppState, cx| {
+                        state.on_stream_item(item, cx)
+                    })
+                    .is_ok();
+                if !alive {
+                    return;
+                }
+            }
+        })
+        .detach();
+
+        Self {
+            client,
+            projects: Vec::new(),
+            tasks: Vec::new(),
+            sessions: Vec::new(),
+            specs: Vec::new(),
+            spec_queue: Vec::new(),
+            builds: Vec::new(),
+            activity: Vec::new(),
+            briefings: Vec::new(),
+            orchestrator_messages: Vec::new(),
+            mode: None,
+            connected: false,
+            loaded: false,
+            error: None,
+            refreshing: false,
+            dirty: false,
+        }
+    }
+
+    fn on_stream_item(&mut self, item: EventStreamItem, cx: &mut Context<Self>) {
+        match item {
+            EventStreamItem::Connected => {
+                self.connected = true;
+                self.error = None;
+                self.refresh(cx);
+            }
+            // Identifier-only invalidation signal: never fold the payload
+            // into state, just refetch the lists.
+            EventStreamItem::Event(_) => self.refresh(cx),
+            EventStreamItem::Disconnected(err) => {
+                self.connected = false;
+                self.error = Some(err.to_string());
+                cx.notify();
+            }
+        }
+    }
+
+    /// Full snapshot on the background executor, applied on completion.
+    /// Coalesced: a refresh requested mid-flight runs once more at the end
+    /// instead of stacking.
+    pub fn refresh(&mut self, cx: &mut Context<Self>) {
+        if self.refreshing {
+            self.dirty = true;
+            return;
+        }
+        self.refreshing = true;
+        let client = self.client.clone();
+        let fetch = cx
+            .background_executor()
+            .spawn(async move { Snapshot::fetch(&client) });
+        cx.spawn(async move |this, cx| {
+            let snapshot = fetch.await;
+            this.update(cx, |state, cx| state.apply(snapshot, cx)).ok();
+        })
+        .detach();
+    }
+
+    fn apply(&mut self, snapshot: Snapshot, cx: &mut Context<Self>) {
+        macro_rules! merge {
+            ($($field:ident),+) => {
+                $(if let Some(value) = snapshot.$field { self.$field = value; })+
+            };
+        }
+        merge!(
+            projects,
+            tasks,
+            sessions,
+            specs,
+            spec_queue,
+            builds,
+            activity,
+            briefings,
+            orchestrator_messages
+        );
+        if let Some(mode) = snapshot.mode {
+            self.mode = Some(mode);
+        }
+        self.loaded = true;
+        self.error = snapshot.error;
+        self.refreshing = false;
+        if self.dirty {
+            self.dirty = false;
+            self.refresh(cx);
+        }
+        cx.notify();
+    }
+
+    /// Run a mutation on the background executor; refresh on success, banner
+    /// the server's message on failure. The refresh is what applies the
+    /// change — responses aren't folded in piecemeal.
+    fn run<T: Send + 'static>(
+        &mut self,
+        cx: &mut Context<Self>,
+        op: impl FnOnce(&Client) -> Result<T, ClientError> + Send + 'static,
+    ) {
+        let client = self.client.clone();
+        let work = cx.background_executor().spawn(async move { op(&client) });
+        cx.spawn(async move |this, cx| {
+            let result = work.await;
+            this.update(cx, |state, cx| match result {
+                Ok(_) => state.refresh(cx),
+                Err(err) => {
+                    state.error = Some(err.to_string());
+                    cx.notify();
+                }
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    // --- mutations the UI invokes ---
+
+    pub fn queue_task(&mut self, id: TaskId, cx: &mut Context<Self>) {
+        self.run(cx, move |client| client.queue_task(&id));
+    }
+
+    pub fn dequeue_task(&mut self, id: TaskId, cx: &mut Context<Self>) {
+        self.run(cx, move |client| client.dequeue_task(&id));
+    }
+
+    pub fn scout_task_now(&mut self, id: TaskId, cx: &mut Context<Self>) {
+        self.run(cx, move |client| client.scout_task_now(&id));
+    }
+
+    pub fn set_mode(&mut self, mode: Mode, cx: &mut Context<Self>) {
+        self.run(cx, move |client| client.set_mode(mode));
+    }
+
+    pub fn review_spec(
+        &mut self,
+        id: SpecId,
+        verdict: SpecQueueStatus,
+        feedback: Option<String>,
+        cx: &mut Context<Self>,
+    ) {
+        self.run(cx, move |client| client.review_spec(&id, verdict, feedback));
+    }
+
+    // --- projections the sections read ---
+
+    pub fn task(&self, id: &TaskId) -> Option<&Task> {
+        self.tasks.iter().find(|task| &task.id == id)
+    }
+
+    /// The project a task belongs to — for the GitHub link.
+    pub fn project(&self, task: &Task) -> Option<&Project> {
+        self.projects
+            .iter()
+            .find(|project| project.id == task.project_id)
+    }
+
+    /// Latest spec for a task, if any (specs are append-only per re-scout).
+    pub fn latest_spec(&self, id: &TaskId) -> Option<&Spec> {
+        self.specs
+            .iter()
+            .filter(|spec| &spec.task_id == id)
+            .max_by_key(|spec| spec.created_at)
+    }
+
+    /// The running session for a task, if one is live.
+    pub fn running_session(&self, id: &TaskId) -> Option<&Session> {
+        self.sessions.iter().find(|session| {
+            &session.task_id == id
+                && session.status == tasks_client::api::models::SessionStatus::Running
+        })
+    }
+}

--- a/app-gpui/src/time.rs
+++ b/app-gpui/src/time.rs
@@ -1,0 +1,21 @@
+//! Compact time formatting for list rows and live clocks.
+
+use chrono::{DateTime, Utc};
+
+/// "now", "5m", "3h", "2d" — the row-trailing relative timestamp.
+pub fn relative(when: DateTime<Utc>) -> String {
+    let seconds = (Utc::now() - when).num_seconds().max(0);
+    match seconds {
+        0..60 => "now".to_string(),
+        60..3600 => format!("{}m", seconds / 60),
+        3600..86_400 => format!("{}h", seconds / 3600),
+        _ => format!("{}d", seconds / 86_400),
+    }
+}
+
+/// "M:SS" elapsed since `since` — the live wall clock for running work
+/// (a clock reads as working; a spinner reads as hung).
+pub fn elapsed(since: DateTime<Utc>) -> String {
+    let seconds = (Utc::now() - since).num_seconds().max(0);
+    format!("{}:{:02}", seconds / 60, seconds % 60)
+}

--- a/app-gpui/src/workspace.rs
+++ b/app-gpui/src/workspace.rs
@@ -1,9 +1,13 @@
 //! The root workspace view.
 //!
 //! Follows Zed's workspace/dock split: the workspace owns UI state
-//! (active section, per-sidebar open/width) and registers action handlers;
-//! chrome components (`TitleBar`, `Sidebar`) are presentation-only and talk
-//! back by dispatching actions, never by reaching into workspace state.
+//! (active section, per-sidebar open/width, selection) and registers action
+//! handlers; chrome components (`TitleBar`, `Sidebar`) are presentation-only
+//! and talk back by dispatching actions, never by reaching into workspace
+//! state. Server state lives in [`AppState`]; the workspace observes it and
+//! re-renders.
+
+use std::time::Duration;
 
 use gpui::prelude::*;
 use gpui::{actions, div, px, Context, Div, Entity, Focusable, MouseButton, Window};
@@ -12,8 +16,10 @@ use gpuikit::elements::input::text_area;
 use gpuikit::input::InputState;
 use gpuikit::theme::{ActiveTheme, Themeable};
 use gpuikit::DefaultIcons as Icons;
+use tasks_client::api::models::{BuildStatus, Mode, SessionStatus, TaskId, TaskState};
 
 use crate::components::{sidebar, title_bar, SidebarSide, SidebarState};
+use crate::state::AppState;
 
 const FONT: &str = "Menlo";
 
@@ -49,22 +55,53 @@ impl Section {
 }
 
 pub struct Workspace {
-    section: Section,
-    left_sidebar: SidebarState,
-    right_sidebar: SidebarState,
+    pub(crate) section: Section,
+    pub(crate) left_sidebar: SidebarState,
+    pub(crate) right_sidebar: SidebarState,
     /// Which sidebar is currently being drag-resized, if any.
-    resizing: Option<SidebarSide>,
-    input: Entity<InputState>,
+    pub(crate) resizing: Option<SidebarSide>,
+    pub(crate) app_state: Entity<AppState>,
+    /// Task shown in the inspector (right sidebar).
+    pub(crate) selected_task: Option<TaskId>,
+    /// Chat composer (placeholder until the chat slice lands).
+    pub(crate) input: Entity<InputState>,
 }
 
 impl Workspace {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let app_state = cx.new(AppState::new);
+        cx.observe(&app_state, |_, _, cx| cx.notify()).detach();
+
+        // Live elapsed clocks (running scouts/builds) tick once a second —
+        // but only when something is actually running.
+        let executor = cx.background_executor().clone();
+        cx.spawn(async move |this, cx| loop {
+            executor.timer(Duration::from_secs(1)).await;
+            let alive = this
+                .update(cx, |this: &mut Workspace, cx| {
+                    let state = this.app_state.read(cx);
+                    let live = state
+                        .sessions
+                        .iter()
+                        .any(|session| session.status == SessionStatus::Running)
+                        || state
+                            .builds
+                            .iter()
+                            .any(|build| build.status == BuildStatus::Running);
+                    if live {
+                        cx.notify();
+                    }
+                })
+                .is_ok();
+            if !alive {
+                return;
+            }
+        })
+        .detach();
+
         let input = cx.new(|cx| {
             let mut state = InputState::new_multiline(cx);
-            state.set_content(
-                "The composer input for chat / review notes lands here.\n\nType away — this is gpuikit's InputState + text_area on gpui 1.14.2.",
-                cx,
-            );
+            state.set_content("Talk to the orchestrator…", cx);
             state
         });
         window.focus(&input.focus_handle(cx), cx);
@@ -74,6 +111,8 @@ impl Workspace {
             left_sidebar: SidebarState::new(true),
             right_sidebar: SidebarState::new(false),
             resizing: None,
+            app_state,
+            selected_task: None,
             input,
         }
     }
@@ -88,6 +127,20 @@ impl Workspace {
     fn toggle_sidebar(&mut self, side: SidebarSide, cx: &mut Context<Self>) {
         let state = self.sidebar_mut(side);
         state.open = !state.open;
+        cx.notify();
+    }
+
+    // --- selection (called from section rows) ---
+
+    pub(crate) fn select_task(&mut self, id: TaskId, cx: &mut Context<Self>) {
+        self.selected_task = Some(id);
+        self.right_sidebar.open = true;
+        cx.notify();
+    }
+
+    pub(crate) fn clear_selection(&mut self, cx: &mut Context<Self>) {
+        self.selected_task = None;
+        self.right_sidebar.open = false;
         cx.notify();
     }
 
@@ -106,6 +159,8 @@ impl Workspace {
     }
 
     fn render_title_bar(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let mode = self.app_state.read(cx).mode;
+
         title_bar()
             .child_left(
                 Self::title_bar_button("toggle-left-sidebar", Icons::panel_left())
@@ -123,7 +178,29 @@ impl Workspace {
                 )),
             )
             .child_center(div().child("tasks"))
-            .child_right(Self::title_bar_button("settings", Icons::gear()).disabled(true))
+            .child_right(
+                Self::title_bar_button("mode-play", Icons::play())
+                    .selected(mode == Some(Mode::Play))
+                    .on_click(cx.listener(|this, _event, _window, cx| {
+                        this.app_state
+                            .update(cx, |state, cx| state.set_mode(Mode::Play, cx));
+                    })),
+            )
+            .child_right(
+                Self::title_bar_button("mode-pause", Icons::pause())
+                    .selected(mode == Some(Mode::Pause))
+                    .on_click(cx.listener(|this, _event, _window, cx| {
+                        this.app_state
+                            .update(cx, |state, cx| state.set_mode(Mode::Pause, cx));
+                    })),
+            )
+            .child_right(
+                Self::title_bar_button("refresh", Icons::reload()).on_click(cx.listener(
+                    |this, _event, _window, cx| {
+                        this.app_state.update(cx, |state, cx| state.refresh(cx));
+                    },
+                )),
+            )
             .child_right(
                 Self::title_bar_button("toggle-right-sidebar", Icons::panel_right())
                     .selected(self.right_sidebar.open)
@@ -135,13 +212,37 @@ impl Workspace {
 
     fn render_left_sidebar(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
-        let (text, text_muted, selected_bg, hover_bg) = (
+        let (text, text_muted, selected_bg, hover_bg, badge_bg) = (
             theme.fg(),
             theme.fg_muted(),
             theme.surface_tertiary(),
             theme.surface_secondary(),
+            theme.surface_tertiary(),
         );
         let active = self.section;
+
+        let state = self.app_state.read(cx);
+        let queued_work = state
+            .tasks
+            .iter()
+            .filter(|task| {
+                matches!(
+                    task.state,
+                    TaskState::Queued
+                        | TaskState::Scouting
+                        | TaskState::InReview
+                        | TaskState::ReadyToBuild
+                        | TaskState::Building
+                )
+            })
+            .count();
+        let banner = if let Some(error) = &state.error {
+            Some((error.clone(), true))
+        } else if state.loaded && !state.connected {
+            Some(("Reconnecting to the tasks server…".to_string(), false))
+        } else {
+            None
+        };
 
         sidebar(SidebarSide::Left, self.left_sidebar.width)
             .on_resize_start({
@@ -155,11 +256,16 @@ impl Workspace {
                     }
                 }
             })
-            .child(div().flex().flex_col().pt(px(8.)).children(
+            .child(div().flex().flex_col().flex_1().pt(px(8.)).children(
                 Section::ALL.into_iter().enumerate().map(|(ix, section)| {
                     let selected = section == active;
+                    let badge = (section == Section::Queue && queued_work > 0)
+                        .then(|| queued_work.to_string());
                     div()
                         .id(ix)
+                        .flex()
+                        .flex_row()
+                        .items_center()
                         .mx(px(6.))
                         .px(px(10.))
                         .py(px(5.))
@@ -171,17 +277,48 @@ impl Workspace {
                             this.section = section;
                             cx.notify();
                         }))
-                        .text_sm()
-                        .text_color(if selected { text } else { text_muted })
-                        .child(section.label())
+                        .child(
+                            div()
+                                .flex_1()
+                                .text_sm()
+                                .text_color(if selected { text } else { text_muted })
+                                .child(section.label()),
+                        )
+                        .when_some(badge, |el, badge| {
+                            el.child(
+                                div()
+                                    .flex_none()
+                                    .px(px(6.))
+                                    .rounded_full()
+                                    .bg(badge_bg)
+                                    .text_xs()
+                                    .text_color(text_muted)
+                                    .child(badge),
+                            )
+                        })
                 }),
             ))
+            .child(div().flex_1())
+            .when_some(banner, |el, (message, is_error)| {
+                el.child(
+                    div()
+                        .m(px(6.))
+                        .p(px(8.))
+                        .rounded(px(5.))
+                        .bg(cx.theme().surface_secondary())
+                        .text_xs()
+                        .text_color(if is_error {
+                            gpui::hsla(30. / 360., 0.9, 0.6, 1.)
+                        } else {
+                            cx.theme().fg_muted()
+                        })
+                        .child(message),
+                )
+            })
     }
 
     fn render_right_sidebar(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let theme = cx.theme();
-        let (text, text_muted) = (theme.fg(), theme.fg_muted());
-
+        let inspector = self.render_inspector(cx);
         sidebar(SidebarSide::Right, self.right_sidebar.width)
             .on_resize_start({
                 let entity = cx.entity().downgrade();
@@ -194,51 +331,109 @@ impl Workspace {
                     }
                 }
             })
+            .child(inspector)
+    }
+
+    fn render_chat(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let state = self.app_state.read(cx);
+        let messages: Vec<_> = state
+            .orchestrator_messages
+            .iter()
+            .map(|message| (message.seq, message.role, message.content.clone()))
+            .collect();
+
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
             .child(
                 div()
-                    .px(px(12.))
-                    .py(px(10.))
-                    .text_color(text)
-                    .child("Inspector"),
+                    .id("chat-scroll")
+                    .flex()
+                    .flex_col()
+                    .flex_1()
+                    .overflow_y_scroll()
+                    .p(px(12.))
+                    .gap(px(8.))
+                    .children(messages.into_iter().map(|(seq, role, content)| {
+                        use tasks_client::api::models::ChatRole;
+                        let bubble = div()
+                            .max_w(px(720.))
+                            .p(px(8.))
+                            .rounded(px(8.))
+                            .text_sm()
+                            .child(content);
+                        div()
+                            .id(seq as usize)
+                            .flex()
+                            .flex_row()
+                            .map(|el| match role {
+                                ChatRole::User => el.justify_end().child(
+                                    bubble
+                                        .bg(cx.theme().accent_bg())
+                                        .text_color(cx.theme().fg()),
+                                ),
+                                ChatRole::Assistant => el.child(
+                                    bubble
+                                        .bg(cx.theme().surface_secondary())
+                                        .text_color(cx.theme().fg()),
+                                ),
+                                ChatRole::Event => {
+                                    el.child(bubble.text_color(cx.theme().fg_muted()).text_xs())
+                                }
+                            })
+                    })),
             )
             .child(
                 div()
-                    .px(px(12.))
+                    .flex_none()
+                    .p(px(8.))
+                    .border_t_1()
+                    .border_color(theme.border_subtle())
                     .text_sm()
-                    .text_color(text_muted)
-                    .child("Task detail / review pane placeholder."),
+                    .child(text_area(&self.input, cx).size_full()),
             )
     }
 
     fn render_center(&self, cx: &mut Context<Self>) -> Div {
-        let theme = cx.theme();
-        let (text, editor_bg) = (theme.fg(), theme.bg());
+        let theme = cx.theme().clone();
+        let loaded = self.app_state.read(cx).loaded;
 
-        div()
+        let mut pane = div()
             .flex()
             .flex_col()
             .flex_grow(1.)
             .h_full()
             .overflow_hidden()
-            .bg(editor_bg)
-            .child(
+            .bg(theme.bg());
+
+        if !loaded {
+            return pane.child(
                 div()
-                    .px(px(16.))
-                    .py(px(10.))
-                    .text_color(text)
-                    .child(self.section.label()),
-            )
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .flex_grow(1.)
-                    .overflow_hidden()
                     .p(px(16.))
                     .text_sm()
-                    .text_color(text)
-                    .child(text_area(&self.input, cx).size_full()),
-            )
+                    .text_color(theme.fg_muted())
+                    .child("Connecting to the tasks server…"),
+            );
+        }
+
+        pane = pane.child(
+            div()
+                .flex_none()
+                .px(px(16.))
+                .py(px(10.))
+                .text_color(theme.fg())
+                .child(self.section.label()),
+        );
+
+        match self.section {
+            Section::Home => pane.child(self.render_home(cx)),
+            Section::Tasks => pane.child(self.render_tasks(cx)),
+            Section::Queue => pane.child(self.render_queue(cx)),
+            Section::Activity => pane.child(self.render_activity(cx)),
+            Section::Chat => pane.child(self.render_chat(cx)),
+        }
     }
 }
 


### PR DESCRIPTION
The gpui app now talks to the real server — every section renders live data, with the sync loop following the clients.md contract.

## What

**`state.rs` — `AppState`**, the Swift `AppModel` as a gpui entity:
- A dedicated OS thread runs `tasks-client`'s reconnecting `stream_events()` into a channel; a foreground task drains it into entity updates.
- **Snapshot on `Connected`, refetch on every event** — events stay invalidation signals, payloads are never folded into state. Refreshes coalesce (one more full pass after the in-flight one, never a stack).
- Blocking client calls ride gpui's **background executor** — no async runtime embedded in the app.
- Mutations (`queue`/`dequeue`/`scout`/`set_mode`/`review`) refresh on success and banner the **server's own error message** on failure — the server stays the authority on legal transitions.

**Sections** (one file per section, `impl Workspace` blocks):
- **Tasks** — Linear-style rows (issue #, title, state badge, updated), click → inspector
- **Queue** — attention-ordered groups (Needs you / Running / Building / Up next / Ready to build) with **live elapsed clocks** that tick only while something is actually running
- **Home** — briefing slots with honest provenance captions ("as of 12m ago · refreshing…"), needs-you rows
- **Activity** — sentences built from the typed `EventPayload` in an **exhaustive match**: a new event kind is a compile error here, not a mystery row (the payoff of #806)
- **Chat** — orchestrator conversation, read-only (composer wiring is the next slice)
- **Inspector** (right sidebar) — per-state actions: Add to Queue / Scout Now / Remove from Queue, Approve / Reject a pending spec (Needs-revision waits for the feedback form), Open on GitHub

**Chrome**: play/pause/refresh in the title bar, queue-count badge in the nav, connection banner at the sidebar bottom, status→color vocabulary matching the Swift app.

## Verified (headless)

Builds warning-free; runs with and without a server (connecting state + 3s retry); against a throwaway server it holds the SSE connection + call pool (`lsof` confirmed) and survives event-driven refresh churn. Visual pass is yours — `cargo run` in `app-gpui/` with the real server up.

## Not yet

Markdown rendering, drag-reorder of the queue, the needs-revision feedback form, chat send + live orchestrator feed, transcript view, unread tracking, "Open in Claude Code".